### PR TITLE
fix: video overlay respects sidebar bounds and click-to-show tiles

### DIFF
--- a/frontend/src/components/Channel/Channel.tsx
+++ b/frontend/src/components/Channel/Channel.tsx
@@ -79,8 +79,12 @@ export function Channel({ channel }: ChannelProps) {
       // For voice channels, join the voice channel and navigate
       try {
         if (voiceState.currentChannelId === channel.id && voiceState.isConnected) {
-          // Already connected to this channel, just navigate to show video tiles
+          // Already connected to this channel, navigate and show video tiles maximized
           navigate(`/community/${communityId}/channel/${channel.id}`);
+          if (!voiceState.showVideoTiles) {
+            voiceActions.setShowVideoTiles(true);
+            voiceActions.requestMaximize();
+          }
         } else {
           // Join the voice channel
           await voiceActions.joinVoiceChannel(
@@ -108,6 +112,7 @@ export function Channel({ channel }: ChannelProps) {
     navigate,
     voiceState.currentChannelId,
     voiceState.isConnected,
+    voiceState.showVideoTiles,
     voiceActions,
     showNotification,
   ]);

--- a/frontend/src/contexts/VideoOverlayContext.tsx
+++ b/frontend/src/contexts/VideoOverlayContext.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useRef, useCallback } from 'react';
+
+interface VideoOverlayContextValue {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  setContainerElement: (el: HTMLDivElement | null) => void;
+}
+
+const VideoOverlayContext = createContext<VideoOverlayContextValue | null>(null);
+
+export const VideoOverlayProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const setContainerElement = useCallback((el: HTMLDivElement | null) => {
+    containerRef.current = el;
+  }, []);
+
+  return (
+    <VideoOverlayContext.Provider value={{ containerRef, setContainerElement }}>
+      {children}
+    </VideoOverlayContext.Provider>
+  );
+};
+
+export function useVideoOverlay(): VideoOverlayContextValue {
+  const ctx = useContext(VideoOverlayContext);
+  if (!ctx) throw new Error('useVideoOverlay must be used within a VideoOverlayProvider');
+  return ctx;
+}

--- a/frontend/src/contexts/VoiceContext.tsx
+++ b/frontend/src/contexts/VoiceContext.tsx
@@ -17,6 +17,7 @@ export interface VoiceState {
   isDeafened: boolean;
   showVideoTiles: boolean;
   screenShareAudioFailed: boolean;
+  requestMaximize: boolean;
   selectedAudioInputId: string | null;
   selectedAudioOutputId: string | null;
   selectedVideoInputId: string | null;
@@ -33,6 +34,7 @@ export type VoiceAction =
   | { type: 'SET_SCREEN_SHARE_AUDIO_FAILED'; payload: boolean }
   | { type: 'SET_SELECTED_AUDIO_INPUT_ID'; payload: string | null }
   | { type: 'SET_SELECTED_AUDIO_OUTPUT_ID'; payload: string | null }
+  | { type: 'SET_REQUEST_MAXIMIZE'; payload: boolean }
   | { type: 'SET_SELECTED_VIDEO_INPUT_ID'; payload: string | null };
 
 const initialState: VoiceState = {
@@ -50,6 +52,7 @@ const initialState: VoiceState = {
   isDeafened: false,
   showVideoTiles: false,
   screenShareAudioFailed: false,
+  requestMaximize: false,
   selectedAudioInputId: null,
   selectedAudioOutputId: null,
   selectedVideoInputId: null,
@@ -106,6 +109,8 @@ function voiceReducer(state: VoiceState, action: VoiceAction): VoiceState {
       return { ...state, showVideoTiles: action.payload };
     case 'SET_SCREEN_SHARE_AUDIO_FAILED':
       return { ...state, screenShareAudioFailed: action.payload };
+    case 'SET_REQUEST_MAXIMIZE':
+      return { ...state, requestMaximize: action.payload };
     case 'SET_SELECTED_AUDIO_INPUT_ID':
       return { ...state, selectedAudioInputId: action.payload };
     case 'SET_SELECTED_AUDIO_OUTPUT_ID':

--- a/frontend/src/hooks/useVoiceConnection.ts
+++ b/frontend/src/hooks/useVoiceConnection.ts
@@ -150,6 +150,10 @@ export const useVoiceConnection = () => {
     [getDeps]
   );
 
+  const handleRequestMaximize = useCallback(() => {
+    dispatch({ type: 'SET_REQUEST_MAXIMIZE', payload: true });
+  }, [dispatch]);
+
   return {
     state: { ...voiceState, room },
     actions: {
@@ -165,6 +169,7 @@ export const useVoiceConnection = () => {
       switchAudioInputDevice: handleSwitchAudioInputDevice,
       switchAudioOutputDevice: handleSwitchAudioOutputDevice,
       switchVideoInputDevice: handleSwitchVideoInputDevice,
+      requestMaximize: handleRequestMaximize,
     },
   };
 };

--- a/frontend/src/pages/CommunityPage.tsx
+++ b/frontend/src/pages/CommunityPage.tsx
@@ -16,6 +16,7 @@ import { ChannelType } from "../types/channel.type";
 import { useVoiceConnection } from "../hooks/useVoiceConnection";
 import { useAuthenticatedImage } from "../hooks/useAuthenticatedImage";
 import { useResponsive } from "../hooks/useResponsive";
+import { useVideoOverlay } from "../contexts/VideoOverlayContext";
 
 const CommunityPage: React.FC = () => {
   const { isMobile } = useResponsive();
@@ -47,6 +48,7 @@ const DesktopCommunityPage: React.FC = () => {
   });
   const { state: voiceState } = useVoiceConnection();
   const { blobUrl: communityAvatarUrl } = useAuthenticatedImage(data?.avatar);
+  const { setContainerElement } = useVideoOverlay();
 
   if (!communityId) return <div>Community ID is required</div>;
   if (isLoading) return <div>Loading...</div>;
@@ -146,7 +148,7 @@ const DesktopCommunityPage: React.FC = () => {
         </CommunityHeader>
         <ChannelList communityId={communityId} />
       </Sidebar>
-      <Content>
+      <Content ref={setContainerElement}>
         {renderChannelContent()}
       </Content>
     </Root>

--- a/frontend/src/pages/DirectMessagesPage.tsx
+++ b/frontend/src/pages/DirectMessagesPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "../api-client/@tanstack/react-query.gen";
 import { styled } from "@mui/material/styles";
 import { DirectMessageGroup, DirectMessageGroupMember } from "../types/direct-message.type";
+import { useVideoOverlay } from "../contexts/VideoOverlayContext";
 
 const Root = styled(Box)({
   display: "flex",
@@ -85,6 +86,7 @@ const DirectMessagesPage: React.FC = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const { data: currentUser } = useQuery(userControllerGetProfileOptions());
   const { data: pendingRequests } = useQuery(friendsControllerGetPendingRequestsOptions());
+  const { setContainerElement } = useVideoOverlay();
 
   // Count of incoming friend requests for badge
   const incomingRequestCount = pendingRequests?.received?.length || 0;
@@ -243,7 +245,7 @@ const DirectMessagesPage: React.FC = () => {
           />
         )}
       </Sidebar>
-      <Content>
+      <Content ref={setContainerElement}>
         {selectedDmGroupId ? (
           <>
             <DMChatHeader


### PR DESCRIPTION
## Summary
- **Bug 1 fix**: Maximized video overlay now fills only the main content area (between sidebars) instead of covering the channel list and community icons. Uses a new `VideoOverlayContext` + `ResizeObserver` to dynamically track container bounds instead of hardcoded pixel math.
- **Bug 2 fix**: Clicking a voice channel you're already connected to now shows video tiles maximized in the content area (if they aren't already visible).

Closes #70

## Changes
- **New**: `VideoOverlayContext` — pages register their content container; overlay reads its bounds
- **Modified**: `PersistentVideoOverlay` — uses container bounds for maximize positioning + consumes `requestMaximize` flag
- **Modified**: `Layout.tsx` — wraps desktop layout with `VideoOverlayProvider`, extracts `LayoutContentArea` component
- **Modified**: `CommunityPage` / `DirectMessagesPage` — register content containers via context ref
- **Modified**: `VoiceContext` / `useVoiceConnection` — added `requestMaximize` state and action
- **Modified**: `Channel.tsx` — triggers video tiles maximized on click when already connected

## Test plan
- [ ] Join a voice channel, navigate to a text channel, maximize video overlay — verify it fills only the content area (not channel list or community icons bar)
- [ ] Resize browser window while maximized — overlay should dynamically resize with the container
- [ ] Toggle the CommunityToggle (hamburger) while maximized — overlay should follow
- [ ] Close video tiles, click the connected voice channel — verify tiles appear maximized
- [ ] Open PiP (un-maximize), click the channel again — verify PiP mode is preserved
- [ ] Test on DM pages — verify sidebar is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)