### PR TITLE
fix: add OpenAPI response types to eliminate unknown type generations

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -32,7 +32,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/LoginResponseDto"
                 }
               }
             }
@@ -53,7 +53,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/LoginResponseDto"
                 }
               }
             }
@@ -70,7 +70,14 @@
         "parameters": [],
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogoutResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -90,7 +97,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object"
+                    "$ref": "#/components/schemas/SessionInfoDto"
                   }
                 }
               }
@@ -107,7 +114,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevokeAllSessionsResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Revoke all sessions except the current one",
@@ -131,7 +145,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevokeSessionResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Revoke a specific session",
@@ -192,7 +213,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserListResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -406,7 +434,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminUserListResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -458,7 +493,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Delete a user account (admin action)",
@@ -585,7 +627,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Unblock a user",
@@ -634,7 +683,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BlockedStatusResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Check if a specific user is blocked",
@@ -659,7 +715,14 @@
         },
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InviteResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -671,7 +734,17 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InviteResponseDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -698,7 +771,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/InviteResponseDto"
                 }
               }
             }
@@ -728,7 +801,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/InviteResponseDto"
                 }
               }
             }
@@ -1187,7 +1260,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RoleUserDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1385,7 +1468,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RoleUserDto"
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Get users assigned to an instance role",
@@ -1410,7 +1503,14 @@
         },
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChannelDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1433,7 +1533,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ChannelDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1456,7 +1566,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ChannelDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1479,7 +1599,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChannelDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1510,7 +1637,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChannelDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1564,7 +1698,17 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ChannelDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1597,7 +1741,17 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ChannelDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1611,7 +1765,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1635,7 +1796,14 @@
         },
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommunityResponseDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1652,7 +1820,17 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CommunityResponseDto"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1709,7 +1887,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommunityResponseDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1745,7 +1930,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommunityResponseDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1815,7 +2007,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommunityStatsListResponseDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1843,7 +2042,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommunityStatsDetailDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1900,7 +2106,14 @@
         },
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnrichedMessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1939,7 +2152,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedMessagesResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1978,7 +2198,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedMessagesResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -2017,7 +2244,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EnrichedMessageDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -2056,7 +2293,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EnrichedMessageDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -2095,7 +2342,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EnrichedMessageDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -2119,7 +2376,14 @@
         },
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -2141,7 +2405,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -2174,7 +2445,14 @@
         },
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnrichedMessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -2197,7 +2475,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnrichedMessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -2228,7 +2513,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnrichedMessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -2272,7 +2564,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileMetadataResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -2809,7 +3108,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationListResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Get notifications for current user with pagination\nGET /notifications?unreadOnly=true&limit=50&offset=0",
@@ -2824,7 +3130,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnreadCountResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Get unread notification count\nGET /notifications/unread-count",
@@ -2848,7 +3161,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationDto"
+                }
+              }
+            }
           }
         },
         "summary": "Mark a notification as read\nPOST /notifications/:id/read",
@@ -2863,7 +3183,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnreadCountResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Mark all notifications as read\nPOST /notifications/read-all",
@@ -2887,7 +3214,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationDto"
+                }
+              }
+            }
           }
         },
         "summary": "Dismiss a notification\nPOST /notifications/:id/dismiss",
@@ -2926,7 +3260,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserNotificationSettingsDto"
+                }
+              }
+            }
           }
         },
         "summary": "Get user notification settings\nGET /notifications/settings",
@@ -2949,7 +3290,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserNotificationSettingsDto"
+                }
+              }
+            }
           }
         },
         "summary": "Update user notification settings\nPUT /notifications/settings",
@@ -2977,7 +3325,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/ChannelNotificationOverrideDto"
                 }
               }
             }
@@ -3012,7 +3360,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChannelNotificationOverrideDto"
+                }
+              }
+            }
           }
         },
         "summary": "Set channel notification override\nPUT /notifications/channels/:channelId/override",
@@ -3059,7 +3414,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebugNotificationResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "DEBUG: Send a test notification to the current user\nPOST /notifications/debug/send-test\nOnly available to OWNER users",
@@ -3074,7 +3436,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebugSubscriptionsResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "DEBUG: Get all push subscriptions for current user\nGET /notifications/debug/subscriptions\nOnly available to OWNER users",
@@ -3089,7 +3458,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClearNotificationDataResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "DEBUG: Clear all notification settings for current user\nDELETE /notifications/debug/clear-all\nOnly available to OWNER users",
@@ -3104,7 +3480,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VapidPublicKeyResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Get the VAPID public key for client subscription\nReturns null if push notifications are not configured",
@@ -3129,7 +3512,14 @@
         },
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessMessageDto"
+                }
+              }
+            }
           }
         },
         "summary": "Subscribe to push notifications",
@@ -3154,7 +3544,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessMessageDto"
+                }
+              }
+            }
           }
         },
         "summary": "Unsubscribe from push notifications",
@@ -3169,7 +3566,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushStatusResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Get current push subscription status",
@@ -3184,7 +3588,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestPushResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3306,7 +3717,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessMessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3345,7 +3763,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessMessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3368,7 +3793,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CommunityBanDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3409,7 +3844,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessMessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3450,7 +3892,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessMessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3489,7 +3938,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessMessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3512,7 +3968,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CommunityTimeoutDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3543,7 +4009,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimeoutStatusResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3576,7 +4049,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessMessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3607,7 +4087,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessMessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3630,7 +4117,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PinnedMessageDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3663,7 +4160,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessMessageDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3710,7 +4214,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModerationLogsResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3734,7 +4245,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadReceiptDto"
+                }
+              }
+            }
           }
         },
         "summary": "Mark messages as read up to a specific message\nPOST /read-receipts/mark-read",
@@ -3755,7 +4273,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object"
+                    "$ref": "#/components/schemas/UnreadCountDto"
                   }
                 }
               }
@@ -3795,7 +4313,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/UnreadCountDto"
                 }
               }
             }
@@ -3830,7 +4348,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LastReadResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Get the last read message ID for a specific channel or DM group\nGET /read-receipts/last-read?channelId=xxx or ?directMessageGroupId=xxx",
@@ -3870,7 +4395,17 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Get all users who have read a specific message\nGET /read-receipts/message/:messageId/readers?channelId=xxx or ?directMessageGroupId=xxx",
@@ -3947,7 +4482,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionInfoResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3961,7 +4503,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LivekitHealthResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3985,7 +4534,14 @@
         },
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StartReplayResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Start replay buffer egress for screen share",
@@ -4000,7 +4556,14 @@
         "parameters": [],
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StopReplayResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Stop replay buffer egress for current user",
@@ -4019,7 +4582,15 @@
             "in": "query",
             "description": "Duration preset in minutes\nUser selects from: 1, 2, 5, or 10 minutes",
             "schema": {
-              "$ref": "#/components/schemas/Object"
+              "minimum": 1,
+              "maximum": 10,
+              "type": "number",
+              "enum": [
+                1,
+                2,
+                5,
+                10
+              ]
             }
           }
         ],
@@ -4240,7 +4811,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Delete a clip from user's library",
@@ -4339,7 +4917,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChannelVoicePresenceResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -4362,7 +4947,14 @@
         ],
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefreshPresenceResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -4376,7 +4968,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserVoiceChannelsResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -4399,7 +4998,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DmVoicePresenceResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -4444,7 +5050,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetupResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -4550,7 +5163,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedMessagesResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -4637,7 +5257,14 @@
         },
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileUploadResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -4660,7 +5287,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileUploadResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -4743,7 +5377,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserStorageListResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Get users list with storage usage (admin only, for storage management page)",
@@ -4838,6 +5479,16 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserStorageStatsDto"
+                }
+              }
+            }
+          },
           "201": {
             "description": "",
             "content": {
@@ -4871,7 +5522,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Update instance storage settings (admin only)",
@@ -4886,7 +5544,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicSettingsResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Get instance settings (public - needed for registration mode)",
@@ -4953,7 +5618,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstanceStatsResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Get instance statistics (admin only)",
@@ -4968,7 +5640,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppearanceSettingsResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Get current user's appearance settings",
@@ -4991,7 +5670,14 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppearanceSettingsResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Update current user's appearance settings",
@@ -5006,7 +5692,17 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FriendUserDto"
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Get all friends for the current user",
@@ -5025,7 +5721,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/PendingRequestsDto"
                 }
               }
             }
@@ -5052,7 +5748,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FriendshipStatusDto"
+                }
+              }
+            }
           }
         },
         "summary": "Get friendship status with a specific user",
@@ -5076,7 +5779,14 @@
         ],
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FriendshipDto"
+                }
+              }
+            }
           }
         },
         "summary": "Send a friend request to a user",
@@ -5100,7 +5810,14 @@
         ],
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FriendshipDto"
+                }
+              }
+            }
           }
         },
         "summary": "Accept a friend request",
@@ -5124,7 +5841,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Decline a friend request",
@@ -5148,7 +5872,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Cancel a sent friend request",
@@ -5172,7 +5903,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Remove a friend (unfriend)",
@@ -5196,7 +5934,14 @@
         ],
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadReplyDto"
+                }
+              }
+            }
           }
         },
         "summary": "Create a reply in a thread.\nPermission check: Uses message resource type to verify access to parent message context.",
@@ -5234,7 +5979,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadRepliesResponseDto"
+                }
+              }
+            }
           }
         },
         "summary": "Get paginated replies for a thread.",
@@ -5258,7 +6010,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadMetadataDto"
+                }
+              }
+            }
           }
         },
         "summary": "Get thread metadata (reply count, subscription status).",
@@ -5594,6 +6353,96 @@
       }
     },
     "schemas": {
+      "LoginResponseDto": {
+        "type": "object",
+        "properties": {
+          "accessToken": {
+            "type": "string"
+          },
+          "refreshToken": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "accessToken"
+        ]
+      },
+      "LogoutResponseDto": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "SessionInfoDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "deviceName": {
+            "type": "string"
+          },
+          "ipAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "lastUsedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "expiresAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "isCurrent": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "deviceName",
+          "ipAddress",
+          "createdAt",
+          "lastUsedAt",
+          "expiresAt",
+          "isCurrent"
+        ]
+      },
+      "RevokeSessionResponseDto": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "RevokeAllSessionsResponseDto": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "revokedCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "message",
+          "revokedCount"
+        ]
+      },
       "CreateUserDto": {
         "type": "object",
         "properties": {
@@ -5624,27 +6473,17 @@
       "UserEntity": {
         "type": "object",
         "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "OWNER",
+              "USER"
+            ]
+          },
           "id": {
             "type": "string"
           },
           "username": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string",
-            "nullable": true
-          },
-          "verified": {
-            "type": "boolean"
-          },
-          "role": {
-            "type": "object"
-          },
-          "createdAt": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "hashedPassword": {
             "type": "string"
           },
           "avatarUrl": {
@@ -5671,53 +6510,18 @@
           "status": {
             "type": "string",
             "nullable": true
-          },
-          "statusUpdatedAt": {
-            "format": "date-time",
-            "type": "string",
-            "nullable": true
-          },
-          "banned": {
-            "type": "boolean"
-          },
-          "bannedAt": {
-            "format": "date-time",
-            "type": "string",
-            "nullable": true
-          },
-          "bannedById": {
-            "type": "string",
-            "nullable": true
-          },
-          "storageQuotaBytes": {
-            "format": "int64",
-            "type": "integer"
-          },
-          "storageUsedBytes": {
-            "format": "int64",
-            "type": "integer"
           }
         },
         "required": [
+          "role",
           "id",
           "username",
-          "email",
-          "verified",
-          "role",
-          "createdAt",
-          "hashedPassword",
           "avatarUrl",
           "bannerUrl",
           "lastSeen",
           "displayName",
           "bio",
-          "status",
-          "statusUpdatedAt",
-          "banned",
-          "bannedAt",
-          "bannedById",
-          "storageQuotaBytes",
-          "storageUsedBytes"
+          "status"
         ]
       },
       "UpdateProfileDto": {
@@ -5744,9 +6548,33 @@
           }
         }
       },
+      "UserListResponseDto": {
+        "type": "object",
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserEntity"
+            }
+          },
+          "continuationToken": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "users"
+        ]
+      },
       "AdminUserEntity": {
         "type": "object",
         "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "OWNER",
+              "USER"
+            ]
+          },
           "id": {
             "type": "string"
           },
@@ -5759,9 +6587,6 @@
           },
           "verified": {
             "type": "boolean"
-          },
-          "role": {
-            "type": "object"
           },
           "createdAt": {
             "format": "date-time",
@@ -5816,17 +6641,14 @@
           "storageUsedBytes": {
             "format": "int64",
             "type": "integer"
-          },
-          "hashedPassword": {
-            "type": "string"
           }
         },
         "required": [
+          "role",
           "id",
           "username",
           "email",
           "verified",
-          "role",
           "createdAt",
           "avatarUrl",
           "bannerUrl",
@@ -5839,15 +6661,35 @@
           "bannedAt",
           "bannedById",
           "storageQuotaBytes",
-          "storageUsedBytes",
-          "hashedPassword"
+          "storageUsedBytes"
+        ]
+      },
+      "AdminUserListResponseDto": {
+        "type": "object",
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdminUserEntity"
+            }
+          },
+          "continuationToken": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "users"
         ]
       },
       "UpdateUserRoleDto": {
         "type": "object",
         "properties": {
           "role": {
-            "type": "object"
+            "type": "string",
+            "enum": [
+              "OWNER",
+              "USER"
+            ]
           }
         },
         "required": [
@@ -5864,6 +6706,28 @@
             "type": "string"
           }
         }
+      },
+      "SuccessResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success"
+        ]
+      },
+      "BlockedStatusResponseDto": {
+        "type": "object",
+        "properties": {
+          "blocked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "blocked"
+        ]
       },
       "CreateInviteDto": {
         "type": "object",
@@ -5887,20 +6751,164 @@
           "communityIds"
         ]
       },
-      "RoleDto": {
+      "InviteCreatorDto": {
         "type": "object",
         "properties": {
           "id": {
             "type": "string"
           },
-          "name": {
+          "username": {
             "type": "string"
           },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "displayName"
+        ]
+      },
+      "InviteResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "createdById": {
+            "type": "string",
+            "nullable": true
+          },
+          "defaultCommunityId": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "maxUses": {
+            "type": "number",
+            "nullable": true
+          },
+          "uses": {
+            "type": "number"
+          },
+          "validUntil": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "usedByIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "disabled": {
+            "type": "boolean"
+          },
+          "createdBy": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InviteCreatorDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "code",
+          "createdById",
+          "defaultCommunityId",
+          "maxUses",
+          "uses",
+          "validUntil",
+          "createdAt",
+          "usedByIds",
+          "disabled"
+        ]
+      },
+      "RoleDto": {
+        "type": "object",
+        "properties": {
           "actions": {
             "type": "array",
             "items": {
-              "type": "object"
+              "type": "string",
+              "enum": [
+                "DELETE_MESSAGE",
+                "DELETE_CHANNEL",
+                "DELETE_COMMUNITY",
+                "DELETE_INVITE",
+                "DELETE_USER",
+                "DELETE_ROLE",
+                "DELETE_ALIAS_GROUP",
+                "DELETE_ALIAS_GROUP_MEMBER",
+                "DELETE_INSTANCE_INVITE",
+                "DELETE_MEMBER",
+                "DELETE_REACTION",
+                "CREATE_MESSAGE",
+                "CREATE_CHANNEL",
+                "CREATE_COMMUNITY",
+                "CREATE_INVITE",
+                "CREATE_USER",
+                "CREATE_ROLE",
+                "CREATE_ALIAS_GROUP",
+                "CREATE_ALIAS_GROUP_MEMBER",
+                "CREATE_INSTANCE_INVITE",
+                "CREATE_MEMBER",
+                "CREATE_REACTION",
+                "JOIN_CHANNEL",
+                "READ_MESSAGE",
+                "READ_CHANNEL",
+                "READ_COMMUNITY",
+                "READ_ALL_COMMUNITIES",
+                "READ_USER",
+                "READ_ROLE",
+                "READ_ALIAS_GROUP",
+                "READ_ALIAS_GROUP_MEMBER",
+                "READ_INSTANCE_INVITE",
+                "READ_MEMBER",
+                "UPDATE_COMMUNITY",
+                "UPDATE_CHANNEL",
+                "UPDATE_MESSAGE",
+                "UPDATE_USER",
+                "UPDATE_ROLE",
+                "UPDATE_ALIAS_GROUP",
+                "UPDATE_ALIAS_GROUP_MEMBER",
+                "UPDATE_INSTANCE_INVITE",
+                "UPDATE_MEMBER",
+                "CAPTURE_REPLAY",
+                "READ_INSTANCE_SETTINGS",
+                "UPDATE_INSTANCE_SETTINGS",
+                "READ_INSTANCE_STATS",
+                "MANAGE_USER_STORAGE",
+                "BAN_USER",
+                "KICK_USER",
+                "TIMEOUT_USER",
+                "UNBAN_USER",
+                "PIN_MESSAGE",
+                "UNPIN_MESSAGE",
+                "DELETE_ANY_MESSAGE",
+                "VIEW_BAN_LIST",
+                "VIEW_MODERATION_LOGS"
+              ]
             }
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
           },
           "createdAt": {
             "format": "date-time",
@@ -5911,9 +6919,9 @@
           }
         },
         "required": [
+          "actions",
           "id",
           "name",
-          "actions",
           "createdAt",
           "isDefault"
         ]
@@ -5921,15 +6929,21 @@
       "UserRolesResponseDto": {
         "type": "object",
         "properties": {
+          "resourceType": {
+            "type": "string",
+            "enum": [
+              "COMMUNITY",
+              "CHANNEL",
+              "INSTANCE"
+            ],
+            "nullable": true
+          },
           "userId": {
             "type": "string"
           },
           "resourceId": {
             "type": "string",
             "nullable": true
-          },
-          "resourceType": {
-            "type": "object"
           },
           "roles": {
             "type": "array",
@@ -5939,9 +6953,9 @@
           }
         },
         "required": [
+          "resourceType",
           "userId",
           "resourceId",
-          "resourceType",
           "roles"
         ]
       },
@@ -5966,26 +6980,154 @@
       "CreateRoleDto": {
         "type": "object",
         "properties": {
+          "actions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": [
+                "DELETE_MESSAGE",
+                "DELETE_CHANNEL",
+                "DELETE_COMMUNITY",
+                "DELETE_INVITE",
+                "DELETE_USER",
+                "DELETE_ROLE",
+                "DELETE_ALIAS_GROUP",
+                "DELETE_ALIAS_GROUP_MEMBER",
+                "DELETE_INSTANCE_INVITE",
+                "DELETE_MEMBER",
+                "DELETE_REACTION",
+                "CREATE_MESSAGE",
+                "CREATE_CHANNEL",
+                "CREATE_COMMUNITY",
+                "CREATE_INVITE",
+                "CREATE_USER",
+                "CREATE_ROLE",
+                "CREATE_ALIAS_GROUP",
+                "CREATE_ALIAS_GROUP_MEMBER",
+                "CREATE_INSTANCE_INVITE",
+                "CREATE_MEMBER",
+                "CREATE_REACTION",
+                "JOIN_CHANNEL",
+                "READ_MESSAGE",
+                "READ_CHANNEL",
+                "READ_COMMUNITY",
+                "READ_ALL_COMMUNITIES",
+                "READ_USER",
+                "READ_ROLE",
+                "READ_ALIAS_GROUP",
+                "READ_ALIAS_GROUP_MEMBER",
+                "READ_INSTANCE_INVITE",
+                "READ_MEMBER",
+                "UPDATE_COMMUNITY",
+                "UPDATE_CHANNEL",
+                "UPDATE_MESSAGE",
+                "UPDATE_USER",
+                "UPDATE_ROLE",
+                "UPDATE_ALIAS_GROUP",
+                "UPDATE_ALIAS_GROUP_MEMBER",
+                "UPDATE_INSTANCE_INVITE",
+                "UPDATE_MEMBER",
+                "CAPTURE_REPLAY",
+                "READ_INSTANCE_SETTINGS",
+                "UPDATE_INSTANCE_SETTINGS",
+                "READ_INSTANCE_STATS",
+                "MANAGE_USER_STORAGE",
+                "BAN_USER",
+                "KICK_USER",
+                "TIMEOUT_USER",
+                "UNBAN_USER",
+                "PIN_MESSAGE",
+                "UNPIN_MESSAGE",
+                "DELETE_ANY_MESSAGE",
+                "VIEW_BAN_LIST",
+                "VIEW_MODERATION_LOGS"
+              ]
+            }
+          },
           "name": {
             "type": "string",
             "maxLength": 50
-          },
-          "actions": {
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "type": "object"
-            }
           }
         },
         "required": [
-          "name",
-          "actions"
+          "actions",
+          "name"
         ]
       },
       "UpdateRoleDto": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "actions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": [
+                "DELETE_MESSAGE",
+                "DELETE_CHANNEL",
+                "DELETE_COMMUNITY",
+                "DELETE_INVITE",
+                "DELETE_USER",
+                "DELETE_ROLE",
+                "DELETE_ALIAS_GROUP",
+                "DELETE_ALIAS_GROUP_MEMBER",
+                "DELETE_INSTANCE_INVITE",
+                "DELETE_MEMBER",
+                "DELETE_REACTION",
+                "CREATE_MESSAGE",
+                "CREATE_CHANNEL",
+                "CREATE_COMMUNITY",
+                "CREATE_INVITE",
+                "CREATE_USER",
+                "CREATE_ROLE",
+                "CREATE_ALIAS_GROUP",
+                "CREATE_ALIAS_GROUP_MEMBER",
+                "CREATE_INSTANCE_INVITE",
+                "CREATE_MEMBER",
+                "CREATE_REACTION",
+                "JOIN_CHANNEL",
+                "READ_MESSAGE",
+                "READ_CHANNEL",
+                "READ_COMMUNITY",
+                "READ_ALL_COMMUNITIES",
+                "READ_USER",
+                "READ_ROLE",
+                "READ_ALIAS_GROUP",
+                "READ_ALIAS_GROUP_MEMBER",
+                "READ_INSTANCE_INVITE",
+                "READ_MEMBER",
+                "UPDATE_COMMUNITY",
+                "UPDATE_CHANNEL",
+                "UPDATE_MESSAGE",
+                "UPDATE_USER",
+                "UPDATE_ROLE",
+                "UPDATE_ALIAS_GROUP",
+                "UPDATE_ALIAS_GROUP_MEMBER",
+                "UPDATE_INSTANCE_INVITE",
+                "UPDATE_MEMBER",
+                "CAPTURE_REPLAY",
+                "READ_INSTANCE_SETTINGS",
+                "UPDATE_INSTANCE_SETTINGS",
+                "READ_INSTANCE_STATS",
+                "MANAGE_USER_STORAGE",
+                "BAN_USER",
+                "KICK_USER",
+                "TIMEOUT_USER",
+                "UNBAN_USER",
+                "PIN_MESSAGE",
+                "UNPIN_MESSAGE",
+                "DELETE_ANY_MESSAGE",
+                "VIEW_BAN_LIST",
+                "VIEW_MODERATION_LOGS"
+              ]
+            }
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 50
+          }
+        }
       },
       "AssignRoleDto": {
         "type": "object",
@@ -6002,9 +7144,34 @@
           "roleId"
         ]
       },
+      "RoleUserDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "userId",
+          "username"
+        ]
+      },
       "CreateChannelDto": {
         "type": "object",
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "TEXT",
+              "VOICE"
+            ]
+          },
           "isPrivate": {
             "type": "boolean"
           },
@@ -6013,9 +7180,6 @@
           },
           "communityId": {
             "type": "string"
-          },
-          "type": {
-            "type": "object"
           },
           "position": {
             "type": "number"
@@ -6034,19 +7198,70 @@
           }
         },
         "required": [
+          "type",
           "isPrivate",
           "name",
           "communityId",
-          "type",
           "position",
           "slowmodeSeconds",
           "id",
           "createdAt"
         ]
       },
+      "ChannelDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "TEXT",
+              "VOICE"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "communityId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "position": {
+            "type": "number"
+          },
+          "slowmodeSeconds": {
+            "type": "number"
+          },
+          "isPrivate": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "name",
+          "communityId",
+          "createdAt",
+          "position",
+          "slowmodeSeconds",
+          "isPrivate"
+        ]
+      },
       "UpdateChannelDto": {
         "type": "object",
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "TEXT",
+              "VOICE"
+            ]
+          },
           "isPrivate": {
             "type": "boolean"
           },
@@ -6055,9 +7270,6 @@
           },
           "communityId": {
             "type": "string"
-          },
-          "type": {
-            "type": "object"
           },
           "position": {
             "type": "number"
@@ -6085,6 +7297,29 @@
         },
         "required": [
           "communityId"
+        ]
+      },
+      "HealthResponseDto": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "instanceName": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "instanceName",
+          "version",
+          "timestamp"
         ]
       },
       "CreateCommunityDto": {
@@ -6150,11 +7385,186 @@
       },
       "UpdateCommunityDto": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "maxLength": 500
+          },
+          "avatar": {
+            "type": "string",
+            "nullable": true
+          },
+          "banner": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "CommunityStatsDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "avatar": {
+            "type": "string",
+            "nullable": true
+          },
+          "banner": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "memberCount": {
+            "type": "number"
+          },
+          "channelCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "avatar",
+          "banner",
+          "createdAt",
+          "memberCount",
+          "channelCount"
+        ]
+      },
+      "CommunityStatsListResponseDto": {
+        "type": "object",
+        "properties": {
+          "communities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommunityStatsDto"
+            }
+          },
+          "continuationToken": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "communities"
+        ]
+      },
+      "CommunityStatsDetailDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "avatar": {
+            "type": "string",
+            "nullable": true
+          },
+          "banner": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "memberCount": {
+            "type": "number"
+          },
+          "channelCount": {
+            "type": "number"
+          },
+          "messageCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "avatar",
+          "banner",
+          "createdAt",
+          "memberCount",
+          "channelCount",
+          "messageCount"
+        ]
+      },
+      "CreateMessageSpanDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "PLAINTEXT",
+              "USER_MENTION",
+              "SPECIAL_MENTION",
+              "COMMUNITY_MENTION",
+              "ALIAS_MENTION"
+            ]
+          },
+          "text": {
+            "type": "string",
+            "nullable": true
+          },
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "specialKind": {
+            "type": "string",
+            "nullable": true
+          },
+          "communityId": {
+            "type": "string",
+            "nullable": true
+          },
+          "aliasId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "type",
+          "text",
+          "userId",
+          "specialKind",
+          "communityId",
+          "aliasId"
+        ]
       },
       "CreateMessageDto": {
         "type": "object",
         "properties": {
+          "spans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateMessageSpanDto"
+            }
+          },
           "id": {
             "type": "string"
           },
@@ -6182,45 +7592,6 @@
             "format": "date-time",
             "type": "string",
             "nullable": true
-          },
-          "spans": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "object"
-                },
-                "text": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "userId": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "specialKind": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "communityId": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "aliasId": {
-                  "type": "string",
-                  "nullable": true
-                }
-              },
-              "required": [
-                "type",
-                "text",
-                "userId",
-                "specialKind",
-                "communityId",
-                "aliasId"
-              ]
-            }
           },
           "attachments": {
             "type": "array",
@@ -6292,6 +7663,7 @@
           }
         },
         "required": [
+          "spans",
           "id",
           "channelId",
           "directMessageGroupId",
@@ -6299,7 +7671,6 @@
           "sentAt",
           "editedAt",
           "deletedAt",
-          "spans",
           "attachments",
           "pendingAttachments",
           "searchText",
@@ -6312,6 +7683,211 @@
           "parentMessageId",
           "replyCount",
           "lastReplyAt"
+        ]
+      },
+      "SpanDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "PLAINTEXT",
+              "USER_MENTION",
+              "SPECIAL_MENTION",
+              "COMMUNITY_MENTION",
+              "ALIAS_MENTION"
+            ]
+          },
+          "text": {
+            "type": "string",
+            "nullable": true
+          },
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "specialKind": {
+            "type": "string",
+            "nullable": true
+          },
+          "communityId": {
+            "type": "string",
+            "nullable": true
+          },
+          "aliasId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "type",
+          "text",
+          "userId",
+          "specialKind",
+          "communityId",
+          "aliasId"
+        ]
+      },
+      "EnrichedAttachment": {
+        "type": "object",
+        "properties": {
+          "fileType": {
+            "type": "string",
+            "enum": [
+              "IMAGE",
+              "VIDEO",
+              "AUDIO",
+              "DOCUMENT",
+              "OTHER"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "fileType",
+          "id",
+          "filename",
+          "mimeType",
+          "size"
+        ]
+      },
+      "ReactionDto": {
+        "type": "object",
+        "properties": {
+          "emoji": {
+            "type": "string"
+          },
+          "userIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "emoji",
+          "userIds"
+        ]
+      },
+      "EnrichedMessageDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string",
+            "nullable": true
+          },
+          "directMessageGroupId": {
+            "type": "string",
+            "nullable": true
+          },
+          "authorId": {
+            "type": "string"
+          },
+          "spans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpanDto"
+            }
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EnrichedAttachment"
+            }
+          },
+          "pendingAttachments": {
+            "type": "number",
+            "nullable": true
+          },
+          "reactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReactionDto"
+            }
+          },
+          "replyCount": {
+            "type": "number"
+          },
+          "lastReplyAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "pinned": {
+            "type": "boolean"
+          },
+          "pinnedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "pinnedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "sentAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "editedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "deletedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "channelId",
+          "directMessageGroupId",
+          "authorId",
+          "spans",
+          "attachments",
+          "pendingAttachments",
+          "reactions",
+          "replyCount",
+          "lastReplyAt",
+          "pinned",
+          "pinnedAt",
+          "pinnedBy",
+          "sentAt",
+          "editedAt",
+          "deletedAt"
+        ]
+      },
+      "PaginatedMessagesResponseDto": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EnrichedMessageDto"
+            }
+          },
+          "continuationToken": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "messages"
         ]
       },
       "AddReactionDto": {
@@ -6327,6 +7903,119 @@
         "required": [
           "messageId",
           "emoji"
+        ]
+      },
+      "MessageDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string",
+            "nullable": true
+          },
+          "directMessageGroupId": {
+            "type": "string",
+            "nullable": true
+          },
+          "authorId": {
+            "type": "string"
+          },
+          "spans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpanDto"
+            }
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "pendingAttachments": {
+            "type": "number",
+            "nullable": true
+          },
+          "reactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReactionDto"
+            }
+          },
+          "replyCount": {
+            "type": "number"
+          },
+          "lastReplyAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "pinned": {
+            "type": "boolean"
+          },
+          "pinnedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "pinnedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "sentAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "editedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "deletedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "searchText": {
+            "type": "string",
+            "nullable": true
+          },
+          "deletedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "deletedByReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentMessageId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "channelId",
+          "directMessageGroupId",
+          "authorId",
+          "spans",
+          "attachments",
+          "pendingAttachments",
+          "reactions",
+          "replyCount",
+          "lastReplyAt",
+          "pinned",
+          "pinnedAt",
+          "pinnedBy",
+          "sentAt",
+          "editedAt",
+          "deletedAt",
+          "searchText",
+          "deletedBy",
+          "deletedByReason",
+          "parentMessageId"
         ]
       },
       "RemoveReactionDto": {
@@ -6354,7 +8043,144 @@
       },
       "UpdateMessageDto": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "spans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateMessageSpanDto"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string",
+            "nullable": true
+          },
+          "directMessageGroupId": {
+            "type": "string",
+            "nullable": true
+          },
+          "authorId": {
+            "type": "string"
+          },
+          "sentAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "editedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "deletedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "pendingAttachments": {
+            "type": "number",
+            "nullable": true,
+            "minimum": 0
+          },
+          "searchText": {
+            "type": "string",
+            "nullable": true
+          },
+          "reactions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "emoji": {
+                  "type": "string"
+                },
+                "userIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "emoji",
+                "userIds"
+              ]
+            }
+          },
+          "pinned": {
+            "type": "boolean"
+          },
+          "pinnedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "pinnedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "deletedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "deletedByReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentMessageId": {
+            "type": "string",
+            "nullable": true
+          },
+          "replyCount": {
+            "type": "number"
+          },
+          "lastReplyAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "FileMetadataResponseDto": {
+        "type": "object",
+        "properties": {
+          "fileType": {
+            "type": "string",
+            "enum": [
+              "IMAGE",
+              "VIDEO",
+              "AUDIO",
+              "DOCUMENT",
+              "OTHER"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "fileType",
+          "id",
+          "filename",
+          "mimeType",
+          "size"
+        ]
       },
       "CreateMembershipDto": {
         "type": "object",
@@ -6474,6 +8300,212 @@
           "joinedAt"
         ]
       },
+      "NotificationAuthorDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "avatarUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "displayName",
+          "avatarUrl"
+        ]
+      },
+      "NotificationMessageDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "content"
+        ]
+      },
+      "NotificationDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "USER_MENTION",
+              "SPECIAL_MENTION",
+              "DIRECT_MESSAGE",
+              "CHANNEL_MESSAGE",
+              "THREAD_REPLY"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string",
+            "nullable": true
+          },
+          "channelId": {
+            "type": "string",
+            "nullable": true
+          },
+          "directMessageGroupId": {
+            "type": "string",
+            "nullable": true
+          },
+          "authorId": {
+            "type": "string"
+          },
+          "parentMessageId": {
+            "type": "string",
+            "nullable": true
+          },
+          "read": {
+            "type": "boolean"
+          },
+          "dismissed": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "author": {
+            "$ref": "#/components/schemas/NotificationAuthorDto"
+          },
+          "message": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NotificationMessageDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "userId",
+          "messageId",
+          "channelId",
+          "directMessageGroupId",
+          "authorId",
+          "parentMessageId",
+          "read",
+          "dismissed",
+          "createdAt"
+        ]
+      },
+      "NotificationListResponseDto": {
+        "type": "object",
+        "properties": {
+          "notifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NotificationDto"
+            }
+          },
+          "total": {
+            "type": "number"
+          },
+          "unreadCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "notifications",
+          "total",
+          "unreadCount"
+        ]
+      },
+      "UnreadCountResponseDto": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "count"
+        ]
+      },
+      "UserNotificationSettingsDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "desktopEnabled": {
+            "type": "boolean"
+          },
+          "playSound": {
+            "type": "boolean"
+          },
+          "soundType": {
+            "type": "string"
+          },
+          "doNotDisturb": {
+            "type": "boolean"
+          },
+          "dndStartTime": {
+            "type": "string",
+            "nullable": true
+          },
+          "dndEndTime": {
+            "type": "string",
+            "nullable": true
+          },
+          "defaultChannelLevel": {
+            "type": "string"
+          },
+          "dmNotifications": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "desktopEnabled",
+          "playSound",
+          "soundType",
+          "doNotDisturb",
+          "dndStartTime",
+          "dndEndTime",
+          "defaultChannelLevel",
+          "dmNotifications",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
       "UpdateNotificationSettingsDto": {
         "type": "object",
         "properties": {
@@ -6515,6 +8547,39 @@
           }
         }
       },
+      "ChannelNotificationOverrideDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string"
+          },
+          "level": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "channelId",
+          "level",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
       "UpdateChannelOverrideDto": {
         "type": "object",
         "properties": {
@@ -6535,7 +8600,14 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": "object"
+            "type": "string",
+            "enum": [
+              "USER_MENTION",
+              "SPECIAL_MENTION",
+              "DIRECT_MESSAGE",
+              "CHANNEL_MESSAGE",
+              "THREAD_REPLY"
+            ]
           },
           "customMessage": {
             "type": "string"
@@ -6543,6 +8615,106 @@
         },
         "required": [
           "type"
+        ]
+      },
+      "DebugNotificationResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "notification": {
+            "$ref": "#/components/schemas/NotificationDto"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "notification",
+          "message"
+        ]
+      },
+      "DebugPushSubscriptionDto": {
+        "type": "object",
+        "properties": {
+          "endpoint": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "endpoint",
+          "createdAt"
+        ]
+      },
+      "DebugSubscriptionsResponseDto": {
+        "type": "object",
+        "properties": {
+          "subscriptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DebugPushSubscriptionDto"
+            }
+          },
+          "count": {
+            "type": "number"
+          },
+          "pushEnabled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "subscriptions",
+          "count",
+          "pushEnabled"
+        ]
+      },
+      "ClearNotificationDataResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "notificationsDeleted": {
+            "type": "number"
+          },
+          "settingsDeleted": {
+            "type": "number"
+          },
+          "overridesDeleted": {
+            "type": "number"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "notificationsDeleted",
+          "settingsDeleted",
+          "overridesDeleted",
+          "message"
+        ]
+      },
+      "VapidPublicKeyResponseDto": {
+        "type": "object",
+        "properties": {
+          "publicKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "publicKey",
+          "enabled"
         ]
       },
       "PushSubscriptionKeys": {
@@ -6578,6 +8750,21 @@
           "keys"
         ]
       },
+      "SuccessMessageDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "message"
+        ]
+      },
       "UnsubscribePushDto": {
         "type": "object",
         "properties": {
@@ -6589,6 +8776,44 @@
           "endpoint"
         ]
       },
+      "PushStatusResponseDto": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "subscriptionCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "enabled",
+          "subscriptionCount"
+        ]
+      },
+      "TestPushResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "sent": {
+            "type": "number"
+          },
+          "failed": {
+            "type": "number"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "sent",
+          "failed",
+          "message"
+        ]
+      },
       "UnbanUserDto": {
         "type": "object",
         "properties": {
@@ -6596,6 +8821,49 @@
             "type": "string"
           }
         }
+      },
+      "CommunityBanDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "communityId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "moderatorId": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "expiresAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "active": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "communityId",
+          "userId",
+          "moderatorId",
+          "reason",
+          "createdAt",
+          "expiresAt",
+          "active"
+        ]
       },
       "KickUserDto": {
         "type": "object",
@@ -6629,6 +8897,59 @@
           }
         }
       },
+      "CommunityTimeoutDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "communityId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "moderatorId": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "expiresAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "communityId",
+          "userId",
+          "moderatorId",
+          "reason",
+          "createdAt",
+          "expiresAt"
+        ]
+      },
+      "TimeoutStatusResponseDto": {
+        "type": "object",
+        "properties": {
+          "isTimedOut": {
+            "type": "boolean"
+          },
+          "expiresAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "isTimedOut"
+        ]
+      },
       "PinMessageDto": {
         "type": "object",
         "properties": {
@@ -6645,6 +8966,187 @@
           }
         }
       },
+      "PinnedMessageAuthorDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "avatarUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "displayName",
+          "avatarUrl"
+        ]
+      },
+      "PinnedMessageAttachmentDto": {
+        "type": "object",
+        "properties": {
+          "fileType": {
+            "type": "string",
+            "enum": [
+              "IMAGE",
+              "VIDEO",
+              "AUDIO",
+              "DOCUMENT",
+              "OTHER"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "fileType",
+          "id",
+          "filename",
+          "mimeType",
+          "size"
+        ]
+      },
+      "PinnedMessageDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string",
+            "nullable": true
+          },
+          "directMessageGroupId": {
+            "type": "string",
+            "nullable": true
+          },
+          "authorId": {
+            "type": "string"
+          },
+          "spans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpanDto"
+            }
+          },
+          "reactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReactionDto"
+            }
+          },
+          "sentAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "editedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "deletedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "pinned": {
+            "type": "boolean"
+          },
+          "pinnedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "pinnedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "replyCount": {
+            "type": "number"
+          },
+          "lastReplyAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "searchText": {
+            "type": "string",
+            "nullable": true
+          },
+          "pendingAttachments": {
+            "type": "number",
+            "nullable": true
+          },
+          "deletedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "deletedByReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentMessageId": {
+            "type": "string",
+            "nullable": true
+          },
+          "author": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PinnedMessageAuthorDto"
+              }
+            ]
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PinnedMessageAttachmentDto"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "channelId",
+          "directMessageGroupId",
+          "authorId",
+          "spans",
+          "reactions",
+          "sentAt",
+          "editedAt",
+          "deletedAt",
+          "pinned",
+          "pinnedAt",
+          "pinnedBy",
+          "replyCount",
+          "lastReplyAt",
+          "searchText",
+          "pendingAttachments",
+          "deletedBy",
+          "deletedByReason",
+          "parentMessageId",
+          "author",
+          "attachments"
+        ]
+      },
       "DeleteMessageAsModDto": {
         "type": "object",
         "properties": {
@@ -6652,6 +9154,78 @@
             "type": "string"
           }
         }
+      },
+      "ModerationLogDto": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "BAN_USER",
+              "UNBAN_USER",
+              "KICK_USER",
+              "TIMEOUT_USER",
+              "REMOVE_TIMEOUT",
+              "DELETE_MESSAGE",
+              "PIN_MESSAGE",
+              "UNPIN_MESSAGE"
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true
+          },
+          "id": {
+            "type": "string"
+          },
+          "communityId": {
+            "type": "string"
+          },
+          "moderatorId": {
+            "type": "string"
+          },
+          "targetUserId": {
+            "type": "string",
+            "nullable": true
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action",
+          "metadata",
+          "id",
+          "communityId",
+          "moderatorId",
+          "targetUserId",
+          "reason",
+          "createdAt"
+        ]
+      },
+      "ModerationLogsResponseDto": {
+        "type": "object",
+        "properties": {
+          "logs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModerationLogDto"
+            }
+          },
+          "total": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "logs",
+          "total"
+        ]
       },
       "MarkAsReadDto": {
         "type": "object",
@@ -6664,6 +9238,76 @@
           },
           "directMessageGroupId": {
             "type": "string"
+          }
+        },
+        "required": [
+          "lastReadMessageId"
+        ]
+      },
+      "ReadReceiptDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string",
+            "nullable": true
+          },
+          "directMessageGroupId": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastReadMessageId": {
+            "type": "string"
+          },
+          "lastReadAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "channelId",
+          "directMessageGroupId",
+          "lastReadMessageId",
+          "lastReadAt"
+        ]
+      },
+      "UnreadCountDto": {
+        "type": "object",
+        "properties": {
+          "channelId": {
+            "type": "string"
+          },
+          "directMessageGroupId": {
+            "type": "string"
+          },
+          "unreadCount": {
+            "type": "number"
+          },
+          "lastReadMessageId": {
+            "type": "string"
+          },
+          "lastReadAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "unreadCount"
+        ]
+      },
+      "LastReadResponseDto": {
+        "type": "object",
+        "properties": {
+          "lastReadMessageId": {
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [
@@ -6718,6 +9362,29 @@
           "roomId"
         ]
       },
+      "ConnectionInfoResponseDto": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "LivekitHealthResponseDto": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "configured": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "status",
+          "configured"
+        ]
+      },
       "StartReplayBufferDto": {
         "type": "object",
         "properties": {
@@ -6745,9 +9412,43 @@
           "audioTrackId"
         ]
       },
-      "Object": {
+      "StartReplayResponseDto": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "sessionId": {
+            "type": "string"
+          },
+          "egressId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sessionId",
+          "egressId",
+          "status"
+        ]
+      },
+      "StopReplayResponseDto": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string"
+          },
+          "egressId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sessionId",
+          "egressId",
+          "status"
+        ]
       },
       "SessionInfoResponseDto": {
         "type": "object",
@@ -6787,8 +9488,23 @@
         "type": "object",
         "properties": {
           "durationMinutes": {
-            "type": "object",
-            "description": "Duration preset in minutes (optional if using custom range)\nUser selects from: 1, 2, 5, or 10 minutes"
+            "type": "number",
+            "description": "Duration preset in minutes (optional if using custom range)\nUser selects from: 1, 2, 5, or 10 minutes",
+            "enum": [
+              1,
+              2,
+              5,
+              10
+            ]
+          },
+          "destination": {
+            "type": "string",
+            "description": "Where to save/post the clip\n- 'library': Save to user's clip library only\n- 'dm': Save to library and send to specified DM group\n- 'channel': Save to library and post to specified channel",
+            "enum": [
+              "library",
+              "dm",
+              "channel"
+            ]
           },
           "startSeconds": {
             "type": "number",
@@ -6799,10 +9515,6 @@
             "type": "number",
             "description": "Custom clip end time in seconds from buffer start\nRequired if using custom range (no durationMinutes)",
             "minimum": 1
-          },
-          "destination": {
-            "type": "object",
-            "description": "Where to save/post the clip\n- 'library': Save to user's clip library only\n- 'dm': Save to library and send to specified DM group\n- 'channel': Save to library and post to specified channel"
           },
           "targetChannelId": {
             "type": "string",
@@ -6916,8 +9628,12 @@
         "type": "object",
         "properties": {
           "destination": {
-            "type": "object",
-            "description": "Where to share the clip\n- 'channel': Post to specified channel\n- 'dm': Send to specified DM group"
+            "type": "string",
+            "description": "Where to share the clip\n- 'channel': Post to specified channel\n- 'dm': Send to specified DM group",
+            "enum": [
+              "channel",
+              "dm"
+            ]
           },
           "targetChannelId": {
             "type": "string",
@@ -6935,20 +9651,24 @@
       "ShareClipResponseDto": {
         "type": "object",
         "properties": {
+          "destination": {
+            "type": "string",
+            "enum": [
+              "channel",
+              "dm"
+            ]
+          },
           "messageId": {
             "type": "string"
           },
           "clipId": {
             "type": "string"
-          },
-          "destination": {
-            "type": "object"
           }
         },
         "required": [
+          "destination",
           "messageId",
-          "clipId",
-          "destination"
+          "clipId"
         ]
       },
       "LiveKitRoomInfo": {
@@ -7064,6 +9784,117 @@
           "event"
         ]
       },
+      "VoicePresenceUserDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "avatarUrl": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "isDeafened": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "joinedAt",
+          "isDeafened"
+        ]
+      },
+      "ChannelVoicePresenceResponseDto": {
+        "type": "object",
+        "properties": {
+          "channelId": {
+            "type": "string"
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VoicePresenceUserDto"
+            }
+          },
+          "count": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "channelId",
+          "users",
+          "count"
+        ]
+      },
+      "RefreshPresenceResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "message",
+          "channelId"
+        ]
+      },
+      "UserVoiceChannelsResponseDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string"
+          },
+          "voiceChannels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "userId",
+          "voiceChannels"
+        ]
+      },
+      "DmVoicePresenceResponseDto": {
+        "type": "object",
+        "properties": {
+          "dmGroupId": {
+            "type": "string"
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VoicePresenceUserDto"
+            }
+          },
+          "count": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "dmGroupId",
+          "users",
+          "count"
+        ]
+      },
       "OnboardingStatusDto": {
         "type": "object",
         "properties": {
@@ -7124,9 +9955,119 @@
           "setupToken"
         ]
       },
+      "SetupResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "adminUserId": {
+            "type": "string"
+          },
+          "defaultCommunityId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "message",
+          "adminUserId"
+        ]
+      },
+      "DmGroupMemberUserDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "avatarUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "username"
+        ]
+      },
+      "DmGroupMemberDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/DmGroupMemberUserDto"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "joinedAt",
+          "user"
+        ]
+      },
+      "DmGroupLastMessageDto": {
+        "type": "object",
+        "properties": {
+          "spans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpanDto"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "authorId": {
+            "type": "string"
+          },
+          "sentAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "spans",
+          "id",
+          "authorId",
+          "sentAt"
+        ]
+      },
       "DmGroupResponseDto": {
         "type": "object",
         "properties": {
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DmGroupMemberDto"
+            }
+          },
+          "lastMessage": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DmGroupLastMessageDto"
+              }
+            ]
+          },
           "id": {
             "type": "string"
           },
@@ -7140,84 +10081,13 @@
           "createdAt": {
             "format": "date-time",
             "type": "string"
-          },
-          "members": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "userId": {
-                  "type": "string"
-                },
-                "joinedAt": {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                "user": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "username": {
-                      "type": "string"
-                    },
-                    "displayName": {
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "avatarUrl": {
-                      "type": "string",
-                      "nullable": true
-                    }
-                  },
-                  "selfRequired": true
-                }
-              },
-              "required": [
-                "id",
-                "userId",
-                "joinedAt",
-                "user"
-              ]
-            }
-          },
-          "lastMessage": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "authorId": {
-                "type": "string"
-              },
-              "spans": {
-                "type": "array",
-                "items": {
-                  "type": "object"
-                }
-              },
-              "sentAt": {
-                "format": "date-time",
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "authorId",
-              "spans",
-              "sentAt"
-            ]
           }
         },
         "required": [
+          "members",
           "id",
           "isGroup",
-          "createdAt",
-          "members"
+          "createdAt"
         ]
       },
       "CreateDmGroupDto": {
@@ -7258,7 +10128,16 @@
         "type": "object",
         "properties": {
           "resourceType": {
-            "type": "object"
+            "type": "string",
+            "enum": [
+              "USER_AVATAR",
+              "USER_BANNER",
+              "COMMUNITY_BANNER",
+              "COMMUNITY_AVATAR",
+              "MESSAGE_ATTACHMENT",
+              "CUSTOM_EMOJI",
+              "REPLAY_CLIP"
+            ]
           },
           "resourceId": {
             "type": "string",
@@ -7267,6 +10146,91 @@
         },
         "required": [
           "resourceType"
+        ]
+      },
+      "FileUploadResponseDto": {
+        "type": "object",
+        "properties": {
+          "fileType": {
+            "type": "string",
+            "enum": [
+              "IMAGE",
+              "VIDEO",
+              "AUDIO",
+              "DOCUMENT",
+              "OTHER"
+            ]
+          },
+          "resourceType": {
+            "type": "string",
+            "enum": [
+              "USER_AVATAR",
+              "USER_BANNER",
+              "COMMUNITY_BANNER",
+              "COMMUNITY_AVATAR",
+              "MESSAGE_ATTACHMENT",
+              "CUSTOM_EMOJI",
+              "REPLAY_CLIP"
+            ]
+          },
+          "storageType": {
+            "type": "string",
+            "enum": [
+              "LOCAL",
+              "S3",
+              "AZURE_BLOB"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "checksum": {
+            "type": "string"
+          },
+          "uploadedById": {
+            "type": "string",
+            "nullable": true
+          },
+          "uploadedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "deletedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "resourceId": {
+            "type": "string",
+            "nullable": true
+          },
+          "storagePath": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "fileType",
+          "resourceType",
+          "storageType",
+          "id",
+          "filename",
+          "mimeType",
+          "size",
+          "checksum",
+          "uploadedById",
+          "uploadedAt",
+          "deletedAt",
+          "resourceId",
+          "storagePath"
         ]
       },
       "UserStorageStatsDto": {
@@ -7466,6 +10430,24 @@
           "server"
         ]
       },
+      "UserStorageListResponseDto": {
+        "type": "object",
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserStorageStatsDto"
+            }
+          },
+          "total": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "users",
+          "total"
+        ]
+      },
       "UpdateUserQuotaDto": {
         "type": "object",
         "properties": {
@@ -7492,9 +10474,33 @@
           }
         }
       },
+      "PublicSettingsResponseDto": {
+        "type": "object",
+        "properties": {
+          "registrationMode": {
+            "type": "string",
+            "enum": [
+              "OPEN",
+              "INVITE_ONLY",
+              "CLOSED"
+            ]
+          }
+        },
+        "required": [
+          "registrationMode"
+        ]
+      },
       "InstanceSettingsResponseDto": {
         "type": "object",
         "properties": {
+          "registrationMode": {
+            "type": "string",
+            "enum": [
+              "OPEN",
+              "INVITE_ONLY",
+              "CLOSED"
+            ]
+          },
           "id": {
             "type": "string"
           },
@@ -7504,9 +10510,6 @@
           "description": {
             "type": "string",
             "nullable": true
-          },
-          "registrationMode": {
-            "type": "object"
           },
           "createdAt": {
             "format": "date-time",
@@ -7526,10 +10529,10 @@
           }
         },
         "required": [
+          "registrationMode",
           "id",
           "name",
           "description",
-          "registrationMode",
           "createdAt",
           "updatedAt",
           "defaultStorageQuotaBytes",
@@ -7539,6 +10542,14 @@
       "UpdateInstanceSettingsDto": {
         "type": "object",
         "properties": {
+          "registrationMode": {
+            "type": "string",
+            "enum": [
+              "OPEN",
+              "INVITE_ONLY",
+              "CLOSED"
+            ]
+          },
           "name": {
             "type": "string",
             "maxLength": 100
@@ -7546,9 +10557,6 @@
           "description": {
             "type": "string",
             "maxLength": 500
-          },
-          "registrationMode": {
-            "type": "object"
           },
           "defaultStorageQuotaBytes": {
             "type": "number",
@@ -7561,6 +10569,74 @@
             "minimum": 0
           }
         }
+      },
+      "InstanceStatsResponseDto": {
+        "type": "object",
+        "properties": {
+          "totalUsers": {
+            "type": "number"
+          },
+          "totalCommunities": {
+            "type": "number"
+          },
+          "totalChannels": {
+            "type": "number"
+          },
+          "totalMessages": {
+            "type": "number"
+          },
+          "activeInvites": {
+            "type": "number"
+          },
+          "bannedUsers": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "totalUsers",
+          "totalCommunities",
+          "totalChannels",
+          "totalMessages",
+          "activeInvites",
+          "bannedUsers"
+        ]
+      },
+      "AppearanceSettingsResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "themeMode": {
+            "type": "string"
+          },
+          "accentColor": {
+            "type": "string"
+          },
+          "intensity": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "themeMode",
+          "accentColor",
+          "intensity",
+          "createdAt",
+          "updatedAt"
+        ]
       },
       "UpdateAppearanceSettingsDto": {
         "type": "object",
@@ -7598,6 +10674,481 @@
             ]
           }
         }
+      },
+      "FriendUserDto": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "OWNER",
+              "USER"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "verified": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "avatarUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "bannerUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastSeen": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "bio": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "statusUpdatedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "banned": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "role",
+          "id",
+          "username",
+          "email",
+          "verified",
+          "createdAt",
+          "avatarUrl",
+          "bannerUrl",
+          "lastSeen",
+          "displayName",
+          "bio",
+          "status",
+          "statusUpdatedAt",
+          "banned"
+        ]
+      },
+      "FriendshipWithUsersDto": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "ACCEPTED",
+              "BLOCKED"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "userAId": {
+            "type": "string"
+          },
+          "userBId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "userA": {
+            "$ref": "#/components/schemas/FriendUserDto"
+          },
+          "userB": {
+            "$ref": "#/components/schemas/FriendUserDto"
+          }
+        },
+        "required": [
+          "status",
+          "id",
+          "userAId",
+          "userBId",
+          "createdAt",
+          "userA",
+          "userB"
+        ]
+      },
+      "PendingRequestsDto": {
+        "type": "object",
+        "properties": {
+          "sent": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FriendshipWithUsersDto"
+            }
+          },
+          "received": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FriendshipWithUsersDto"
+            }
+          }
+        },
+        "required": [
+          "sent",
+          "received"
+        ]
+      },
+      "FriendshipStatusDto": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "PENDING",
+              "ACCEPTED",
+              "BLOCKED"
+            ]
+          },
+          "direction": {
+            "type": "string",
+            "enum": [
+              "sent",
+              "received"
+            ],
+            "nullable": true
+          },
+          "friendshipId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "status",
+          "direction",
+          "friendshipId"
+        ]
+      },
+      "FriendshipDto": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "ACCEPTED",
+              "BLOCKED"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "userAId": {
+            "type": "string"
+          },
+          "userBId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "id",
+          "userAId",
+          "userBId",
+          "createdAt"
+        ]
+      },
+      "ThreadReplyDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string",
+            "nullable": true
+          },
+          "directMessageGroupId": {
+            "type": "string",
+            "nullable": true
+          },
+          "authorId": {
+            "type": "string"
+          },
+          "spans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpanDto"
+            }
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "pendingAttachments": {
+            "type": "number",
+            "nullable": true
+          },
+          "reactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReactionDto"
+            }
+          },
+          "sentAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "editedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "deletedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "pinned": {
+            "type": "boolean"
+          },
+          "pinnedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "pinnedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "replyCount": {
+            "type": "number"
+          },
+          "lastReplyAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "parentMessageId": {
+            "type": "string",
+            "nullable": true
+          },
+          "searchText": {
+            "type": "string",
+            "nullable": true
+          },
+          "deletedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "deletedByReason": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "channelId",
+          "directMessageGroupId",
+          "authorId",
+          "spans",
+          "attachments",
+          "pendingAttachments",
+          "reactions",
+          "sentAt",
+          "editedAt",
+          "deletedAt",
+          "pinned",
+          "pinnedAt",
+          "pinnedBy",
+          "replyCount",
+          "lastReplyAt",
+          "parentMessageId",
+          "searchText",
+          "deletedBy",
+          "deletedByReason"
+        ]
+      },
+      "EnrichedThreadReplyDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string",
+            "nullable": true
+          },
+          "directMessageGroupId": {
+            "type": "string",
+            "nullable": true
+          },
+          "authorId": {
+            "type": "string"
+          },
+          "spans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpanDto"
+            }
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EnrichedAttachment"
+            }
+          },
+          "pendingAttachments": {
+            "type": "number",
+            "nullable": true
+          },
+          "reactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReactionDto"
+            }
+          },
+          "sentAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "editedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "deletedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "pinned": {
+            "type": "boolean"
+          },
+          "pinnedAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "pinnedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "replyCount": {
+            "type": "number"
+          },
+          "lastReplyAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "parentMessageId": {
+            "type": "string",
+            "nullable": true
+          },
+          "searchText": {
+            "type": "string",
+            "nullable": true
+          },
+          "deletedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "deletedByReason": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "channelId",
+          "directMessageGroupId",
+          "authorId",
+          "spans",
+          "attachments",
+          "pendingAttachments",
+          "reactions",
+          "sentAt",
+          "editedAt",
+          "deletedAt",
+          "pinned",
+          "pinnedAt",
+          "pinnedBy",
+          "replyCount",
+          "lastReplyAt",
+          "parentMessageId",
+          "searchText",
+          "deletedBy",
+          "deletedByReason"
+        ]
+      },
+      "ThreadRepliesResponseDto": {
+        "type": "object",
+        "properties": {
+          "replies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EnrichedThreadReplyDto"
+            }
+          },
+          "continuationToken": {
+            "type": "string"
+          },
+          "fileMetadata": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "replies"
+        ]
+      },
+      "ThreadMetadataDto": {
+        "type": "object",
+        "properties": {
+          "parentMessageId": {
+            "type": "string"
+          },
+          "replyCount": {
+            "type": "number"
+          },
+          "lastReplyAt": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "isSubscribed": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "parentMessageId",
+          "replyCount",
+          "lastReplyAt",
+          "isSubscribed"
+        ]
       },
       "CreateAliasGroupDto": {
         "type": "object",

--- a/backend/src/appearance-settings/appearance-settings.controller.ts
+++ b/backend/src/appearance-settings/appearance-settings.controller.ts
@@ -6,6 +6,7 @@ import {
   UseGuards,
   Request,
 } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
 import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
 import { AppearanceSettingsService } from './appearance-settings.service';
 import { UpdateAppearanceSettingsDto } from './dto/update-appearance-settings.dto';
@@ -22,6 +23,7 @@ export class AppearanceSettingsController {
    * Get current user's appearance settings
    */
   @Get()
+  @ApiOkResponse({ type: AppearanceSettingsResponseDto })
   async getSettings(
     @Request() req: { user: { id: string } },
   ): Promise<AppearanceSettingsResponseDto> {
@@ -32,6 +34,7 @@ export class AppearanceSettingsController {
    * Update current user's appearance settings
    */
   @Patch()
+  @ApiOkResponse({ type: AppearanceSettingsResponseDto })
   async updateSettings(
     @Request() req: { user: { id: string } },
     @Body() dto: UpdateAppearanceSettingsDto,

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -13,6 +13,7 @@ import {
   NotFoundException,
   Logger,
 } from '@nestjs/common';
+import { ApiOkResponse, ApiCreatedResponse } from '@nestjs/swagger';
 import { LocalAuthGuard } from './local-auth.guard';
 import { JwtAuthGuard } from './jwt-auth.guard';
 import { AuthService, DeviceInfo } from './auth.service';
@@ -58,6 +59,7 @@ export class AuthController {
   @UseGuards(LocalAuthGuard)
   @Post('login')
   @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({ type: LoginResponseDto })
   async login(
     @Req() req: AuthenticatedRequest,
     @Res({ passthrough: true }) res: Response,
@@ -88,6 +90,7 @@ export class AuthController {
   @Throttle({ short: { limit: 4, ttl: 1000 }, long: { limit: 10, ttl: 60000 } })
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({ type: LoginResponseDto })
   async refresh(
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
@@ -149,6 +152,7 @@ export class AuthController {
 
   @Throttle({ short: { limit: 2, ttl: 1000 }, long: { limit: 5, ttl: 60000 } })
   @Post('logout')
+  @ApiCreatedResponse({ type: LogoutResponseDto })
   async logout(
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
@@ -218,6 +222,7 @@ export class AuthController {
    */
   @UseGuards(JwtAuthGuard)
   @Get('sessions')
+  @ApiOkResponse({ type: [SessionInfoDto] })
   async getSessions(
     @Req() req: AuthenticatedRequest,
   ): Promise<SessionInfoDto[]> {
@@ -230,6 +235,7 @@ export class AuthController {
    */
   @UseGuards(JwtAuthGuard)
   @Delete('sessions/:sessionId')
+  @ApiOkResponse({ type: RevokeSessionResponseDto })
   async revokeSession(
     @Req() req: AuthenticatedRequest,
     @Param('sessionId', ParseObjectIdPipe) sessionId: string,
@@ -251,6 +257,7 @@ export class AuthController {
    */
   @UseGuards(JwtAuthGuard)
   @Delete('sessions')
+  @ApiOkResponse({ type: RevokeAllSessionsResponseDto })
   async revokeAllOtherSessions(
     @Req() req: AuthenticatedRequest,
   ): Promise<RevokeAllSessionsResponseDto> {

--- a/backend/src/channels/channels.controller.ts
+++ b/backend/src/channels/channels.controller.ts
@@ -10,6 +10,7 @@ import {
   HttpCode,
   Req,
 } from '@nestjs/common';
+import { ApiOkResponse, ApiCreatedResponse } from '@nestjs/swagger';
 import { ChannelsService } from './channels.service';
 import { CreateChannelDto } from './dto/create-channel.dto';
 import { UpdateChannelDto } from './dto/update-channel.dto';
@@ -40,6 +41,7 @@ export class ChannelsController {
     idKey: 'communityId',
     source: ResourceIdSource.BODY,
   })
+  @ApiCreatedResponse({ type: ChannelDto })
   create(
     @Body() createChannelDto: CreateChannelDto,
     @Req() req: AuthenticatedRequest,
@@ -54,6 +56,7 @@ export class ChannelsController {
     idKey: 'communityId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: [ChannelDto] })
   findAllForCommunity(
     @Param('communityId', ParseObjectIdPipe) communityId: string,
   ): Promise<ChannelDto[]> {
@@ -67,6 +70,7 @@ export class ChannelsController {
     idKey: 'communityId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: [ChannelDto] })
   getMentionableChannels(
     @Param('communityId', ParseObjectIdPipe) communityId: string,
     @Req() req: AuthenticatedRequest,
@@ -84,6 +88,7 @@ export class ChannelsController {
     idKey: 'id',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: ChannelDto })
   findOne(@Param('id', ParseObjectIdPipe) id: string): Promise<ChannelDto> {
     return this.channelsService.findOne(id);
   }
@@ -95,6 +100,7 @@ export class ChannelsController {
     idKey: 'id',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: ChannelDto })
   update(
     @Param('id', ParseObjectIdPipe) id: string,
     @Body() updateChannelDto: UpdateChannelDto,
@@ -122,6 +128,7 @@ export class ChannelsController {
     idKey: 'communityId',
     source: ResourceIdSource.BODY,
   })
+  @ApiOkResponse({ type: [ChannelDto] })
   moveUp(
     @Param('id', ParseObjectIdPipe) id: string,
     @Body() moveChannelDto: MoveChannelDto,
@@ -137,6 +144,7 @@ export class ChannelsController {
     idKey: 'communityId',
     source: ResourceIdSource.BODY,
   })
+  @ApiOkResponse({ type: [ChannelDto] })
   moveDown(
     @Param('id', ParseObjectIdPipe) id: string,
     @Body() moveChannelDto: MoveChannelDto,

--- a/backend/src/channels/dto/channel-response.dto.ts
+++ b/backend/src/channels/dto/channel-response.dto.ts
@@ -1,10 +1,13 @@
 import { ChannelType } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import { ChannelTypeValues } from '@/common/enums/swagger-enums';
 
 export class ChannelDto {
   id: string;
   name: string;
   communityId: string;
   createdAt: Date;
+  @ApiProperty({ enum: ChannelTypeValues })
   type: ChannelType;
   position: number;
   slowmodeSeconds: number;

--- a/backend/src/channels/dto/create-channel.dto.ts
+++ b/backend/src/channels/dto/create-channel.dto.ts
@@ -10,6 +10,8 @@ import {
   Min,
   Max,
 } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { ChannelTypeValues } from '@/common/enums/swagger-enums';
 
 export class CreateChannelDto implements Channel {
   @IsBoolean()
@@ -24,6 +26,7 @@ export class CreateChannelDto implements Channel {
   @IsNotEmpty()
   communityId: string;
 
+  @ApiProperty({ enum: ChannelTypeValues })
   @IsEnum($Enums.ChannelType)
   type: $Enums.ChannelType;
 

--- a/backend/src/common/dto/common-response.dto.ts
+++ b/backend/src/common/dto/common-response.dto.ts
@@ -1,0 +1,8 @@
+export class SuccessResponseDto {
+  success: boolean;
+}
+
+export class SuccessMessageDto {
+  success: boolean;
+  message: string;
+}

--- a/backend/src/common/enums/swagger-enums.ts
+++ b/backend/src/common/enums/swagger-enums.ts
@@ -1,0 +1,130 @@
+/**
+ * Const arrays mirroring Prisma enums for use with @ApiProperty({ enum: ... }).
+ *
+ * The NestJS Swagger plugin can't introspect Prisma enum types, so we provide
+ * these arrays as the enum metadata source for OpenAPI spec generation.
+ *
+ * Keep these in sync with the enum definitions in prisma/schema.prisma.
+ */
+
+export const SpanTypeValues = [
+  'PLAINTEXT',
+  'USER_MENTION',
+  'SPECIAL_MENTION',
+  'COMMUNITY_MENTION',
+  'ALIAS_MENTION',
+] as const;
+
+export const FileTypeValues = [
+  'IMAGE',
+  'VIDEO',
+  'AUDIO',
+  'DOCUMENT',
+  'OTHER',
+] as const;
+
+export const ResourceTypeValues = [
+  'USER_AVATAR',
+  'USER_BANNER',
+  'COMMUNITY_BANNER',
+  'COMMUNITY_AVATAR',
+  'MESSAGE_ATTACHMENT',
+  'CUSTOM_EMOJI',
+  'REPLAY_CLIP',
+] as const;
+
+export const StorageTypeValues = ['LOCAL', 'S3', 'AZURE_BLOB'] as const;
+
+export const FriendshipStatusValues = [
+  'PENDING',
+  'ACCEPTED',
+  'BLOCKED',
+] as const;
+
+export const ChannelTypeValues = ['TEXT', 'VOICE'] as const;
+
+export const RbacActionsValues = [
+  'DELETE_MESSAGE',
+  'DELETE_CHANNEL',
+  'DELETE_COMMUNITY',
+  'DELETE_INVITE',
+  'DELETE_USER',
+  'DELETE_ROLE',
+  'DELETE_ALIAS_GROUP',
+  'DELETE_ALIAS_GROUP_MEMBER',
+  'DELETE_INSTANCE_INVITE',
+  'DELETE_MEMBER',
+  'DELETE_REACTION',
+  'CREATE_MESSAGE',
+  'CREATE_CHANNEL',
+  'CREATE_COMMUNITY',
+  'CREATE_INVITE',
+  'CREATE_USER',
+  'CREATE_ROLE',
+  'CREATE_ALIAS_GROUP',
+  'CREATE_ALIAS_GROUP_MEMBER',
+  'CREATE_INSTANCE_INVITE',
+  'CREATE_MEMBER',
+  'CREATE_REACTION',
+  'JOIN_CHANNEL',
+  'READ_MESSAGE',
+  'READ_CHANNEL',
+  'READ_COMMUNITY',
+  'READ_ALL_COMMUNITIES',
+  'READ_USER',
+  'READ_ROLE',
+  'READ_ALIAS_GROUP',
+  'READ_ALIAS_GROUP_MEMBER',
+  'READ_INSTANCE_INVITE',
+  'READ_MEMBER',
+  'UPDATE_COMMUNITY',
+  'UPDATE_CHANNEL',
+  'UPDATE_MESSAGE',
+  'UPDATE_USER',
+  'UPDATE_ROLE',
+  'UPDATE_ALIAS_GROUP',
+  'UPDATE_ALIAS_GROUP_MEMBER',
+  'UPDATE_INSTANCE_INVITE',
+  'UPDATE_MEMBER',
+  'CAPTURE_REPLAY',
+  'READ_INSTANCE_SETTINGS',
+  'UPDATE_INSTANCE_SETTINGS',
+  'READ_INSTANCE_STATS',
+  'MANAGE_USER_STORAGE',
+  'BAN_USER',
+  'KICK_USER',
+  'TIMEOUT_USER',
+  'UNBAN_USER',
+  'PIN_MESSAGE',
+  'UNPIN_MESSAGE',
+  'DELETE_ANY_MESSAGE',
+  'VIEW_BAN_LIST',
+  'VIEW_MODERATION_LOGS',
+] as const;
+
+export const InstanceRoleValues = ['OWNER', 'USER'] as const;
+
+export const ModerationActionValues = [
+  'BAN_USER',
+  'UNBAN_USER',
+  'KICK_USER',
+  'TIMEOUT_USER',
+  'REMOVE_TIMEOUT',
+  'DELETE_MESSAGE',
+  'PIN_MESSAGE',
+  'UNPIN_MESSAGE',
+] as const;
+
+export const NotificationTypeValues = [
+  'USER_MENTION',
+  'SPECIAL_MENTION',
+  'DIRECT_MESSAGE',
+  'CHANNEL_MESSAGE',
+  'THREAD_REPLY',
+] as const;
+
+export const RegistrationModeValues = [
+  'OPEN',
+  'INVITE_ONLY',
+  'CLOSED',
+] as const;

--- a/backend/src/community/community.controller.ts
+++ b/backend/src/community/community.controller.ts
@@ -13,7 +13,12 @@ import {
   ParseIntPipe,
   DefaultValuePipe,
 } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOkResponse } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiCreatedResponse,
+} from '@nestjs/swagger';
 import { ParseObjectIdPipe } from 'nestjs-object-id';
 import { CommunityService } from './community.service';
 import { CreateCommunityDto } from './dto/create-community.dto';
@@ -45,6 +50,7 @@ export class CommunityController {
   @HttpCode(201)
   @RequiredActions(RbacActions.CREATE_COMMUNITY)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiCreatedResponse({ type: CommunityResponseDto })
   create(
     @Body() createCommunityDto: CreateCommunityDto,
     @Req() req: AuthenticatedRequest,
@@ -55,6 +61,7 @@ export class CommunityController {
   @Get()
   @RequiredActions(RbacActions.READ_ALL_COMMUNITIES)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiOkResponse({ type: [CommunityResponseDto] })
   findAll(): Promise<CommunityResponseDto[]> {
     return this.communityService.findAll();
   }
@@ -75,6 +82,7 @@ export class CommunityController {
     idKey: 'id',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: CommunityResponseDto })
   findOne(
     @Param('id', ParseObjectIdPipe) id: string,
   ): Promise<CommunityResponseDto> {
@@ -88,6 +96,7 @@ export class CommunityController {
     idKey: 'id',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: CommunityResponseDto })
   update(
     @Param('id', ParseObjectIdPipe) id: string,
     @Body() updateCommunityDto: UpdateCommunityDto,
@@ -117,6 +126,7 @@ export class CommunityController {
   @Get('admin/list')
   @RequiredActions(RbacActions.READ_ALL_COMMUNITIES)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiOkResponse({ type: CommunityStatsListResponseDto })
   findAllWithStats(
     @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,
     @Query('continuationToken') continuationToken?: string,
@@ -135,6 +145,7 @@ export class CommunityController {
   @Get('admin/:id')
   @RequiredActions(RbacActions.READ_ALL_COMMUNITIES)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiOkResponse({ type: CommunityStatsDetailDto })
   findOneWithStats(
     @Param('id', ParseObjectIdPipe) id: string,
   ): Promise<CommunityStatsDetailDto> {

--- a/backend/src/community/dto/update-community.dto.ts
+++ b/backend/src/community/dto/update-community.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreateCommunityDto } from './create-community.dto';
 
 export class UpdateCommunityDto extends PartialType(CreateCommunityDto) {}

--- a/backend/src/direct-messages/direct-messages.controller.ts
+++ b/backend/src/direct-messages/direct-messages.controller.ts
@@ -8,6 +8,7 @@ import {
   UseGuards,
   Req,
 } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
 import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
 import { RbacGuard } from '@/auth/rbac.guard';
 import { RequiredActions } from '@/auth/rbac-action.decorator';
@@ -73,6 +74,7 @@ export class DirectMessagesController {
     idKey: 'id',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: PaginatedMessagesResponseDto })
   async getDmMessages(
     @Param('id') id: string,
     @Req() req: { user: { id: string } },

--- a/backend/src/direct-messages/dto/dm-group-response.dto.ts
+++ b/backend/src/direct-messages/dto/dm-group-response.dto.ts
@@ -1,23 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SpanDto } from '@/messages/dto/message-response.dto';
+
+export class DmGroupMemberUserDto {
+  id: string;
+  username: string;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+}
+
+export class DmGroupMemberDto {
+  id: string;
+  userId: string;
+  joinedAt: Date;
+  user: DmGroupMemberUserDto;
+}
+
+export class DmGroupLastMessageDto {
+  id: string;
+  authorId: string;
+  @ApiProperty({ type: [SpanDto] })
+  spans: SpanDto[];
+  sentAt: Date;
+}
+
 export class DmGroupResponseDto {
   id: string;
   name?: string | null;
   isGroup: boolean;
   createdAt: Date;
-  members: {
-    id: string;
-    userId: string;
-    joinedAt: Date;
-    user: {
-      id: string;
-      username: string;
-      displayName?: string | null;
-      avatarUrl?: string | null;
-    };
-  }[];
-  lastMessage?: {
-    id: string;
-    authorId: string;
-    spans: any[];
-    sentAt: Date;
-  } | null;
+  @ApiProperty({ type: [DmGroupMemberDto] })
+  members: DmGroupMemberDto[];
+  @ApiProperty({ type: DmGroupLastMessageDto, nullable: true, required: false })
+  lastMessage?: DmGroupLastMessageDto | null;
 }

--- a/backend/src/file-upload/dto/create-file-upload.dto.ts
+++ b/backend/src/file-upload/dto/create-file-upload.dto.ts
@@ -1,7 +1,10 @@
 import { ResourceType } from '@prisma/client';
 import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { ResourceTypeValues } from '@/common/enums/swagger-enums';
 
 export class CreateFileUploadDto {
+  @ApiProperty({ enum: ResourceTypeValues })
   @IsEnum(ResourceType)
   resourceType: ResourceType;
 

--- a/backend/src/file-upload/dto/file-upload-response.dto.ts
+++ b/backend/src/file-upload/dto/file-upload-response.dto.ts
@@ -1,17 +1,26 @@
 import { FileType, StorageType, ResourceType } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  FileTypeValues,
+  ResourceTypeValues,
+  StorageTypeValues,
+} from '@/common/enums/swagger-enums';
 
 export class FileUploadResponseDto {
   id: string;
   filename: string;
   mimeType: string;
+  @ApiProperty({ enum: FileTypeValues })
   fileType: FileType;
   size: number;
   checksum: string;
   uploadedById: string | null;
   uploadedAt: Date;
   deletedAt: Date | null;
+  @ApiProperty({ enum: ResourceTypeValues })
   resourceType: ResourceType;
   resourceId: string | null;
+  @ApiProperty({ enum: StorageTypeValues })
   storageType: StorageType;
   storagePath: string;
 }

--- a/backend/src/file-upload/file-upload.controller.ts
+++ b/backend/src/file-upload/file-upload.controller.ts
@@ -12,6 +12,7 @@ import {
   UseGuards,
   Req,
 } from '@nestjs/common';
+import { ApiCreatedResponse, ApiOkResponse } from '@nestjs/swagger';
 import { FileUploadService } from './file-upload.service';
 import { CreateFileUploadDto } from './dto/create-file-upload.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
@@ -28,6 +29,7 @@ export class FileUploadController {
 
   @Post()
   @UseInterceptors(FileInterceptor('file'))
+  @ApiCreatedResponse({ type: FileUploadResponseDto })
   uploadFile(
     @UploadedFile(
       new ParseFilePipe({
@@ -49,6 +51,7 @@ export class FileUploadController {
   }
 
   @Delete(':id')
+  @ApiOkResponse({ type: FileUploadResponseDto })
   remove(
     @Param('id', ParseObjectIdPipe) id: string,
     @Req() req: AuthenticatedRequest,

--- a/backend/src/file/dto/file-metadata-response.dto.ts
+++ b/backend/src/file/dto/file-metadata-response.dto.ts
@@ -1,7 +1,12 @@
+import { FileType } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import { FileTypeValues } from '@/common/enums/swagger-enums';
+
 export class FileMetadataResponseDto {
   id: string;
   filename: string;
   mimeType: string;
-  fileType: string;
+  @ApiProperty({ enum: FileTypeValues })
+  fileType: FileType;
   size: number;
 }

--- a/backend/src/file/file.controller.ts
+++ b/backend/src/file/file.controller.ts
@@ -8,6 +8,7 @@ import {
   StreamableFile,
   UseGuards,
 } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
 import { Response } from 'express';
 import { FileService } from './file.service';
 import { StorageType } from '@prisma/client';
@@ -23,6 +24,7 @@ export class FileController {
 
   @Get(':id/metadata')
   @UseGuards(JwtAuthGuard, FileAccessGuard)
+  @ApiOkResponse({ type: FileMetadataResponseDto })
   async getFileMetadata(
     @Param('id', ParseObjectIdPipe) id: string,
   ): Promise<FileMetadataResponseDto> {

--- a/backend/src/friends/dto/friends-response.dto.ts
+++ b/backend/src/friends/dto/friends-response.dto.ts
@@ -1,10 +1,16 @@
 import { FriendshipStatus, InstanceRole } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  InstanceRoleValues,
+  FriendshipStatusValues,
+} from '@/common/enums/swagger-enums';
 
 export class FriendUserDto {
   id: string;
   username: string;
   email: string | null;
   verified: boolean;
+  @ApiProperty({ enum: InstanceRoleValues })
   role: InstanceRole;
   createdAt: Date;
   avatarUrl: string | null;
@@ -21,6 +27,7 @@ export class FriendshipDto {
   id: string;
   userAId: string;
   userBId: string;
+  @ApiProperty({ enum: FriendshipStatusValues })
   status: FriendshipStatus;
   createdAt: Date;
 }
@@ -29,6 +36,7 @@ export class FriendshipWithUsersDto {
   id: string;
   userAId: string;
   userBId: string;
+  @ApiProperty({ enum: FriendshipStatusValues })
   status: FriendshipStatus;
   createdAt: Date;
   userA: FriendUserDto;
@@ -41,7 +49,9 @@ export class PendingRequestsDto {
 }
 
 export class FriendshipStatusDto {
+  @ApiProperty({ enum: FriendshipStatusValues, nullable: true })
   status: FriendshipStatus | null;
   friendshipId: string | null;
+  @ApiProperty({ enum: ['sent', 'received'], nullable: true })
   direction: 'sent' | 'received' | null;
 }

--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -7,6 +7,7 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
+import { ApiOkResponse, ApiCreatedResponse } from '@nestjs/swagger';
 import { FriendsService } from './friends.service';
 import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
 import { AuthenticatedRequest } from '@/types';
@@ -16,6 +17,7 @@ import {
   PendingRequestsDto,
   FriendshipStatusDto,
 } from './dto/friends-response.dto';
+import { SuccessResponseDto } from '@/common/dto/common-response.dto';
 
 @Controller('friends')
 @UseGuards(JwtAuthGuard)
@@ -26,6 +28,7 @@ export class FriendsController {
    * Get all friends for the current user
    */
   @Get()
+  @ApiOkResponse({ type: [FriendUserDto] })
   async getFriends(@Req() req: AuthenticatedRequest): Promise<FriendUserDto[]> {
     return this.friendsService.getFriends(req.user.id);
   }
@@ -34,6 +37,7 @@ export class FriendsController {
    * Get pending friend requests (sent and received)
    */
   @Get('requests')
+  @ApiOkResponse({ type: PendingRequestsDto })
   async getPendingRequests(
     @Req() req: AuthenticatedRequest,
   ): Promise<PendingRequestsDto> {
@@ -44,6 +48,7 @@ export class FriendsController {
    * Get friendship status with a specific user
    */
   @Get('status/:userId')
+  @ApiOkResponse({ type: FriendshipStatusDto })
   async getFriendshipStatus(
     @Req() req: AuthenticatedRequest,
     @Param('userId') userId: string,
@@ -55,6 +60,7 @@ export class FriendsController {
    * Send a friend request to a user
    */
   @Post('request/:userId')
+  @ApiCreatedResponse({ type: FriendshipDto })
   async sendFriendRequest(
     @Req() req: AuthenticatedRequest,
     @Param('userId') userId: string,
@@ -66,6 +72,7 @@ export class FriendsController {
    * Accept a friend request
    */
   @Post('accept/:id')
+  @ApiCreatedResponse({ type: FriendshipDto })
   async acceptFriendRequest(
     @Req() req: AuthenticatedRequest,
     @Param('id') friendshipId: string,
@@ -77,6 +84,7 @@ export class FriendsController {
    * Decline a friend request
    */
   @Delete('decline/:id')
+  @ApiOkResponse({ type: SuccessResponseDto })
   async declineFriendRequest(
     @Req() req: AuthenticatedRequest,
     @Param('id') friendshipId: string,
@@ -89,6 +97,7 @@ export class FriendsController {
    * Cancel a sent friend request
    */
   @Delete('cancel/:id')
+  @ApiOkResponse({ type: SuccessResponseDto })
   async cancelFriendRequest(
     @Req() req: AuthenticatedRequest,
     @Param('id') friendshipId: string,
@@ -101,6 +110,7 @@ export class FriendsController {
    * Remove a friend (unfriend)
    */
   @Delete(':id')
+  @ApiOkResponse({ type: SuccessResponseDto })
   async removeFriend(
     @Req() req: AuthenticatedRequest,
     @Param('id') friendshipId: string,

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiTags, ApiOkResponse } from '@nestjs/swagger';
 import { Public } from '@/auth/public.decorator';
 import { HealthService } from './health.service';
 import { HealthResponseDto } from './dto/health-response.dto';
@@ -11,6 +11,7 @@ export class HealthController {
 
   @Get()
   @Public()
+  @ApiOkResponse({ type: HealthResponseDto })
   check(): HealthResponseDto {
     return this.healthService.getHealthMetadata();
   }

--- a/backend/src/instance/dto/instance-response.dto.ts
+++ b/backend/src/instance/dto/instance-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { RegistrationModeValues } from '@/common/enums/swagger-enums';
+
+export class PublicSettingsResponseDto {
+  @ApiProperty({ enum: RegistrationModeValues })
+  registrationMode: string;
+}
+
+export class InstanceStatsResponseDto {
+  totalUsers: number;
+  totalCommunities: number;
+  totalChannels: number;
+  totalMessages: number;
+  activeInvites: number;
+  bannedUsers: number;
+}

--- a/backend/src/instance/dto/instance-settings-response.dto.ts
+++ b/backend/src/instance/dto/instance-settings-response.dto.ts
@@ -1,5 +1,7 @@
 import { Transform } from 'class-transformer';
 import { RegistrationMode, InstanceSettings } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import { RegistrationModeValues } from '@/common/enums/swagger-enums';
 
 /**
  * Instance settings response DTO with BigInt converted to Number for JSON serialization
@@ -8,6 +10,7 @@ export class InstanceSettingsResponseDto implements InstanceSettings {
   id: string;
   name: string;
   description: string | null;
+  @ApiProperty({ enum: RegistrationModeValues })
   registrationMode: RegistrationMode;
   createdAt: Date;
   updatedAt: Date;

--- a/backend/src/instance/dto/update-instance-settings.dto.ts
+++ b/backend/src/instance/dto/update-instance-settings.dto.ts
@@ -8,6 +8,8 @@ import {
 } from 'class-validator';
 import { RegistrationMode } from '@prisma/client';
 import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { RegistrationModeValues } from '@/common/enums/swagger-enums';
 
 export class UpdateInstanceSettingsDto {
   @IsOptional()
@@ -20,6 +22,7 @@ export class UpdateInstanceSettingsDto {
   @MaxLength(500)
   description?: string;
 
+  @ApiProperty({ enum: RegistrationModeValues, required: false })
   @IsOptional()
   @IsEnum(RegistrationMode)
   registrationMode?: RegistrationMode;

--- a/backend/src/instance/instance.controller.ts
+++ b/backend/src/instance/instance.controller.ts
@@ -7,6 +7,7 @@ import {
   UseInterceptors,
   ClassSerializerInterceptor,
 } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
 import { InstanceService } from './instance.service';
 import { RbacActions } from '@prisma/client';
 import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
@@ -15,6 +16,10 @@ import { RequiredActions } from '@/auth/rbac-action.decorator';
 import { RbacResource, RbacResourceType } from '@/auth/rbac-resource.decorator';
 import { UpdateInstanceSettingsDto } from './dto/update-instance-settings.dto';
 import { InstanceSettingsResponseDto } from './dto/instance-settings-response.dto';
+import {
+  PublicSettingsResponseDto,
+  InstanceStatsResponseDto,
+} from './dto/instance-response.dto';
 
 @Controller('instance')
 @UseInterceptors(ClassSerializerInterceptor)
@@ -25,7 +30,8 @@ export class InstanceController {
    * Get instance settings (public - needed for registration mode)
    */
   @Get('settings/public')
-  async getPublicSettings(): Promise<{ registrationMode: string }> {
+  @ApiOkResponse({ type: PublicSettingsResponseDto })
+  async getPublicSettings(): Promise<PublicSettingsResponseDto> {
     const settings = await this.instanceService.getSettings();
     return { registrationMode: settings.registrationMode };
   }
@@ -37,6 +43,7 @@ export class InstanceController {
   @UseGuards(JwtAuthGuard, RbacGuard)
   @RequiredActions(RbacActions.READ_INSTANCE_SETTINGS)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiOkResponse({ type: InstanceSettingsResponseDto })
   async getSettings(): Promise<InstanceSettingsResponseDto> {
     const settings = await this.instanceService.getSettings();
     return new InstanceSettingsResponseDto(settings);
@@ -49,6 +56,7 @@ export class InstanceController {
   @UseGuards(JwtAuthGuard, RbacGuard)
   @RequiredActions(RbacActions.UPDATE_INSTANCE_SETTINGS)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiOkResponse({ type: InstanceSettingsResponseDto })
   async updateSettings(
     @Body() dto: UpdateInstanceSettingsDto,
   ): Promise<InstanceSettingsResponseDto> {
@@ -63,14 +71,8 @@ export class InstanceController {
   @UseGuards(JwtAuthGuard, RbacGuard)
   @RequiredActions(RbacActions.READ_INSTANCE_STATS)
   @RbacResource({ type: RbacResourceType.INSTANCE })
-  async getStats(): Promise<{
-    totalUsers: number;
-    totalCommunities: number;
-    totalChannels: number;
-    totalMessages: number;
-    activeInvites: number;
-    bannedUsers: number;
-  }> {
+  @ApiOkResponse({ type: InstanceStatsResponseDto })
+  async getStats(): Promise<InstanceStatsResponseDto> {
     return this.instanceService.getStats();
   }
 }

--- a/backend/src/invite/invite.controller.ts
+++ b/backend/src/invite/invite.controller.ts
@@ -8,6 +8,7 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
+import { ApiOkResponse, ApiCreatedResponse } from '@nestjs/swagger';
 import { InviteService } from './invite.service';
 import { RbacActions } from '@prisma/client';
 import { CreateInviteDto } from './dto/create-invite.dto';
@@ -26,6 +27,7 @@ export class InviteController {
   @UseGuards(JwtAuthGuard, RbacGuard)
   @RequiredActions(RbacActions.CREATE_INSTANCE_INVITE)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiCreatedResponse({ type: InviteResponseDto })
   async createInvite(
     @Req() req: AuthenticatedRequest,
     @Body() dto: CreateInviteDto,
@@ -42,6 +44,7 @@ export class InviteController {
   @UseGuards(JwtAuthGuard, RbacGuard)
   @RequiredActions(RbacActions.READ_INSTANCE_INVITE)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiOkResponse({ type: [InviteResponseDto] })
   async getInvites(
     @Req() req: AuthenticatedRequest,
   ): Promise<InviteResponseDto[]> {
@@ -49,6 +52,7 @@ export class InviteController {
   }
 
   @Get('public/:code')
+  @ApiOkResponse({ type: InviteResponseDto })
   async getPublicInvite(
     @Param('code') code: string,
   ): Promise<InviteResponseDto | null> {
@@ -59,6 +63,7 @@ export class InviteController {
   @UseGuards(JwtAuthGuard, RbacGuard)
   @RequiredActions(RbacActions.READ_INSTANCE_INVITE)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiOkResponse({ type: InviteResponseDto })
   async getInvite(@Param('code') code: string): Promise<InviteResponseDto | null> {
     return this.inviteService.getInviteByCode(code);
   }

--- a/backend/src/livekit/dto/capture-replay.dto.ts
+++ b/backend/src/livekit/dto/capture-replay.dto.ts
@@ -8,6 +8,7 @@ import {
   Max,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
 
 /**
  * DTO for streaming a replay clip (download-only, no persistence)
@@ -17,6 +18,7 @@ export class StreamReplayDto {
    * Duration preset in minutes
    * User selects from: 1, 2, 5, or 10 minutes
    */
+  @ApiProperty({ enum: [1, 2, 5, 10] })
   @Type(() => Number)
   @IsInt()
   @Min(1)
@@ -35,6 +37,7 @@ export class CaptureReplayDto {
    * Duration preset in minutes (optional if using custom range)
    * User selects from: 1, 2, 5, or 10 minutes
    */
+  @ApiProperty({ enum: [1, 2, 5, 10], required: false })
   @IsOptional()
   @ValidateIf((o: CaptureReplayDto) => !o.startSeconds && !o.endSeconds)
   @IsEnum([1, 2, 5, 10], {
@@ -70,6 +73,7 @@ export class CaptureReplayDto {
    * - 'dm': Save to library and send to specified DM group
    * - 'channel': Save to library and post to specified channel
    */
+  @ApiProperty({ enum: ['library', 'dm', 'channel'] })
   @IsEnum(['library', 'dm', 'channel'], {
     message: 'Destination must be library, dm, or channel',
   })

--- a/backend/src/livekit/dto/clip-library.dto.ts
+++ b/backend/src/livekit/dto/clip-library.dto.ts
@@ -5,6 +5,7 @@ import {
   IsOptional,
   ValidateIf,
 } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 /**
  * DTO for updating a replay clip (e.g., toggling public visibility)
@@ -27,6 +28,7 @@ export class ShareClipDto {
    * - 'channel': Post to specified channel
    * - 'dm': Send to specified DM group
    */
+  @ApiProperty({ enum: ['channel', 'dm'] })
   @IsEnum(['channel', 'dm'], {
     message: 'Destination must be channel or dm',
   })
@@ -70,5 +72,6 @@ export class ClipResponseDto {
 export class ShareClipResponseDto {
   messageId: string;
   clipId: string;
+  @ApiProperty({ enum: ['channel', 'dm'] })
   destination: 'channel' | 'dm';
 }

--- a/backend/src/livekit/livekit.controller.ts
+++ b/backend/src/livekit/livekit.controller.ts
@@ -12,6 +12,7 @@ import {
   Param,
   Logger,
 } from '@nestjs/common';
+import { ApiOkResponse, ApiCreatedResponse } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { Response } from 'express';
 import { LivekitService } from './livekit.service';
@@ -39,6 +40,7 @@ import {
   StopReplayResponseDto,
 } from './dto/livekit-response.dto';
 import { StorageService } from '@/storage/storage.service';
+import { SuccessResponseDto } from '@/common/dto/common-response.dto';
 import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
 import { RbacGuard } from '@/auth/rbac.guard';
 import { RequiredActions } from '@/auth/rbac-action.decorator';
@@ -69,6 +71,7 @@ export class LivekitController {
     idKey: 'roomId',
     source: ResourceIdSource.BODY,
   })
+  @ApiCreatedResponse({ type: TokenResponseDto })
   async generateToken(
     @Body() createTokenDto: CreateTokenDto,
     @Req() req: AuthenticatedRequest,
@@ -88,6 +91,7 @@ export class LivekitController {
     idKey: 'roomId',
     source: ResourceIdSource.BODY,
   })
+  @ApiCreatedResponse({ type: TokenResponseDto })
   async generateDmToken(
     @Body() createTokenDto: CreateTokenDto,
     @Req() req: AuthenticatedRequest,
@@ -101,11 +105,13 @@ export class LivekitController {
   }
 
   @Get('connection-info')
+  @ApiOkResponse({ type: ConnectionInfoResponseDto })
   getConnectionInfo(): ConnectionInfoResponseDto {
     return this.livekitService.getConnectionInfo();
   }
 
   @Get('health')
+  @ApiOkResponse({ type: LivekitHealthResponseDto })
   validateConfiguration(): LivekitHealthResponseDto {
     const isValid = this.livekitService.validateConfiguration();
     return {
@@ -124,6 +130,7 @@ export class LivekitController {
     idKey: 'channelId',
     source: ResourceIdSource.BODY,
   })
+  @ApiCreatedResponse({ type: StartReplayResponseDto })
   async startReplayBuffer(
     @Body() dto: StartReplayBufferDto,
     @Req() req: AuthenticatedRequest,
@@ -142,6 +149,7 @@ export class LivekitController {
    * Stop replay buffer egress for current user
    */
   @Post('replay/stop')
+  @ApiCreatedResponse({ type: StopReplayResponseDto })
   async stopReplayBuffer(
     @Req() req: AuthenticatedRequest,
   ): Promise<StopReplayResponseDto> {
@@ -217,6 +225,7 @@ export class LivekitController {
    * Get session info for active replay buffer (for trim UI)
    */
   @Get('replay/session-info')
+  @ApiOkResponse({ type: SessionInfoResponseDto })
   async getSessionInfo(
     @Req() req: AuthenticatedRequest,
   ): Promise<SessionInfoResponseDto> {
@@ -283,6 +292,7 @@ export class LivekitController {
   @RbacResource({
     type: RbacResourceType.INSTANCE,
   })
+  @ApiCreatedResponse({ type: CaptureReplayResponseDto })
   async captureReplay(
     @Body() dto: CaptureReplayDto,
     @Req() req: AuthenticatedRequest,
@@ -294,6 +304,7 @@ export class LivekitController {
    * Get current user's clip library
    */
   @Get('clips')
+  @ApiOkResponse({ type: [ClipResponseDto] })
   async getMyClips(
     @Req() req: AuthenticatedRequest,
   ): Promise<ClipResponseDto[]> {
@@ -304,6 +315,7 @@ export class LivekitController {
    * Get public clips for a specific user (for profile viewing)
    */
   @Get('clips/user/:userId')
+  @ApiOkResponse({ type: [ClipResponseDto] })
   async getUserPublicClips(
     @Param('userId') userId: string,
   ): Promise<ClipResponseDto[]> {
@@ -314,6 +326,7 @@ export class LivekitController {
    * Update a clip (e.g., toggle public visibility)
    */
   @Put('clips/:clipId')
+  @ApiOkResponse({ type: ClipResponseDto })
   async updateClip(
     @Param('clipId') clipId: string,
     @Body() dto: UpdateClipDto,
@@ -326,6 +339,7 @@ export class LivekitController {
    * Delete a clip from user's library
    */
   @Delete('clips/:clipId')
+  @ApiOkResponse({ type: SuccessResponseDto })
   async deleteClip(
     @Param('clipId') clipId: string,
     @Req() req: AuthenticatedRequest,
@@ -338,6 +352,7 @@ export class LivekitController {
    * Share an existing clip to a channel or DM
    */
   @Post('clips/:clipId/share')
+  @ApiCreatedResponse({ type: ShareClipResponseDto })
   async shareClip(
     @Param('clipId') clipId: string,
     @Body() dto: ShareClipDto,

--- a/backend/src/messages/dto/create-message.dto.ts
+++ b/backend/src/messages/dto/create-message.dto.ts
@@ -1,7 +1,19 @@
 import { $Enums, Message } from '@prisma/client';
 import { Exclude } from 'class-transformer';
 import { IsString, IsOptional, IsArray, IsInt, Min } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { SpanTypeValues } from '@/common/enums/swagger-enums';
 import { ArrayMinLength } from '../../decorators/array-min-length.decorator';
+
+class CreateMessageSpanDto {
+  @ApiProperty({ enum: SpanTypeValues })
+  type: $Enums.SpanType;
+  text: string | null;
+  userId: string | null;
+  specialKind: string | null;
+  communityId: string | null;
+  aliasId: string | null;
+}
 
 export class CreateMessageDto implements Message {
   @Exclude()
@@ -24,16 +36,10 @@ export class CreateMessageDto implements Message {
   @Exclude()
   deletedAt: Date | null;
 
+  @ApiProperty({ type: [CreateMessageSpanDto] })
   @IsArray()
   @ArrayMinLength(1, { message: 'At least one span is required' })
-  spans: {
-    type: $Enums.SpanType;
-    text: string | null;
-    userId: string | null;
-    specialKind: string | null;
-    communityId: string | null;
-    aliasId: string | null;
-  }[];
+  spans: CreateMessageSpanDto[];
 
   @IsArray()
   attachments: string[];

--- a/backend/src/messages/dto/message-response.dto.ts
+++ b/backend/src/messages/dto/message-response.dto.ts
@@ -1,6 +1,12 @@
 import { FileType, SpanType } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  SpanTypeValues,
+  FileTypeValues,
+} from '@/common/enums/swagger-enums';
 
 export class SpanDto {
+  @ApiProperty({ enum: SpanTypeValues })
   type: SpanType;
   text: string | null;
   userId: string | null;
@@ -18,6 +24,7 @@ export class EnrichedAttachment {
   id: string;
   filename: string;
   mimeType: string;
+  @ApiProperty({ enum: FileTypeValues })
   fileType: FileType;
   size: number;
 }

--- a/backend/src/messages/dto/update-message.dto.ts
+++ b/backend/src/messages/dto/update-message.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreateMessageDto } from './create-message.dto';
 
 export class UpdateMessageDto extends PartialType(CreateMessageDto) {}

--- a/backend/src/messages/messages.controller.ts
+++ b/backend/src/messages/messages.controller.ts
@@ -13,6 +13,7 @@ import {
   DefaultValuePipe,
   ParseIntPipe,
 } from '@nestjs/common';
+import { ApiOkResponse, ApiCreatedResponse } from '@nestjs/swagger';
 import { MessagesService } from './messages.service';
 import { ReactionsService } from './reactions.service';
 import { CreateMessageDto } from './dto/create-message.dto';
@@ -51,6 +52,7 @@ export class MessagesController {
 
   @Post()
   @HttpCode(201)
+  @ApiCreatedResponse({ type: EnrichedMessageDto })
   @RequiredActions(RbacActions.CREATE_MESSAGE)
   @RbacResource({
     type: RbacResourceType.CHANNEL,
@@ -71,6 +73,7 @@ export class MessagesController {
   }
 
   @Get('/group/:groupId')
+  @ApiOkResponse({ type: PaginatedMessagesResponseDto })
   @RequiredActions(RbacActions.READ_MESSAGE)
   @RbacResource({
     type: RbacResourceType.DM_GROUP,
@@ -90,6 +93,7 @@ export class MessagesController {
   }
 
   @Get('/channel/:channelId')
+  @ApiOkResponse({ type: PaginatedMessagesResponseDto })
   @RequiredActions(RbacActions.READ_MESSAGE)
   @RbacResource({
     type: RbacResourceType.CHANNEL,
@@ -109,6 +113,7 @@ export class MessagesController {
   }
 
   @Get('search/channel/:channelId')
+  @ApiOkResponse({ type: [EnrichedMessageDto] })
   @RequiredActions(RbacActions.READ_MESSAGE)
   @RbacResource({
     type: RbacResourceType.CHANNEL,
@@ -124,6 +129,7 @@ export class MessagesController {
   }
 
   @Get('search/group/:groupId')
+  @ApiOkResponse({ type: [EnrichedMessageDto] })
   @RequiredActions(RbacActions.READ_MESSAGE)
   @RbacResource({
     type: RbacResourceType.DM_GROUP,
@@ -139,6 +145,7 @@ export class MessagesController {
   }
 
   @Get('search/community/:communityId')
+  @ApiOkResponse({ type: [EnrichedMessageDto] })
   @RequiredActions(RbacActions.READ_MESSAGE)
   @RbacResource({
     type: RbacResourceType.COMMUNITY,
@@ -160,6 +167,7 @@ export class MessagesController {
   }
 
   @Post('reactions')
+  @ApiCreatedResponse({ type: MessageDto })
   @RequiredActions(RbacActions.CREATE_REACTION)
   @RbacResource({
     type: RbacResourceType.MESSAGE,
@@ -194,6 +202,7 @@ export class MessagesController {
   }
 
   @Delete('reactions')
+  @ApiOkResponse({ type: MessageDto })
   @RequiredActions(RbacActions.DELETE_REACTION)
   @RbacResource({
     type: RbacResourceType.MESSAGE,
@@ -228,6 +237,7 @@ export class MessagesController {
   }
 
   @Post(':id/attachments')
+  @ApiCreatedResponse({ type: EnrichedMessageDto })
   @UseGuards(JwtAuthGuard, MessageOwnershipGuard)
   async addAttachment(
     @Param('id', ParseObjectIdPipe) id: string,
@@ -260,6 +270,7 @@ export class MessagesController {
   }
 
   @Get(':id')
+  @ApiOkResponse({ type: EnrichedMessageDto })
   @RequiredActions(RbacActions.READ_MESSAGE)
   @RbacResource({
     type: RbacResourceType.CHANNEL,
@@ -275,6 +286,7 @@ export class MessagesController {
   }
 
   @Patch(':id')
+  @ApiOkResponse({ type: EnrichedMessageDto })
   @UseGuards(JwtAuthGuard, MessageOwnershipGuard)
   async update(
     @Param('id', ParseObjectIdPipe) id: string,

--- a/backend/src/moderation/dto/moderation-response.dto.ts
+++ b/backend/src/moderation/dto/moderation-response.dto.ts
@@ -1,5 +1,12 @@
 import { FileType, ModerationAction, Prisma } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  FileTypeValues,
+  ModerationActionValues,
+} from '@/common/enums/swagger-enums';
 import { SpanDto, ReactionDto } from '@/messages/dto/message-response.dto';
+
+export { SuccessMessageDto } from '@/common/dto/common-response.dto';
 
 export class PinnedMessageAuthorDto {
   id: string;
@@ -12,6 +19,7 @@ export class PinnedMessageAttachmentDto {
   id: string;
   filename: string;
   mimeType: string;
+  @ApiProperty({ enum: FileTypeValues })
   fileType: FileType;
   size: number;
 }
@@ -66,8 +74,10 @@ export class ModerationLogDto {
   communityId: string;
   moderatorId: string;
   targetUserId: string | null;
+  @ApiProperty({ enum: ModerationActionValues })
   action: ModerationAction;
   reason: string | null;
+  @ApiProperty({ type: 'object', nullable: true, additionalProperties: true })
   metadata: Prisma.JsonValue | null;
   createdAt: Date;
 }
@@ -82,7 +92,3 @@ export class ModerationLogsResponseDto {
   total: number;
 }
 
-export class SuccessMessageDto {
-  success: boolean;
-  message: string;
-}

--- a/backend/src/moderation/moderation.controller.ts
+++ b/backend/src/moderation/moderation.controller.ts
@@ -12,6 +12,7 @@ import {
   DefaultValuePipe,
   ParseIntPipe,
 } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
 import { ModerationService } from './moderation.service';
 import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
 import { RbacGuard } from '@/auth/rbac.guard';
@@ -61,6 +62,7 @@ export class ModerationController {
     source: ResourceIdSource.PARAM,
   })
   @HttpCode(200)
+  @ApiOkResponse({ type: SuccessMessageDto })
   async banUser(
     @Param('communityId', ParseObjectIdPipe) communityId: string,
     @Param('userId', ParseObjectIdPipe) userId: string,
@@ -86,6 +88,7 @@ export class ModerationController {
     idKey: 'communityId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: SuccessMessageDto })
   async unbanUser(
     @Param('communityId', ParseObjectIdPipe) communityId: string,
     @Param('userId', ParseObjectIdPipe) userId: string,
@@ -109,6 +112,7 @@ export class ModerationController {
     idKey: 'communityId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: [CommunityBanDto] })
   async getBanList(
     @Param('communityId', ParseObjectIdPipe) communityId: string,
   ): Promise<CommunityBanDto[]> {
@@ -128,6 +132,7 @@ export class ModerationController {
     source: ResourceIdSource.PARAM,
   })
   @HttpCode(200)
+  @ApiOkResponse({ type: SuccessMessageDto })
   async kickUser(
     @Param('communityId', ParseObjectIdPipe) communityId: string,
     @Param('userId', ParseObjectIdPipe) userId: string,
@@ -156,6 +161,7 @@ export class ModerationController {
     source: ResourceIdSource.PARAM,
   })
   @HttpCode(200)
+  @ApiOkResponse({ type: SuccessMessageDto })
   async timeoutUser(
     @Param('communityId', ParseObjectIdPipe) communityId: string,
     @Param('userId', ParseObjectIdPipe) userId: string,
@@ -180,6 +186,7 @@ export class ModerationController {
     idKey: 'communityId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: SuccessMessageDto })
   async removeTimeout(
     @Param('communityId', ParseObjectIdPipe) communityId: string,
     @Param('userId', ParseObjectIdPipe) userId: string,
@@ -203,6 +210,7 @@ export class ModerationController {
     idKey: 'communityId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: [CommunityTimeoutDto] })
   async getTimeoutList(
     @Param('communityId', ParseObjectIdPipe) communityId: string,
   ): Promise<CommunityTimeoutDto[]> {
@@ -217,6 +225,7 @@ export class ModerationController {
     idKey: 'communityId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: TimeoutStatusResponseDto })
   async getTimeoutStatus(
     @Param('communityId', ParseObjectIdPipe) communityId: string,
     @Param('userId', ParseObjectIdPipe) userId: string,
@@ -237,6 +246,7 @@ export class ModerationController {
     source: ResourceIdSource.PARAM,
   })
   @HttpCode(200)
+  @ApiOkResponse({ type: SuccessMessageDto })
   async pinMessage(
     @Param('messageId', ParseObjectIdPipe) messageId: string,
     @Body() dto: PinMessageDto,
@@ -254,6 +264,7 @@ export class ModerationController {
     idKey: 'messageId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: SuccessMessageDto })
   async unpinMessage(
     @Param('messageId', ParseObjectIdPipe) messageId: string,
     @Body() dto: UnpinMessageDto,
@@ -275,6 +286,7 @@ export class ModerationController {
     idKey: 'channelId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: [PinnedMessageDto] })
   async getPinnedMessages(
     @Param('channelId', ParseObjectIdPipe) channelId: string,
   ): Promise<PinnedMessageDto[]> {
@@ -293,6 +305,7 @@ export class ModerationController {
     idKey: 'messageId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: SuccessMessageDto })
   async deleteMessageAsMod(
     @Param('messageId', ParseObjectIdPipe) messageId: string,
     @Body() dto: DeleteMessageAsModDto,
@@ -318,6 +331,7 @@ export class ModerationController {
     idKey: 'communityId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: ModerationLogsResponseDto })
   async getModerationLogs(
     @Param('communityId', ParseObjectIdPipe) communityId: string,
     @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,

--- a/backend/src/notifications/dto/create-notification.dto.ts
+++ b/backend/src/notifications/dto/create-notification.dto.ts
@@ -1,11 +1,14 @@
 import { IsEnum, IsNotEmpty, IsOptional } from 'class-validator';
 import { NotificationType } from '@prisma/client';
 import { IsObjectId } from 'nestjs-object-id';
+import { ApiProperty } from '@nestjs/swagger';
+import { NotificationTypeValues } from '@/common/enums/swagger-enums';
 
 export class CreateNotificationDto {
   @IsObjectId()
   userId: string;
 
+  @ApiProperty({ enum: NotificationTypeValues })
   @IsNotEmpty()
   @IsEnum(NotificationType)
   type: NotificationType;

--- a/backend/src/notifications/dto/debug-notification.dto.ts
+++ b/backend/src/notifications/dto/debug-notification.dto.ts
@@ -1,11 +1,14 @@
 import { IsEnum, IsOptional, IsString } from 'class-validator';
 import { NotificationType } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import { NotificationTypeValues } from '@/common/enums/swagger-enums';
 
 /**
  * DTO for sending test notifications (debug only)
  * Used by admin users to test notification delivery
  */
 export class SendTestNotificationDto {
+  @ApiProperty({ enum: NotificationTypeValues })
   @IsEnum(NotificationType)
   type: NotificationType;
 

--- a/backend/src/notifications/dto/notification-response.dto.ts
+++ b/backend/src/notifications/dto/notification-response.dto.ts
@@ -1,4 +1,6 @@
 import { NotificationType } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import { NotificationTypeValues } from '@/common/enums/swagger-enums';
 
 export class UserNotificationSettingsDto {
   id: string;
@@ -39,6 +41,7 @@ export class NotificationMessageDto {
 export class NotificationDto {
   id: string;
   userId: string;
+  @ApiProperty({ enum: NotificationTypeValues })
   type: NotificationType;
   messageId: string | null;
   channelId: string | null;
@@ -68,8 +71,14 @@ export class DebugNotificationResponseDto {
   message: string;
 }
 
+export class DebugPushSubscriptionDto {
+  endpoint: string;
+  createdAt: Date;
+}
+
 export class DebugSubscriptionsResponseDto {
-  subscriptions: any[];
+  @ApiProperty({ type: [DebugPushSubscriptionDto] })
+  subscriptions: DebugPushSubscriptionDto[];
   count: number;
   pushEnabled: boolean;
 }

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -12,6 +12,7 @@ import {
   HttpCode,
   ForbiddenException,
 } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
 import { NotificationsService } from './notifications.service';
 import { UpdateNotificationSettingsDto } from './dto/update-notification-settings.dto';
 import { UpdateChannelOverrideDto } from './dto/update-channel-override.dto';
@@ -46,6 +47,7 @@ export class NotificationsController {
    * GET /notifications?unreadOnly=true&limit=50&offset=0
    */
   @Get()
+  @ApiOkResponse({ type: NotificationListResponseDto })
   async getNotifications(
     @Req() req: AuthenticatedRequest,
     @Query() query: NotificationQueryDto,
@@ -71,6 +73,7 @@ export class NotificationsController {
    * GET /notifications/unread-count
    */
   @Get('unread-count')
+  @ApiOkResponse({ type: UnreadCountResponseDto })
   async getUnreadCount(
     @Req() req: AuthenticatedRequest,
   ): Promise<UnreadCountResponseDto> {
@@ -84,6 +87,7 @@ export class NotificationsController {
    */
   @Post(':id/read')
   @HttpCode(200)
+  @ApiOkResponse({ type: NotificationDto })
   async markAsRead(
     @Req() req: AuthenticatedRequest,
     @Param('id', ParseObjectIdPipe) notificationId: string,
@@ -97,6 +101,7 @@ export class NotificationsController {
    */
   @Post('read-all')
   @HttpCode(200)
+  @ApiOkResponse({ type: UnreadCountResponseDto })
   async markAllAsRead(
     @Req() req: AuthenticatedRequest,
   ): Promise<{ count: number }> {
@@ -109,6 +114,7 @@ export class NotificationsController {
    */
   @Post(':id/dismiss')
   @HttpCode(200)
+  @ApiOkResponse({ type: NotificationDto })
   async dismissNotification(
     @Req() req: AuthenticatedRequest,
     @Param('id', ParseObjectIdPipe) notificationId: string,
@@ -140,6 +146,7 @@ export class NotificationsController {
    * GET /notifications/settings
    */
   @Get('settings')
+  @ApiOkResponse({ type: UserNotificationSettingsDto })
   async getSettings(
     @Req() req: AuthenticatedRequest,
   ): Promise<UserNotificationSettingsDto> {
@@ -151,6 +158,7 @@ export class NotificationsController {
    * PUT /notifications/settings
    */
   @Put('settings')
+  @ApiOkResponse({ type: UserNotificationSettingsDto })
   async updateSettings(
     @Req() req: AuthenticatedRequest,
     @Body() dto: UpdateNotificationSettingsDto,
@@ -163,6 +171,7 @@ export class NotificationsController {
    * GET /notifications/channels/:channelId/override
    */
   @Get('channels/:channelId/override')
+  @ApiOkResponse({ type: ChannelNotificationOverrideDto })
   async getChannelOverride(
     @Req() req: AuthenticatedRequest,
     @Param('channelId', ParseObjectIdPipe) channelId: string,
@@ -175,6 +184,7 @@ export class NotificationsController {
    * PUT /notifications/channels/:channelId/override
    */
   @Put('channels/:channelId/override')
+  @ApiOkResponse({ type: ChannelNotificationOverrideDto })
   async setChannelOverride(
     @Req() req: AuthenticatedRequest,
     @Param('channelId', ParseObjectIdPipe) channelId: string,
@@ -223,6 +233,7 @@ export class NotificationsController {
    */
   @Post('debug/send-test')
   @HttpCode(200)
+  @ApiOkResponse({ type: DebugNotificationResponseDto })
   async sendTestNotification(
     @Req() req: AuthenticatedRequest,
     @Body() dto: SendTestNotificationDto,
@@ -245,6 +256,7 @@ export class NotificationsController {
    * Only available to OWNER users
    */
   @Get('debug/subscriptions')
+  @ApiOkResponse({ type: DebugSubscriptionsResponseDto })
   async getDebugSubscriptions(
     @Req() req: AuthenticatedRequest,
   ): Promise<DebugSubscriptionsResponseDto> {
@@ -265,6 +277,7 @@ export class NotificationsController {
    */
   @Delete('debug/clear-all')
   @HttpCode(200)
+  @ApiOkResponse({ type: ClearNotificationDataResponseDto })
   async clearDebugSettings(
     @Req() req: AuthenticatedRequest,
   ): Promise<ClearNotificationDataResponseDto> {

--- a/backend/src/onboarding/onboarding.controller.ts
+++ b/backend/src/onboarding/onboarding.controller.ts
@@ -7,6 +7,7 @@ import {
   HttpStatus,
   BadRequestException,
 } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
 import { OnboardingService } from './onboarding.service';
 import {
   SetupInstanceDto,
@@ -22,6 +23,7 @@ export class OnboardingController {
 
   @Get('status')
   @Public()
+  @ApiOkResponse({ type: OnboardingStatusDto })
   async getStatus(): Promise<OnboardingStatusDto> {
     return this.onboardingService.getStatus();
   }
@@ -30,6 +32,7 @@ export class OnboardingController {
   @Public()
   @HttpCode(HttpStatus.OK)
   @Throttle({ short: { limit: 2, ttl: 1000 }, long: { limit: 5, ttl: 60000 } })
+  @ApiOkResponse({ type: SetupResponseDto })
   async setupInstance(
     @Body() dto: SetupInstanceDto,
   ): Promise<SetupResponseDto> {

--- a/backend/src/push-notifications/dto/push-notifications-response.dto.ts
+++ b/backend/src/push-notifications/dto/push-notifications-response.dto.ts
@@ -1,0 +1,16 @@
+export class VapidPublicKeyResponseDto {
+  publicKey: string | null;
+  enabled: boolean;
+}
+
+export class PushStatusResponseDto {
+  enabled: boolean;
+  subscriptionCount: number;
+}
+
+export class TestPushResponseDto {
+  success: boolean;
+  sent: number;
+  failed: number;
+  message: string;
+}

--- a/backend/src/read-receipts/read-receipts.controller.ts
+++ b/backend/src/read-receipts/read-receipts.controller.ts
@@ -9,6 +9,7 @@ import {
   HttpCode,
   Param,
 } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
 import { ReadReceiptsService } from './read-receipts.service';
 import { MarkAsReadDto } from './dto/mark-as-read.dto';
 import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
@@ -31,6 +32,7 @@ export class ReadReceiptsController {
    */
   @Post('mark-read')
   @HttpCode(200)
+  @ApiOkResponse({ type: ReadReceiptDto })
   async markAsRead(
     @Req() req: AuthenticatedRequest,
     @Body() markAsReadDto: MarkAsReadDto,
@@ -43,6 +45,7 @@ export class ReadReceiptsController {
    * GET /read-receipts/unread-counts
    */
   @Get('unread-counts')
+  @ApiOkResponse({ type: [UnreadCountDto] })
   async getUnreadCounts(
     @Req() req: AuthenticatedRequest,
   ): Promise<UnreadCountDto[]> {
@@ -54,6 +57,7 @@ export class ReadReceiptsController {
    * GET /read-receipts/unread-count?channelId=xxx or ?directMessageGroupId=xxx
    */
   @Get('unread-count')
+  @ApiOkResponse({ type: UnreadCountDto })
   async getUnreadCount(
     @Req() req: AuthenticatedRequest,
     @Query('channelId', ParseObjectIdPipe) channelId?: string,
@@ -72,6 +76,7 @@ export class ReadReceiptsController {
    * GET /read-receipts/last-read?channelId=xxx or ?directMessageGroupId=xxx
    */
   @Get('last-read')
+  @ApiOkResponse({ type: LastReadResponseDto })
   async getLastReadMessageId(
     @Req() req: AuthenticatedRequest,
     @Query('channelId', ParseObjectIdPipe) channelId?: string,

--- a/backend/src/roles/dto/create-role.dto.ts
+++ b/backend/src/roles/dto/create-role.dto.ts
@@ -1,11 +1,14 @@
 import { IsString, IsArray, ArrayMinSize, MaxLength } from 'class-validator';
 import { RbacActions } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import { RbacActionsValues } from '@/common/enums/swagger-enums';
 
 export class CreateRoleDto {
   @IsString()
   @MaxLength(50, { message: 'Role name must not exceed 50 characters' })
   name: string;
 
+  @ApiProperty({ enum: RbacActionsValues, isArray: true })
   @IsArray()
   @ArrayMinSize(1, { message: 'Role must have at least one permission' })
   actions: RbacActions[];

--- a/backend/src/roles/dto/update-role.dto.ts
+++ b/backend/src/roles/dto/update-role.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreateRoleDto } from './create-role.dto';
 
 export class UpdateRoleDto extends PartialType(CreateRoleDto) {}

--- a/backend/src/roles/dto/user-roles-response.dto.ts
+++ b/backend/src/roles/dto/user-roles-response.dto.ts
@@ -1,8 +1,11 @@
 import { RbacActions } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import { RbacActionsValues } from '@/common/enums/swagger-enums';
 
 export class RoleDto {
   id: string;
   name: string;
+  @ApiProperty({ enum: RbacActionsValues, isArray: true })
   actions: RbacActions[];
   createdAt: Date;
   isDefault: boolean;
@@ -11,6 +14,7 @@ export class RoleDto {
 export class UserRolesResponseDto {
   userId: string;
   resourceId: string | null;
+  @ApiProperty({ enum: ['COMMUNITY', 'CHANNEL', 'INSTANCE'], nullable: true })
   resourceType: 'COMMUNITY' | 'CHANNEL' | 'INSTANCE' | null;
   roles: RoleDto[];
 }

--- a/backend/src/roles/roles.controller.ts
+++ b/backend/src/roles/roles.controller.ts
@@ -10,6 +10,7 @@ import {
   UseGuards,
   HttpCode,
 } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
 import { RolesService } from './roles.service';
 import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
 import { RbacGuard } from '@/auth/rbac.guard';
@@ -206,6 +207,7 @@ export class RolesController {
   }
 
   @Get('community/:communityId/:roleId/users')
+  @ApiOkResponse({ type: [RoleUserDto] })
   @UseGuards(RbacGuard)
   @RequiredActions(RbacActions.READ_ROLE)
   @RbacResource({
@@ -310,6 +312,7 @@ export class RolesController {
    * Get users assigned to an instance role
    */
   @Get('instance/:roleId/users')
+  @ApiOkResponse({ type: [RoleUserDto] })
   @UseGuards(RbacGuard)
   @RequiredActions(RbacActions.READ_USER)
   @RbacResource({ type: RbacResourceType.INSTANCE })

--- a/backend/src/storage-quota/dto/storage-stats.dto.ts
+++ b/backend/src/storage-quota/dto/storage-stats.dto.ts
@@ -1,4 +1,5 @@
 import { IsNumber, IsOptional, Min, Max } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 /**
  * User storage stats response
@@ -10,6 +11,15 @@ export class UserStorageStatsDto {
   quotaBytes: number;
   percentUsed: number;
   fileCount: number;
+}
+
+/**
+ * Paginated user storage list response
+ */
+export class UserStorageListResponseDto {
+  @ApiProperty({ type: [UserStorageStatsDto] })
+  users: UserStorageStatsDto[];
+  total: number;
 }
 
 /**

--- a/backend/src/storage-quota/storage-quota.controller.ts
+++ b/backend/src/storage-quota/storage-quota.controller.ts
@@ -11,6 +11,7 @@ import {
   DefaultValuePipe,
   ParseIntPipe,
 } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
 import { StorageQuotaService } from './storage-quota.service';
 import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
 import { RbacGuard } from '@/auth/rbac.guard';
@@ -18,10 +19,12 @@ import { RequiredActions } from '@/auth/rbac-action.decorator';
 import { RbacResource, RbacResourceType } from '@/auth/rbac-resource.decorator';
 import { RbacActions } from '@prisma/client';
 import { AuthenticatedRequest } from '@/types';
+import { SuccessResponseDto } from '@/common/dto/common-response.dto';
 import {
   UpdateUserQuotaDto,
   UpdateStorageSettingsDto,
   UserStorageStatsDto,
+  UserStorageListResponseDto,
   InstanceStorageStatsDto,
 } from './dto/storage-stats.dto';
 
@@ -34,6 +37,7 @@ export class StorageQuotaController {
    * Get current user's storage stats (for user settings)
    */
   @Get('my-usage')
+  @ApiOkResponse({ type: UserStorageStatsDto })
   async getMyStorageStats(
     @Req() req: AuthenticatedRequest,
   ): Promise<UserStorageStatsDto> {
@@ -46,6 +50,7 @@ export class StorageQuotaController {
   @Get('instance')
   @RequiredActions(RbacActions.READ_INSTANCE_STATS)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiOkResponse({ type: InstanceStorageStatsDto })
   async getInstanceStorageStats(): Promise<InstanceStorageStatsDto> {
     return this.storageQuotaService.getInstanceStorageStats();
   }
@@ -56,6 +61,7 @@ export class StorageQuotaController {
   @Get('users')
   @RequiredActions(RbacActions.MANAGE_USER_STORAGE)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiOkResponse({ type: UserStorageListResponseDto })
   async getUsersStorageList(
     @Query('skip', new DefaultValuePipe(0), ParseIntPipe) skip: number,
     @Query('take', new DefaultValuePipe(20), ParseIntPipe) take: number,
@@ -75,6 +81,7 @@ export class StorageQuotaController {
   @Get('users/:userId')
   @RequiredActions(RbacActions.MANAGE_USER_STORAGE)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiOkResponse({ type: UserStorageStatsDto })
   async getUserStorageStats(
     @Param('userId') userId: string,
   ): Promise<UserStorageStatsDto> {
@@ -87,6 +94,7 @@ export class StorageQuotaController {
   @Patch('users/:userId/quota')
   @RequiredActions(RbacActions.MANAGE_USER_STORAGE)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiOkResponse({ type: UserStorageStatsDto })
   async updateUserQuota(
     @Param('userId') userId: string,
     @Body() dto: UpdateUserQuotaDto,
@@ -100,6 +108,7 @@ export class StorageQuotaController {
   @Post('users/:userId/recalculate')
   @RequiredActions(RbacActions.MANAGE_USER_STORAGE)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiOkResponse({ type: UserStorageStatsDto })
   async recalculateUserStorage(
     @Param('userId') userId: string,
   ): Promise<UserStorageStatsDto> {
@@ -112,6 +121,7 @@ export class StorageQuotaController {
   @Patch('settings')
   @RequiredActions(RbacActions.UPDATE_INSTANCE_SETTINGS)
   @RbacResource({ type: RbacResourceType.INSTANCE })
+  @ApiOkResponse({ type: SuccessResponseDto })
   async updateStorageSettings(
     @Body() dto: UpdateStorageSettingsDto,
   ): Promise<{ success: boolean }> {

--- a/backend/src/threads/dto/create-thread-reply.dto.ts
+++ b/backend/src/threads/dto/create-thread-reply.dto.ts
@@ -1,5 +1,17 @@
 import { IsString, IsOptional, IsArray, IsInt, Min } from 'class-validator';
 import { $Enums } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import { SpanTypeValues } from '@/common/enums/swagger-enums';
+
+class ThreadReplySpanDto {
+  @ApiProperty({ enum: SpanTypeValues })
+  type: $Enums.SpanType;
+  text: string | null;
+  userId: string | null;
+  specialKind: string | null;
+  communityId: string | null;
+  aliasId: string | null;
+}
 
 /**
  * DTO for creating a thread reply message.
@@ -9,15 +21,9 @@ export class CreateThreadReplyDto {
   @IsString()
   parentMessageId: string;
 
+  @ApiProperty({ type: [ThreadReplySpanDto] })
   @IsArray()
-  spans: {
-    type: $Enums.SpanType;
-    text: string | null;
-    userId: string | null;
-    specialKind: string | null;
-    communityId: string | null;
-    aliasId: string | null;
-  }[];
+  spans: ThreadReplySpanDto[];
 
   @IsArray()
   @IsOptional()

--- a/backend/src/threads/dto/send-thread-reply.dto.ts
+++ b/backend/src/threads/dto/send-thread-reply.dto.ts
@@ -1,5 +1,17 @@
 import { IsString, IsOptional, IsArray, IsInt, Min } from 'class-validator';
 import { $Enums } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import { SpanTypeValues } from '@/common/enums/swagger-enums';
+
+class SendThreadReplySpanDto {
+  @ApiProperty({ enum: SpanTypeValues })
+  type: $Enums.SpanType;
+  text: string | null;
+  userId: string | null;
+  specialKind: string | null;
+  communityId: string | null;
+  aliasId: string | null;
+}
 
 /**
  * DTO for sending a thread reply via WebSocket.
@@ -8,15 +20,9 @@ export class SendThreadReplyDto {
   @IsString()
   parentMessageId: string;
 
+  @ApiProperty({ type: [SendThreadReplySpanDto] })
   @IsArray()
-  spans: {
-    type: $Enums.SpanType;
-    text: string | null;
-    userId: string | null;
-    specialKind: string | null;
-    communityId: string | null;
-    aliasId: string | null;
-  }[];
+  spans: SendThreadReplySpanDto[];
 
   @IsArray()
   @IsOptional()

--- a/backend/src/threads/threads.controller.ts
+++ b/backend/src/threads/threads.controller.ts
@@ -12,6 +12,7 @@ import {
   DefaultValuePipe,
   ParseIntPipe,
 } from '@nestjs/common';
+import { ApiCreatedResponse, ApiOkResponse } from '@nestjs/swagger';
 import { ThreadsService } from './threads.service';
 import { CreateThreadReplyDto } from './dto/create-thread-reply.dto';
 import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
@@ -52,6 +53,7 @@ export class ThreadsController {
     idKey: 'parentMessageId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiCreatedResponse({ type: ThreadReplyDto })
   async createReply(
     @Param('parentMessageId', ParseObjectIdPipe) parentMessageId: string,
     @Body() body: Omit<CreateThreadReplyDto, 'parentMessageId'>,
@@ -74,6 +76,7 @@ export class ThreadsController {
     idKey: 'parentMessageId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: ThreadRepliesResponseDto })
   async getReplies(
     @Param('parentMessageId', ParseObjectIdPipe) parentMessageId: string,
     @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,
@@ -96,6 +99,7 @@ export class ThreadsController {
     idKey: 'parentMessageId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: ThreadMetadataDto })
   async getMetadata(
     @Param('parentMessageId', ParseObjectIdPipe) parentMessageId: string,
     @Req() req: AuthenticatedRequest,

--- a/backend/src/user/dto/admin-user-response.dto.ts
+++ b/backend/src/user/dto/admin-user-response.dto.ts
@@ -1,6 +1,7 @@
 import { Exclude, Transform } from 'class-transformer';
 import { $Enums, User } from '@prisma/client';
-import { ApiHideProperty } from '@nestjs/swagger';
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { InstanceRoleValues } from '@/common/enums/swagger-enums';
 
 /**
  * Admin-level user response that includes ban status and other sensitive fields
@@ -10,6 +11,7 @@ export class AdminUserEntity implements User {
   username: string;
   email: string | null;
   verified: boolean;
+  @ApiProperty({ enum: InstanceRoleValues })
   role: $Enums.InstanceRole;
   createdAt: Date;
   avatarUrl: string | null;

--- a/backend/src/user/dto/update-user-role.dto.ts
+++ b/backend/src/user/dto/update-user-role.dto.ts
@@ -1,7 +1,10 @@
 import { IsEnum } from 'class-validator';
 import { InstanceRole } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+import { InstanceRoleValues } from '@/common/enums/swagger-enums';
 
 export class UpdateUserRoleDto {
+  @ApiProperty({ enum: InstanceRoleValues })
   @IsEnum(InstanceRole)
   role: InstanceRole;
 }

--- a/backend/src/user/dto/user-response.dto.ts
+++ b/backend/src/user/dto/user-response.dto.ts
@@ -1,6 +1,8 @@
 import { $Enums, User } from '@prisma/client';
 import { Exclude } from 'class-transformer';
-import { ApiHideProperty } from '@nestjs/swagger';
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { InstanceRoleValues } from '@/common/enums/swagger-enums';
+import { AdminUserEntity } from './admin-user-response.dto';
 
 export class UserEntity implements User {
   id: string;
@@ -13,6 +15,7 @@ export class UserEntity implements User {
   @Exclude()
   @ApiHideProperty()
   verified: boolean;
+  @ApiProperty({ enum: InstanceRoleValues })
   role: $Enums.InstanceRole;
 
   @Exclude()
@@ -59,4 +62,24 @@ export class UserEntity implements User {
   constructor(partial: Partial<UserEntity>) {
     Object.assign(this, partial);
   }
+}
+
+export class UserListResponseDto {
+  @ApiProperty({ type: [UserEntity] })
+  users: UserEntity[];
+
+  @ApiProperty({ required: false })
+  continuationToken?: string;
+}
+
+export class AdminUserListResponseDto {
+  @ApiProperty({ type: () => [AdminUserEntity] })
+  users: AdminUserEntity[];
+
+  @ApiProperty({ required: false })
+  continuationToken?: string;
+}
+
+export class BlockedStatusResponseDto {
+  blocked: boolean;
 }

--- a/backend/src/voice-presence/voice-presence.controller.ts
+++ b/backend/src/voice-presence/voice-presence.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Post, Param, UseGuards, Req } from '@nestjs/common';
+import { ApiOkResponse, ApiCreatedResponse } from '@nestjs/swagger';
 import { VoicePresenceService } from './voice-presence.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RbacGuard } from '../auth/rbac.guard';
@@ -29,6 +30,7 @@ export class VoicePresenceController {
     idKey: 'channelId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiOkResponse({ type: ChannelVoicePresenceResponseDto })
   async getChannelPresence(
     @Param('channelId') channelId: string,
   ): Promise<ChannelVoicePresenceResponseDto> {
@@ -47,6 +49,7 @@ export class VoicePresenceController {
     idKey: 'channelId',
     source: ResourceIdSource.PARAM,
   })
+  @ApiCreatedResponse({ type: RefreshPresenceResponseDto })
   async refreshPresence(
     @Param('channelId') channelId: string,
     @Req() req: AuthenticatedRequest,
@@ -66,6 +69,7 @@ export class DmVoicePresenceController {
   constructor(private readonly voicePresenceService: VoicePresenceService) {}
 
   @Get()
+  @ApiOkResponse({ type: DmVoicePresenceResponseDto })
   async getDmPresence(
     @Param('dmGroupId') dmGroupId: string,
   ): Promise<DmVoicePresenceResponseDto> {
@@ -84,6 +88,7 @@ export class UserVoicePresenceController {
   constructor(private readonly voicePresenceService: VoicePresenceService) {}
 
   @Get('me')
+  @ApiOkResponse({ type: UserVoiceChannelsResponseDto })
   async getMyVoiceChannels(
     @Req() req: AuthenticatedRequest,
   ): Promise<UserVoiceChannelsResponseDto> {


### PR DESCRIPTION
## Summary

- Reduced `200: unknown` in generated API client types from ~93 to 9
- Reduced `[key: string]: unknown` from ~38 to 10
- Created `swagger-enums.ts` with const arrays for all 11 Prisma enums
- Added `@ApiProperty({ enum })` decorators to ~30 DTO properties using Prisma enums or string literal unions
- Added `@ApiOkResponse`/`@ApiCreatedResponse` decorators to all controller endpoints across 20+ controllers
- Created proper response DTOs replacing inline return types (user list, instance stats, push notifications, storage quota, etc.)
- Fixed `PartialType` imports from `@nestjs/mapped-types` to `@nestjs/swagger` (3 files)
- Regenerated `openapi.json` and frontend `api-client/`

### Remaining `200: unknown` (9) — all unfixable without API changes

Void or streaming `@Res()` endpoints with no typed body:
- `deleteInvite`, `leaveDmGroup`, `deleteAliasGroup`, `updateMembers`, `removeMember` (void)
- `getFile`, `streamReplay`, `getPreviewPlaylist`, `getPreviewSegment` (streaming)

## Test plan

- [x] `docker compose run --rm backend npm run generate:openapi` — spec generates cleanly
- [x] `docker compose run --rm frontend npm run generate:api` — client codegen succeeds
- [x] Backend `tsc --noEmit` — no type errors
- [x] Frontend `tsc --noEmit` — no type errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)