### PR TITLE
feat: always deliver push notifications + test button in settings

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3649,6 +3649,28 @@
         ]
       }
     },
+    "/api/push/test": {
+      "post": {
+        "operationId": "PushNotificationsController_sendTestPushToSelf",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestPushResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Send a test push notification to the current user\nPOST /push/test\nAny authenticated user can test their own push notifications",
+        "tags": [
+          "PushNotifications"
+        ]
+      }
+    },
     "/api/push/debug/send-test": {
       "post": {
         "operationId": "PushNotificationsController_sendTestPush",
@@ -3667,87 +3689,6 @@
         },
         "tags": [
           "PushNotifications"
-        ]
-      }
-    },
-    "/api/presence/user/{userId}": {
-      "get": {
-        "operationId": "PresenceController_getUserPresence",
-        "parameters": [
-          {
-            "name": "userId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserPresenceResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Presence"
-        ]
-      }
-    },
-    "/api/presence/users/bulk": {
-      "get": {
-        "operationId": "PresenceController_getBulkPresence",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkPresenceResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Presence"
-        ]
-      }
-    },
-    "/api/presence/users/{userIds}": {
-      "get": {
-        "operationId": "PresenceController_getMultipleUserPresence",
-        "parameters": [
-          {
-            "name": "userIds",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkPresenceResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Presence"
         ]
       }
     },
@@ -4478,6 +4419,87 @@
         "summary": "Get all users who have read a specific message\nGET /read-receipts/message/:messageId/readers?channelId=xxx or ?directMessageGroupId=xxx",
         "tags": [
           "ReadReceipts"
+        ]
+      }
+    },
+    "/api/presence/user/{userId}": {
+      "get": {
+        "operationId": "PresenceController_getUserPresence",
+        "parameters": [
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserPresenceResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Presence"
+        ]
+      }
+    },
+    "/api/presence/users/bulk": {
+      "get": {
+        "operationId": "PresenceController_getBulkPresence",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkPresenceResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Presence"
+        ]
+      }
+    },
+    "/api/presence/users/{userIds}": {
+      "get": {
+        "operationId": "PresenceController_getMultipleUserPresence",
+        "parameters": [
+          {
+            "name": "userIds",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkPresenceResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Presence"
         ]
       }
     },
@@ -9012,35 +9034,6 @@
           "message"
         ]
       },
-      "UserPresenceResponseDto": {
-        "type": "object",
-        "properties": {
-          "userId": {
-            "type": "string"
-          },
-          "isOnline": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "userId",
-          "isOnline"
-        ]
-      },
-      "BulkPresenceResponseDto": {
-        "type": "object",
-        "properties": {
-          "presence": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "boolean"
-            }
-          }
-        },
-        "required": [
-          "presence"
-        ]
-      },
       "UnbanUserDto": {
         "type": "object",
         "properties": {
@@ -9569,6 +9562,35 @@
           "displayName",
           "avatarUrl",
           "readAt"
+        ]
+      },
+      "UserPresenceResponseDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string"
+          },
+          "isOnline": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "userId",
+          "isOnline"
+        ]
+      },
+      "BulkPresenceResponseDto": {
+        "type": "object",
+        "properties": {
+          "presence": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          }
+        },
+        "required": [
+          "presence"
         ]
       },
       "CreateTokenDto": {

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -7,7 +7,6 @@ import { WebsocketModule } from '@/websocket/websocket.module';
 import { AuthModule } from '@/auth/auth.module';
 import { UserModule } from '@/user/user.module';
 import { PushNotificationsModule } from '@/push-notifications/push-notifications.module';
-import { PresenceModule } from '@/presence/presence.module';
 
 @Module({
   controllers: [NotificationsController],
@@ -18,7 +17,6 @@ import { PresenceModule } from '@/presence/presence.module';
     AuthModule,
     UserModule,
     PushNotificationsModule,
-    PresenceModule,
   ],
   exports: [NotificationsService, NotificationsGateway],
 })

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -23,6 +23,7 @@ import { useResponsive } from "./hooks/useResponsive";
 import type { User } from "./types/auth.type";
 import { APPBAR_HEIGHT, SIDEBAR_WIDTH, VOICE_BAR_HEIGHT } from "./constants/layout";
 import { useNotifications } from "./hooks/useNotifications";
+import { usePushNotifications } from "./hooks/usePushNotifications";
 import NotificationBadge from "./components/Notifications/NotificationBadge";
 import NotificationCenter from "./components/Notifications/NotificationCenter";
 import { ReplayBufferProvider } from "./contexts/ReplayBufferContext";
@@ -81,10 +82,14 @@ const Layout: React.FC = () => {
   useChannelWebSocket();
   useDirectMessageWebSocket();
 
+  // Check push subscription status to avoid duplicate desktop notifications
+  const { isSubscribed: isPushSubscribed } = usePushNotifications();
+
   // Initialize notification WebSocket listeners and desktop notifications
   useNotifications({
     showDesktopNotifications: true,
     playSound: true,
+    isPushSubscribed,
   });
 
   // Sync theme settings with server (server wins on initial load)

--- a/frontend/src/utils/notifications.ts
+++ b/frontend/src/utils/notifications.ts
@@ -15,6 +15,13 @@ import { NotificationType } from '../types/notification.type';
 export type NotificationPermission = 'default' | 'granted' | 'denied';
 
 /**
+ * Check if notification permission is currently granted
+ */
+export const isNotificationPermissionGranted = (): boolean => {
+  return getNotificationPermission() === 'granted';
+};
+
+/**
  * Check if notifications are supported in the current environment
  */
 export const supportsNotifications = (): boolean => {


### PR DESCRIPTION
## Summary

- **Always send push notifications** to subscribed users — removed the `presenceService.isOnline()` check that silently skipped push for online users (desktop/Electron users always have an active WebSocket, so they never received push)
- **Added `POST /push/test` endpoint** accessible to all authenticated users to send a test push to their own devices
- **Prevent duplicate desktop notifications** — when push is subscribed, the WebSocket handler skips the browser `Notification API` call (the service worker push handler shows it instead)
- **Added test buttons to NotificationSettings** — "Send Test Notification" (local browser) and "Send Test Push" (via backend) for verifying push works
- **Extracted `isNotificationPermissionGranted()` helper** to eliminate magic string comparison

Closes #110

## Test plan

- [ ] Send an @mention to a user who is online with push subscribed → push notification arrives via service worker
- [ ] Same scenario → only ONE desktop notification shown (from push), not two
- [ ] User without push subscription → browser notification from WebSocket handler still works
- [ ] Settings → click "Send Test Notification" → browser notification appears
- [ ] Settings → subscribe to push → click "Send Test Push" → push notification delivered
- [ ] `docker compose run --rm backend npm run test -- --testPathPattern "push-notifications|notifications"` → 44 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)