### PR TITLE
fix: replace notification badge polling with WebSocket updates

### DIFF
--- a/frontend/src/__tests__/components/MobileBottomNavigation.test.tsx
+++ b/frontend/src/__tests__/components/MobileBottomNavigation.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders, createTestQueryClient } from '../test-utils';
+import { MobileBottomNavigation } from '../../components/Mobile/Navigation/MobileBottomNavigation';
+import { notificationsControllerGetUnreadCountQueryKey } from '../../api-client/@tanstack/react-query.gen';
+
+vi.mock('../../api-client/client.gen', () => ({
+  client: {
+    getConfig: () => ({ baseUrl: 'http://localhost:3000' }),
+  },
+}));
+
+const mockSetActiveTab = vi.fn();
+vi.mock('../../components/Mobile/Navigation/MobileNavigationContext', () => ({
+  useMobileNavigation: () => ({
+    activeTab: 'home',
+    setActiveTab: mockSetActiveTab,
+  }),
+}));
+
+describe('MobileBottomNavigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all four navigation tabs', () => {
+    renderWithProviders(<MobileBottomNavigation />);
+
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Messages')).toBeInTheDocument();
+    expect(screen.getByText('Notifications')).toBeInTheDocument();
+    expect(screen.getByText('Profile')).toBeInTheDocument();
+  });
+
+  it('displays real notification count from query cache', () => {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(notificationsControllerGetUnreadCountQueryKey(), { count: 7 });
+
+    renderWithProviders(<MobileBottomNavigation />, { queryClient });
+
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('shows no visible badge when unread count is 0', () => {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(notificationsControllerGetUnreadCountQueryKey(), { count: 0 });
+
+    renderWithProviders(<MobileBottomNavigation />, { queryClient });
+
+    // MUI Badge hides when badgeContent is 0 by default
+    const badges = screen.queryAllByText('0');
+    // The "0" for Messages badge may or may not be visible depending on MUI version,
+    // but the notification count should not show a visible "0" badge
+    expect(screen.queryByText('7')).not.toBeInTheDocument();
+  });
+
+  it('switches tab when clicked', async () => {
+    const { user } = renderWithProviders(<MobileBottomNavigation />);
+
+    await user.click(screen.getByText('Notifications'));
+
+    expect(mockSetActiveTab).toHaveBeenCalledWith('notifications');
+  });
+});

--- a/frontend/src/__tests__/components/NotificationBadge.test.tsx
+++ b/frontend/src/__tests__/components/NotificationBadge.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders, createTestQueryClient } from '../test-utils';
+import { NotificationBadge } from '../../components/Notifications/NotificationBadge';
+import { notificationsControllerGetUnreadCountQueryKey } from '../../api-client/@tanstack/react-query.gen';
+
+vi.mock('../../api-client/client.gen', () => ({
+  client: {
+    getConfig: () => ({ baseUrl: 'http://localhost:3000' }),
+  },
+}));
+
+describe('NotificationBadge', () => {
+  let onClick: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onClick = vi.fn();
+  });
+
+  it('renders with unread count from query cache', () => {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(notificationsControllerGetUnreadCountQueryKey(), { count: 5 });
+
+    renderWithProviders(<NotificationBadge onClick={onClick} />, { queryClient });
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByLabelText('5 unread notifications')).toBeInTheDocument();
+  });
+
+  it('renders 0 badge when cache is empty', () => {
+    renderWithProviders(<NotificationBadge onClick={onClick} />);
+
+    // Badge with 0 is hidden by MUI by default, but aria-label still reflects it
+    expect(screen.getByLabelText('0 unread notifications')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', async () => {
+    const { user } = renderWithProviders(<NotificationBadge onClick={onClick} />);
+
+    await user.click(screen.getByLabelText('0 unread notifications'));
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('caps displayed count at 99', () => {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(notificationsControllerGetUnreadCountQueryKey(), { count: 150 });
+
+    renderWithProviders(<NotificationBadge onClick={onClick} />, { queryClient });
+
+    expect(screen.getByText('99+')).toBeInTheDocument();
+    expect(screen.getByLabelText('150 unread notifications')).toBeInTheDocument();
+  });
+
+  it('does not use polling (no refetchInterval)', () => {
+    const queryClient = createTestQueryClient();
+    renderWithProviders(<NotificationBadge onClick={onClick} />, { queryClient });
+
+    const queries = queryClient.getQueryCache().getAll();
+    const unreadQuery = queries.find(
+      (q) => JSON.stringify(q.queryKey) === JSON.stringify(notificationsControllerGetUnreadCountQueryKey()),
+    );
+    // The query should exist but should not have a refetch interval set
+    expect(unreadQuery).toBeDefined();
+    expect(unreadQuery?.options.refetchInterval).toBeUndefined();
+  });
+});

--- a/frontend/src/__tests__/hooks/useNotifications.test.ts
+++ b/frontend/src/__tests__/hooks/useNotifications.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Mock the generated client
+vi.mock('../../api-client/client.gen', () => ({
+  client: {
+    getConfig: () => ({ baseUrl: 'http://localhost:3000' }),
+  },
+}));
+
+// Mock react-router-dom
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useNavigate: () => mockNavigate,
+}));
+
+// Mock notification utilities
+vi.mock('../../utils/notifications', () => ({
+  showNotification: vi.fn(),
+  formatNotificationContent: vi.fn(() => ({ title: 'Test', body: 'test body' })),
+  isNotificationPermissionGranted: vi.fn(() => false),
+  getNotificationPermission: vi.fn(() => 'default' as NotificationPermission),
+}));
+
+vi.mock('../../utils/notificationTracking', () => ({
+  markNotificationAsShown: vi.fn(),
+}));
+
+vi.mock('../../utils/platform', () => ({
+  isElectron: vi.fn(() => false),
+  getElectronAPI: vi.fn(() => null),
+}));
+
+import { useNotifications } from '../../hooks/useNotifications';
+import {
+  notificationsControllerGetNotificationsQueryKey,
+  notificationsControllerGetUnreadCountQueryKey,
+} from '../../api-client/@tanstack/react-query.gen';
+import type { NotificationListResponseDto, UnreadCountResponseDto } from '../../api-client';
+import {
+  createTestQueryClient,
+  createMockSocket,
+  createTestWrapper,
+} from '../test-utils';
+import type { MockSocket } from '../test-utils';
+
+let queryClient: ReturnType<typeof createTestQueryClient>;
+let mockSocket: MockSocket;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryClient = createTestQueryClient();
+  mockSocket = createMockSocket();
+  mockNavigate.mockReset();
+});
+
+function renderNotifications(options = {}) {
+  return renderHook(() => useNotifications(options), {
+    wrapper: createTestWrapper({ queryClient, socket: mockSocket }),
+  });
+}
+
+function createNotificationPayload(overrides = {}) {
+  return {
+    notificationId: 'notif-1',
+    type: 'MENTION',
+    messageId: 'msg-1',
+    channelId: 'channel-1',
+    communityId: 'community-1',
+    directMessageGroupId: null,
+    authorId: 'author-1',
+    read: false,
+    createdAt: '2025-01-01T00:00:00Z',
+    channelName: 'general',
+    author: { id: 'author-1', username: 'TestUser', avatarUrl: null },
+    message: {
+      id: 'msg-1',
+      spans: [{ type: 'PLAINTEXT', text: 'Hello @you' }],
+    },
+    ...overrides,
+  };
+}
+
+function seedNotificationsCache(notifications: NotificationListResponseDto['notifications'] = []) {
+  const key = notificationsControllerGetNotificationsQueryKey();
+  queryClient.setQueryData(key, {
+    notifications,
+    total: notifications.length,
+    unreadCount: notifications.filter((n) => !n.read).length,
+  } satisfies NotificationListResponseDto);
+}
+
+function seedUnreadCountCache(count: number) {
+  const key = notificationsControllerGetUnreadCountQueryKey();
+  queryClient.setQueryData(key, { count } satisfies UnreadCountResponseDto);
+}
+
+describe('useNotifications', () => {
+  describe('event registration', () => {
+    it('registers WebSocket event handlers on mount', () => {
+      renderNotifications();
+
+      expect(mockSocket.on).toHaveBeenCalledWith('newNotification', expect.any(Function));
+      expect(mockSocket.on).toHaveBeenCalledWith('notificationRead', expect.any(Function));
+      expect(mockSocket.on).toHaveBeenCalledWith('connect', expect.any(Function));
+    });
+
+    it('unregisters event handlers on unmount', () => {
+      const { unmount } = renderNotifications();
+      unmount();
+
+      expect(mockSocket.off).toHaveBeenCalledWith('newNotification', expect.any(Function));
+      expect(mockSocket.off).toHaveBeenCalledWith('notificationRead', expect.any(Function));
+      expect(mockSocket.off).toHaveBeenCalledWith('connect', expect.any(Function));
+    });
+  });
+
+  describe('NEW_NOTIFICATION', () => {
+    it('prepends notification to list cache', async () => {
+      const key = notificationsControllerGetNotificationsQueryKey();
+      seedNotificationsCache([]);
+
+      renderNotifications();
+
+      await act(() => mockSocket.simulateEvent('newNotification', createNotificationPayload()));
+
+      const data = queryClient.getQueryData(key) as NotificationListResponseDto;
+      expect(data.notifications).toHaveLength(1);
+      expect(data.notifications[0].id).toBe('notif-1');
+    });
+
+    it('increments unread count for unread notifications', async () => {
+      const key = notificationsControllerGetUnreadCountQueryKey();
+      seedUnreadCountCache(3);
+
+      renderNotifications();
+
+      await act(() =>
+        mockSocket.simulateEvent('newNotification', createNotificationPayload({ read: false })),
+      );
+
+      const data = queryClient.getQueryData(key) as UnreadCountResponseDto;
+      expect(data.count).toBe(4);
+    });
+
+    it('does not increment unread count for already-read notifications', async () => {
+      const key = notificationsControllerGetUnreadCountQueryKey();
+      seedUnreadCountCache(3);
+
+      renderNotifications();
+
+      await act(() =>
+        mockSocket.simulateEvent('newNotification', createNotificationPayload({ read: true })),
+      );
+
+      const data = queryClient.getQueryData(key) as UnreadCountResponseDto;
+      expect(data.count).toBe(3);
+    });
+
+    it('does not add duplicate notifications', async () => {
+      const key = notificationsControllerGetNotificationsQueryKey();
+      seedNotificationsCache([
+        {
+          id: 'notif-1',
+          userId: '',
+          type: 'MENTION',
+          messageId: 'msg-1',
+          channelId: 'channel-1',
+          communityId: 'community-1',
+          directMessageGroupId: null,
+          authorId: 'author-1',
+          parentMessageId: null,
+          read: false,
+          dismissed: false,
+          createdAt: '2025-01-01T00:00:00Z',
+        },
+      ]);
+
+      renderNotifications();
+
+      await act(() => mockSocket.simulateEvent('newNotification', createNotificationPayload()));
+
+      const data = queryClient.getQueryData(key) as NotificationListResponseDto;
+      expect(data.notifications).toHaveLength(1);
+    });
+
+    it('initializes unread count to 1 when cache is empty', async () => {
+      const key = notificationsControllerGetUnreadCountQueryKey();
+      // No cache seeded
+
+      renderNotifications();
+
+      await act(() =>
+        mockSocket.simulateEvent('newNotification', createNotificationPayload({ read: false })),
+      );
+
+      const data = queryClient.getQueryData(key) as UnreadCountResponseDto;
+      expect(data.count).toBe(1);
+    });
+  });
+
+  describe('NOTIFICATION_READ', () => {
+    it('marks notification as read in list cache', async () => {
+      const key = notificationsControllerGetNotificationsQueryKey();
+      seedNotificationsCache([
+        {
+          id: 'notif-1',
+          userId: '',
+          type: 'MENTION',
+          messageId: 'msg-1',
+          channelId: 'channel-1',
+          communityId: 'community-1',
+          directMessageGroupId: null,
+          authorId: 'author-1',
+          parentMessageId: null,
+          read: false,
+          dismissed: false,
+          createdAt: '2025-01-01T00:00:00Z',
+        },
+      ]);
+
+      renderNotifications();
+
+      await act(() =>
+        mockSocket.simulateEvent('notificationRead', { notificationId: 'notif-1' }),
+      );
+
+      const data = queryClient.getQueryData(key) as NotificationListResponseDto;
+      expect(data.notifications[0].read).toBe(true);
+      expect(data.unreadCount).toBe(0);
+    });
+
+    it('decrements unread count cache', async () => {
+      const key = notificationsControllerGetUnreadCountQueryKey();
+      seedUnreadCountCache(5);
+
+      renderNotifications();
+
+      await act(() =>
+        mockSocket.simulateEvent('notificationRead', { notificationId: 'notif-1' }),
+      );
+
+      const data = queryClient.getQueryData(key) as UnreadCountResponseDto;
+      expect(data.count).toBe(4);
+    });
+
+    it('does not let unread count go below zero', async () => {
+      const key = notificationsControllerGetUnreadCountQueryKey();
+      seedUnreadCountCache(0);
+
+      renderNotifications();
+
+      await act(() =>
+        mockSocket.simulateEvent('notificationRead', { notificationId: 'notif-1' }),
+      );
+
+      const data = queryClient.getQueryData(key) as UnreadCountResponseDto;
+      expect(data.count).toBe(0);
+    });
+  });
+
+  describe('connect (reconnect)', () => {
+    it('invalidates unread count query on reconnect', async () => {
+      seedUnreadCountCache(3);
+      renderNotifications();
+
+      await act(() => mockSocket.simulateEvent('connect'));
+
+      const query = queryClient
+        .getQueryCache()
+        .find({ queryKey: notificationsControllerGetUnreadCountQueryKey() });
+      expect(query?.isStale()).toBe(true);
+    });
+
+    it('invalidates notifications list query on reconnect', async () => {
+      seedNotificationsCache([]);
+      renderNotifications();
+
+      await act(() => mockSocket.simulateEvent('connect'));
+
+      const query = queryClient
+        .getQueryCache()
+        .find({ queryKey: notificationsControllerGetNotificationsQueryKey() });
+      expect(query?.isStale()).toBe(true);
+    });
+  });
+});

--- a/frontend/src/components/Mobile/Navigation/MobileBottomNavigation.tsx
+++ b/frontend/src/components/Mobile/Navigation/MobileBottomNavigation.tsx
@@ -13,6 +13,8 @@ import {
   Notifications as NotificationsIcon,
   Person as PersonIcon,
 } from '@mui/icons-material';
+import { useQuery } from '@tanstack/react-query';
+import { notificationsControllerGetUnreadCountOptions } from '../../../api-client/@tanstack/react-query.gen';
 import { useMobileNavigation, type MobileTab } from './MobileNavigationContext';
 import { LAYOUT_CONSTANTS, TOUCH_TARGETS } from '../../../utils/breakpoints';
 
@@ -25,6 +27,8 @@ import { LAYOUT_CONSTANTS, TOUCH_TARGETS } from '../../../utils/breakpoints';
  */
 export const MobileBottomNavigation: React.FC = () => {
   const { activeTab, setActiveTab } = useMobileNavigation();
+  const { data: unreadData } = useQuery(notificationsControllerGetUnreadCountOptions());
+  const notificationCount = unreadData?.count ?? 0;
 
   const handleChange = (_event: React.SyntheticEvent, newValue: MobileTab) => {
     setActiveTab(newValue);
@@ -87,7 +91,7 @@ export const MobileBottomNavigation: React.FC = () => {
           label="Notifications"
           value="notifications"
           icon={
-            <Badge badgeContent={0} color="error">
+            <Badge badgeContent={notificationCount} color="error">
               <NotificationsIcon />
             </Badge>
           }

--- a/frontend/src/components/Notifications/NotificationBadge.tsx
+++ b/frontend/src/components/Notifications/NotificationBadge.tsx
@@ -4,7 +4,7 @@
  * Displays a badge icon with unread notification count in the app bar.
  * Opens the NotificationCenter drawer when clicked.
  *
- * Uses TanStack Query to fetch the unread count from the server.
+ * Uses TanStack Query cache — kept in sync by useNotifications WebSocket listeners.
  */
 
 import React from 'react';
@@ -18,11 +18,8 @@ interface NotificationBadgeProps {
 }
 
 export const NotificationBadge: React.FC<NotificationBadgeProps> = ({ onClick }) => {
-  // Fetch unread count from server, poll every 30 seconds
-  const { data } = useQuery({
-    ...notificationsControllerGetUnreadCountOptions(),
-    refetchInterval: 30_000,
-  });
+  // Unread count is seeded on mount and kept current via WebSocket cache updates in useNotifications
+  const { data } = useQuery(notificationsControllerGetUnreadCountOptions());
 
   const unreadCount = data?.count ?? 0;
 


### PR DESCRIPTION
## Summary

- **Remove 30s polling** from `NotificationBadge` — the `useNotifications` hook already updates the TanStack Query cache in real-time via WebSocket (`NEW_NOTIFICATION`, `NOTIFICATION_READ` events), making polling redundant and causing perceived 0–30s delays
- **Add reconnect-based query invalidation** to `useNotifications` — on socket reconnect, invalidates both unread count and notifications list queries to catch any events missed during the disconnection gap
- **Wire up real unread count on mobile** — `MobileBottomNavigation` now reads from the same query cache instead of showing hardcoded `badgeContent={0}`
- **Fix missing import** — `getNotificationPermission` was used but never imported in `useNotifications`

Closes #76

## Test plan

- [x] `NotificationBadge` tests (5): renders count from cache, no polling, click handler, 99+ cap
- [x] `useNotifications` tests (12): event registration/cleanup, cache updates for new/read notifications, deduplication, reconnect invalidation
- [x] `MobileBottomNavigation` tests (4): renders all tabs, real badge count, tab switching
- [ ] Manual: send @mention from another tab → badge updates instantly (no 30s delay)
- [ ] Manual: check mobile bottom nav shows notification count
- [ ] Manual: disconnect/reconnect network → badge catches up

🤖 Generated with [Claude Code](https://claude.com/claude-code)