### PR TITLE
fix: unread marker bugs and DM seen indicator

### DIFF
--- a/backend/src/messages/messages.module.ts
+++ b/backend/src/messages/messages.module.ts
@@ -13,6 +13,7 @@ import { FileModule } from '@/file/file.module';
 import { MessageOwnershipGuard } from '@/auth/message-ownership.guard';
 import { NotificationsModule } from '@/notifications/notifications.module';
 import { ModerationModule } from '@/moderation/moderation.module';
+import { ReadReceiptsModule } from '@/read-receipts/read-receipts.module';
 
 @Module({
   controllers: [MessagesController],
@@ -32,6 +33,7 @@ import { ModerationModule } from '@/moderation/moderation.module';
     FileModule,
     NotificationsModule,
     ModerationModule,
+    ReadReceiptsModule,
   ],
   exports: [MessagesService, ReactionsService],
 })

--- a/backend/src/read-receipts/read-receipts.controller.spec.ts
+++ b/backend/src/read-receipts/read-receipts.controller.spec.ts
@@ -1,0 +1,108 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReadReceiptsController } from './read-receipts.controller';
+import { ReadReceiptsService } from './read-receipts.service';
+import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
+
+describe('ReadReceiptsController', () => {
+  let controller: ReadReceiptsController;
+
+  const mockReadReceiptsService = {
+    markAsRead: jest.fn(),
+    getUnreadCounts: jest.fn(),
+    getUnreadCount: jest.fn(),
+    getLastReadMessageId: jest.fn(),
+    getMessageReaders: jest.fn(),
+  };
+
+  const mockGuard = { canActivate: jest.fn(() => true) };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReadReceiptsController],
+      providers: [
+        {
+          provide: ReadReceiptsService,
+          useValue: mockReadReceiptsService,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockGuard)
+      .compile();
+
+    controller = module.get<ReadReceiptsController>(ReadReceiptsController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getMessageReaders', () => {
+    const messageId = 'message-123';
+    const channelId = 'channel-456';
+    const userId = 'user-789';
+    const mockReq = { user: { id: userId } } as any;
+
+    it('should pass req.user.id as excludeUserId to the service', async () => {
+      const mockReaders = [
+        {
+          userId: 'user-456',
+          username: 'other',
+          displayName: 'Other',
+          avatarUrl: null,
+          readAt: new Date(),
+        },
+      ];
+
+      mockReadReceiptsService.getMessageReaders.mockResolvedValue(mockReaders);
+
+      const result = await controller.getMessageReaders(
+        mockReq,
+        messageId,
+        channelId,
+      );
+
+      expect(result).toEqual(mockReaders);
+      expect(mockReadReceiptsService.getMessageReaders).toHaveBeenCalledWith(
+        messageId,
+        channelId,
+        undefined,
+        userId,
+      );
+    });
+
+    it('should pass directMessageGroupId when provided instead of channelId', async () => {
+      const directMessageGroupId = 'dm-group-123';
+      const mockReaders = [
+        {
+          userId: 'user-456',
+          username: 'other',
+          displayName: 'Other',
+          avatarUrl: null,
+          readAt: new Date(),
+        },
+      ];
+
+      mockReadReceiptsService.getMessageReaders.mockResolvedValue(mockReaders);
+
+      const result = await controller.getMessageReaders(
+        mockReq,
+        messageId,
+        undefined,
+        directMessageGroupId,
+      );
+
+      expect(result).toEqual(mockReaders);
+      expect(mockReadReceiptsService.getMessageReaders).toHaveBeenCalledWith(
+        messageId,
+        undefined,
+        directMessageGroupId,
+        userId,
+      );
+    });
+  });
+});

--- a/backend/src/read-receipts/read-receipts.controller.ts
+++ b/backend/src/read-receipts/read-receipts.controller.ts
@@ -102,6 +102,7 @@ export class ReadReceiptsController {
   @Get('message/:messageId/readers')
   @ApiOkResponse({ type: [MessageReaderDto] })
   async getMessageReaders(
+    @Req() req: AuthenticatedRequest,
     @Param('messageId', ParseObjectIdPipe) messageId: string,
     @Query('channelId', OptionalParseObjectIdPipe) channelId?: string,
     @Query('directMessageGroupId', OptionalParseObjectIdPipe)
@@ -111,6 +112,7 @@ export class ReadReceiptsController {
       messageId,
       channelId,
       directMessageGroupId,
+      req.user.id,
     );
   }
 }

--- a/frontend/src/__tests__/components/ReadStatusIndicator.test.tsx
+++ b/frontend/src/__tests__/components/ReadStatusIndicator.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import { ReadStatusIndicator } from '../../components/Message/ReadStatusIndicator';
+import type { ReadStatus } from '../../components/Message/ReadStatusIndicator';
+
+const defaultProps = (): { status: ReadStatus; showForDm?: boolean; disableTooltip?: boolean } => ({
+  status: 'sent',
+});
+
+describe('ReadStatusIndicator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders check icon for "sent" status', () => {
+    renderWithProviders(<ReadStatusIndicator {...defaultProps()} status="sent" />);
+
+    // DoneIcon (check) should be rendered
+    const icon = screen.getByTestId('DoneIcon');
+    expect(icon).toBeInTheDocument();
+    // VisibilityIcon should NOT be rendered
+    expect(screen.queryByTestId('VisibilityIcon')).not.toBeInTheDocument();
+  });
+
+  it('renders eye icon for "read" status', () => {
+    renderWithProviders(<ReadStatusIndicator {...defaultProps()} status="read" />);
+
+    // VisibilityIcon (eye) should be rendered
+    const icon = screen.getByTestId('VisibilityIcon');
+    expect(icon).toBeInTheDocument();
+    // DoneIcon should NOT be rendered
+    expect(screen.queryByTestId('DoneIcon')).not.toBeInTheDocument();
+  });
+
+  it('renders eye icon for "delivered" status (treated same as read)', () => {
+    renderWithProviders(<ReadStatusIndicator {...defaultProps()} status="delivered" />);
+
+    const icon = screen.getByTestId('VisibilityIcon');
+    expect(icon).toBeInTheDocument();
+    expect(screen.queryByTestId('DoneIcon')).not.toBeInTheDocument();
+  });
+
+  it('returns null when showForDm is false', () => {
+    const { container } = renderWithProviders(
+      <ReadStatusIndicator {...defaultProps()} showForDm={false} />
+    );
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('shows tooltip with "Sent" text when status is "sent"', async () => {
+    const { user } = renderWithProviders(
+      <ReadStatusIndicator {...defaultProps()} status="sent" />
+    );
+
+    const icon = screen.getByTestId('DoneIcon');
+    await user.hover(icon);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Sent');
+  });
+
+  it('shows tooltip with "Seen" text when status is "read"', async () => {
+    const { user } = renderWithProviders(
+      <ReadStatusIndicator {...defaultProps()} status="read" />
+    );
+
+    const icon = screen.getByTestId('VisibilityIcon');
+    await user.hover(icon);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Seen');
+  });
+
+  it('renders without tooltip when disableTooltip is true', async () => {
+    const { user } = renderWithProviders(
+      <ReadStatusIndicator {...defaultProps()} status="sent" disableTooltip={true} />
+    );
+
+    const icon = screen.getByTestId('DoneIcon');
+    expect(icon).toBeInTheDocument();
+
+    // Hover should NOT produce a tooltip
+    await user.hover(icon);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/SeenByTooltip.test.tsx
+++ b/frontend/src/__tests__/components/SeenByTooltip.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll, afterEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../msw/server';
+import { renderWithProviders } from '../test-utils';
+import { SeenByTooltip } from '../../components/Message/SeenByTooltip';
+import type { MessageReader } from '../../types/read-receipt.type';
+
+vi.mock('../../api-client/client.gen', async (importOriginal) => {
+  const { createClient, createConfig } = await import('../../api-client/client');
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    client: createClient(createConfig({ baseUrl: 'http://localhost:3000' })),
+  };
+});
+
+const BASE_URL = 'http://localhost:3000';
+
+const defaultProps = () => ({
+  messageId: 'msg-1',
+  directMessageGroupId: 'dm-group-1',
+});
+
+describe('SeenByTooltip', () => {
+  beforeAll(() => server.listen());
+  afterAll(() => server.close());
+  afterEach(() => server.resetHandlers());
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders check icon initially (before hover/data fetch)', () => {
+    // Before hovering, the query is disabled so no readers are fetched.
+    // The default readStatus should be "sent" which shows DoneIcon.
+    server.use(
+      http.get(`${BASE_URL}/api/read-receipts/message/:messageId/readers`, () => {
+        return HttpResponse.json([]);
+      })
+    );
+
+    renderWithProviders(<SeenByTooltip {...defaultProps()} />);
+
+    // DoneIcon (check) should be visible for "sent" status
+    expect(screen.getByTestId('DoneIcon')).toBeInTheDocument();
+    expect(screen.queryByTestId('VisibilityIcon')).not.toBeInTheDocument();
+  });
+
+  it('shows eye icon after readers data is loaded on hover', async () => {
+    const readers: MessageReader[] = [
+      {
+        userId: 'u2',
+        username: 'alice',
+        displayName: 'Alice',
+        avatarUrl: undefined,
+        readAt: new Date(),
+      },
+    ];
+
+    server.use(
+      http.get(`${BASE_URL}/api/read-receipts/message/:messageId/readers`, () => {
+        return HttpResponse.json(readers);
+      })
+    );
+
+    const { user } = renderWithProviders(<SeenByTooltip {...defaultProps()} />);
+
+    // Initially should show check icon (sent)
+    expect(screen.getByTestId('DoneIcon')).toBeInTheDocument();
+
+    // Hover to trigger the tooltip open and data fetch
+    const indicator = screen.getByTestId('DoneIcon').closest('span')!;
+    await user.hover(indicator);
+
+    // After data loads, the status should switch to "read" and show VisibilityIcon
+    await waitFor(() => {
+      expect(screen.getByTestId('VisibilityIcon')).toBeInTheDocument();
+    });
+
+    // The tooltip should show "Seen by" header and the reader name
+    expect(screen.getByText('Seen by')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('shows "Not seen yet" text when readers list is empty after loading', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/read-receipts/message/:messageId/readers`, () => {
+        return HttpResponse.json([]);
+      })
+    );
+
+    const { user } = renderWithProviders(<SeenByTooltip {...defaultProps()} />);
+
+    // Hover to trigger fetch
+    const indicator = screen.getByTestId('DoneIcon').closest('span')!;
+    await user.hover(indicator);
+
+    // After data loads with empty array, tooltip should show "Not seen yet"
+    await waitFor(() => {
+      expect(screen.getByText('Not seen yet')).toBeInTheDocument();
+    });
+
+    // Status should remain "sent" (check icon) since no readers
+    expect(screen.getByTestId('DoneIcon')).toBeInTheDocument();
+    expect(screen.queryByTestId('VisibilityIcon')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Message/MessageComponent.tsx
+++ b/frontend/src/components/Message/MessageComponent.tsx
@@ -23,7 +23,6 @@ import { isUserMentioned } from "./messageUtils";
 import UserAvatar from "../Common/UserAvatar";
 import { ThreadReplyBadge } from "../Thread/ThreadReplyBadge";
 import { useUserProfile } from "../../contexts/UserProfileContext";
-import { ReadStatusIndicator, ReadStatus } from "./ReadStatusIndicator";
 import { SeenByTooltip } from "./SeenByTooltip";
 
 interface MessageProps {
@@ -37,8 +36,6 @@ interface MessageProps {
   onOpenThread?: (message: MessageType) => void;
   /** Context type to determine if read receipts should be shown */
   contextType?: "channel" | "dm";
-  /** Read status for DM messages (sent/delivered/read) */
-  readStatus?: ReadStatus;
 }
 
 function MessageComponentInner({
@@ -50,7 +47,6 @@ function MessageComponentInner({
   isThreadReply,
   onOpenThread,
   contextType,
-  readStatus = "sent",
 }: MessageProps) {
   const { data: author } = useQuery(userControllerGetUserByIdOptions({ path: { id: message.authorId } }));
   const { data: currentUser } = useQuery(userControllerGetProfileOptions());
@@ -143,11 +139,7 @@ function MessageComponentInner({
               <SeenByTooltip
                 messageId={message.id}
                 directMessageGroupId={contextId}
-              >
-                <span>
-                  <ReadStatusIndicator status={readStatus} showForDm={true} />
-                </span>
-              </SeenByTooltip>
+              />
             )}
           </Typography>
           {isPinned && (
@@ -238,7 +230,6 @@ const MessageComponent = React.memo(MessageComponentInner, (prevProps, nextProps
     prevProps.isThreadReply === nextProps.isThreadReply &&
     prevProps.isAuthor === nextProps.isAuthor &&
     prevProps.contextType === nextProps.contextType &&
-    prevProps.readStatus === nextProps.readStatus &&
     // Deep compare reactions array
     prevMsg.reactions.length === nextMsg.reactions.length &&
     prevMsg.reactions.every((r, i) =>

--- a/frontend/src/components/Message/ReadStatusIndicator.tsx
+++ b/frontend/src/components/Message/ReadStatusIndicator.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Tooltip } from "@mui/material";
 import DoneIcon from "@mui/icons-material/Done";
-import DoneAllIcon from "@mui/icons-material/DoneAll";
+import VisibilityIcon from "@mui/icons-material/Visibility";
 
 export type ReadStatus = "sent" | "delivered" | "read";
 
@@ -9,62 +9,55 @@ interface ReadStatusIndicatorProps {
   status: ReadStatus;
   /** Only shown in DMs for own messages */
   showForDm?: boolean;
+  /** Disable the built-in tooltip (when wrapped by an outer tooltip) */
+  disableTooltip?: boolean;
 }
 
 /**
- * Discord-style read status indicator showing checkmarks for messages
+ * Read status indicator for DM messages:
+ * - check icon (gray) = sent
+ * - eye icon (blue) = seen by recipient(s)
  *
- * ✓ (gray) = sent/delivered
- * ✓✓ (gray) = delivered to recipient
- * ✓✓ (blue) = read by recipient
- *
- * Only displayed for the user's own messages in DMs
+ * Only displayed for the user's own messages in DMs.
  */
 export const ReadStatusIndicator: React.FC<ReadStatusIndicatorProps> = ({
   status,
   showForDm = true,
+  disableTooltip = false,
 }) => {
   if (!showForDm) return null;
 
-  const getIcon = () => {
-    switch (status) {
-      case "sent":
-        return <DoneIcon sx={{ fontSize: 14 }} />;
-      case "delivered":
-        return <DoneAllIcon sx={{ fontSize: 14 }} />;
-      case "read":
-        return <DoneAllIcon sx={{ fontSize: 14, color: "primary.main" }} />;
-      default:
-        return null;
-    }
-  };
+  const isSeen = status === "read" || status === "delivered";
 
-  const getTooltipText = () => {
-    switch (status) {
-      case "sent":
-        return "Sent";
-      case "delivered":
-        return "Delivered";
-      case "read":
-        return "Read";
-      default:
-        return "";
-    }
-  };
+  const icon = isSeen ? (
+    <VisibilityIcon sx={{ fontSize: 14, color: "primary.main" }} />
+  ) : (
+    <DoneIcon sx={{ fontSize: 14 }} />
+  );
+
+  const tooltipText = isSeen ? "Seen" : "Sent";
+
+  const content = (
+    <Box
+      component="span"
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        color: isSeen ? "primary.main" : "text.disabled",
+        ml: 0.5,
+      }}
+    >
+      {icon}
+    </Box>
+  );
+
+  if (disableTooltip) {
+    return content;
+  }
 
   return (
-    <Tooltip title={getTooltipText()} placement="top" arrow>
-      <Box
-        component="span"
-        sx={{
-          display: "inline-flex",
-          alignItems: "center",
-          color: status === "read" ? "primary.main" : "text.disabled",
-          ml: 0.5,
-        }}
-      >
-        {getIcon()}
-      </Box>
+    <Tooltip title={tooltipText} placement="top" arrow>
+      {content}
     </Tooltip>
   );
 };


### PR DESCRIPTION
## Summary

- **Auto-mark sender's read receipt** when sending a message (channel or DM) so the sender never sees their own messages as "new" (fixes #134)
- **Prevent watermark regression** in `markAsRead()` by comparing `sentAt` timestamps before upserting — stale `MARK_AS_READ` events from network delays or race conditions are now no-ops
- **Filter self from "Seen by" list** so users don't see themselves in the DM read receipt tooltip
- **Replace double-checkmark with eye icon** (`VisibilityIcon`) for the "seen" status in DMs
- **Eliminate double-tooltip** on DM read indicators — `SeenByTooltip` now renders the icon directly with a single unified tooltip

## Test plan

- [x] Backend: `read-receipts.service.spec.ts` — 3 new watermark regression tests, 3 new `getMessageReaders` tests (including self-exclusion)
- [x] Backend: `read-receipts.controller.spec.ts` — 2 new tests verifying `excludeUserId` is passed
- [x] Backend: `messages.gateway.spec.ts` — 2 new tests verifying `markAsRead` is called after send
- [x] Frontend: `ReadStatusIndicator.test.tsx` — 7 tests covering icon/tooltip behavior
- [x] Frontend: `SeenByTooltip.test.tsx` — 3 tests covering lazy-load and seen state
- [ ] Manual: Send a message in a channel → no "NEW MESSAGES" divider for your own message
- [ ] Manual: Navigate away and back → divider appears only for messages from others
- [ ] Manual: In DMs, hover the indicator → shows "Seen by" without yourself in the list
- [ ] Manual: Eye icon appears after the other user reads your DM

🤖 Generated with [Claude Code](https://claude.com/claude-code)