### PR TITLE
fix: replay buffer recordings have no audio (#100)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -9665,8 +9665,7 @@
         "required": [
           "channelId",
           "roomName",
-          "videoTrackId",
-          "audioTrackId"
+          "videoTrackId"
         ]
       },
       "StartReplayResponseDto": {

--- a/backend/src/livekit/dto/start-replay-buffer.dto.ts
+++ b/backend/src/livekit/dto/start-replay-buffer.dto.ts
@@ -10,8 +10,9 @@ export class StartReplayBufferDto {
   @IsString()
   videoTrackId: string;
 
+  @IsOptional()
   @IsString()
-  audioTrackId: string;
+  audioTrackId?: string;
 
   /**
    * Participant identity (usually the user ID)

--- a/backend/src/livekit/livekit-replay.service.ts
+++ b/backend/src/livekit/livekit-replay.service.ts
@@ -115,7 +115,7 @@ export class LivekitReplayService {
     channelId: string;
     roomName: string;
     videoTrackId: string;
-    audioTrackId: string;
+    audioTrackId?: string;
     participantIdentity?: string;
   }) {
     const {
@@ -227,7 +227,7 @@ export class LivekitReplayService {
         outputs,
         {
           videoTrackId,
-          audioTrackId,
+          ...(audioTrackId ? { audioTrackId } : {}),
           encodingOptions,
         },
       );


### PR DESCRIPTION
## Summary

- **Root cause**: `publication.audioTrack?.sid` always returned `undefined` because `audioTrack` is a getter that only works on audio publications — the ScreenShare publication is a video track
- **Fix**: Look up the `ScreenShareAudio` track publication from `room.localParticipant.getTrackPublication()` with a retry loop (10 × 200ms) since the audio track may publish slightly after video
- **Backend**: Made `audioTrackId` optional in `StartReplayBufferDto` so recordings proceed gracefully without audio when unavailable
- **Egress call**: Conditionally passes `audioTrackId` only when truthy, avoiding sending empty strings to LiveKit

## Test plan

- [x] Backend livekit-replay tests pass (34/34)
- [x] Backend controller tests pass (11/11)
- [x] Frontend type-check clean
- [x] Frontend tests pass (393/393)
- [ ] Manual: Electron screen share with system audio → verify egress logs show non-empty `audioTrackId`
- [ ] Manual: Web (Chrome) screen share with audio → verify audio in captured clip
- [ ] Manual: Screen share without audio → verify recording starts without audio gracefully

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)