### PR TITLE
feat: MkDocs Material documentation site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,28 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs-site/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r docs-site/requirements.txt
+
+      - name: Build and deploy
+        run: cd docs-site && mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+
+# MkDocs build output
+docs-site/site/

--- a/docs-site/docs/CNAME
+++ b/docs-site/docs/CNAME
@@ -1,0 +1,1 @@
+docs.krakenchat.app

--- a/docs-site/docs/contributing/index.md
+++ b/docs-site/docs/contributing/index.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Thanks for your interest in contributing to Kraken! Whether it's a bug report, feature request, or code contribution, every bit helps.
+
+## Ways to contribute
+
+- **Report bugs** — Open a [GitHub issue](https://github.com/krakenchat/kraken/issues) with reproduction steps
+- **Suggest features** — Open a discussion or issue describing what you'd like to see
+- **Submit code** — Fix a bug, implement a feature, or improve documentation
+- **Improve docs** — Fix typos, clarify instructions, or add missing guides
+
+## Getting started
+
+1. **Fork** the repository on GitHub
+2. **Clone** your fork locally
+3. **Set up** the [development environment](development-setup.md)
+4. **Create a branch** for your changes
+5. **Make your changes** following the patterns in the codebase
+6. **Test** your changes — run the test suite and verify manually
+7. **Submit a pull request** against the `main` branch
+
+## Pull request guidelines
+
+- Keep PRs focused — one feature or fix per PR
+- Write descriptive commit messages
+- Include tests for new features and bug fixes
+- Make sure existing tests pass before submitting
+- Update documentation if your changes affect user-facing behavior
+
+## Code style
+
+- **Backend**: TypeScript with NestJS conventions, ESLint + Prettier
+- **Frontend**: TypeScript with React, ESLint + Prettier
+- Run `docker compose run --rm backend npm run lint` and `docker compose run --rm frontend npm run lint` before submitting
+
+## Reporting issues
+
+When reporting a bug, include:
+
+- Steps to reproduce
+- Expected vs actual behavior
+- Browser/OS/Docker version
+- Relevant logs (`docker-compose logs backend` or browser console)
+
+## Legal
+
+By contributing to Kraken, you agree that your contribution may be included in both open-source (AGPLv3) and commercial distributions of Kraken.
+
+## Questions?
+
+Open a [GitHub issue](https://github.com/krakenchat/kraken/issues) or start a discussion — we're happy to help.

--- a/docs-site/docs/deployment/docker-compose.md
+++ b/docs-site/docs/deployment/docker-compose.md
@@ -1,0 +1,166 @@
+# Self-Hosting with Docker Compose
+
+This guide covers deploying Kraken in production using Docker Compose. For Kubernetes deployments, see the [Helm chart documentation](https://github.com/krakenchat/kraken/tree/main/helm/kraken).
+
+## Prerequisites
+
+- **Docker** (v20+) and **Docker Compose** (v2+)
+- A server with at least **2 GB RAM** and **10 GB disk**
+- A domain name (optional but recommended for HTTPS)
+- A [LiveKit](https://livekit.io/) server (for voice/video — can be configured later)
+
+## Architecture overview
+
+Docker Compose runs four services:
+
+```mermaid
+graph LR
+    Client[Browser] --> Frontend[Frontend<br/>React + Nginx<br/>:5173]
+    Frontend --> Backend[Backend<br/>NestJS<br/>:3000]
+    Client --> Backend
+    Backend --> MongoDB[(MongoDB<br/>:27017)]
+    Backend --> Redis[(Redis<br/>:6379)]
+    Backend --> LiveKit[LiveKit Server]
+```
+
+## Deployment steps
+
+### 1. Clone and configure
+
+```bash
+git clone https://github.com/krakenchat/kraken.git
+cd kraken
+cp backend/env.sample backend/.env
+```
+
+Edit `backend/.env` with production values:
+
+```env
+# Database
+MONGODB_URL=mongodb://mongo:27017/kraken?replicaSet=rs0&retryWrites=true&w=majority&directConnection=true
+
+# Generate strong secrets — never use defaults!
+JWT_SECRET=<output of: openssl rand -base64 32>
+JWT_REFRESH_SECRET=<output of: openssl rand -base64 32>
+
+# Redis
+REDIS_HOST=redis
+
+# LiveKit (optional)
+LIVEKIT_URL=wss://your-livekit-server.com
+LIVEKIT_API_KEY=your-api-key
+LIVEKIT_API_SECRET=your-api-secret
+```
+
+### 2. Start services
+
+```bash
+docker-compose up -d
+```
+
+### 3. Initialize the database
+
+```bash
+docker compose run --rm backend npm run prisma
+```
+
+### 4. Verify
+
+```bash
+# Check all containers are running
+docker-compose ps
+
+# Check backend logs
+docker-compose logs backend
+
+# Check frontend logs
+docker-compose logs frontend
+```
+
+Visit your server's IP or domain on port 5173 to confirm the frontend loads.
+
+## Production considerations
+
+### Secrets
+
+!!! danger "Change all default secrets"
+    Generate strong random values for **every** secret:
+    ```bash
+    openssl rand -base64 32
+    ```
+
+Never commit `.env` files to version control.
+
+### Reverse proxy and HTTPS
+
+In production, place a reverse proxy (Nginx, Caddy, or Traefik) in front of Kraken to handle TLS termination:
+
+- Proxy `your-domain.com` to the frontend (port 5173)
+- Proxy `your-domain.com/api` to the backend (port 3000)
+- Ensure WebSocket upgrade headers are forwarded for Socket.IO
+
+### Data persistence
+
+Docker Compose uses named volumes for MongoDB and Redis data. These persist across container restarts.
+
+- **Backup MongoDB** regularly: `docker compose exec mongo mongodump --out /backup`
+- **Monitor disk usage** — MongoDB and uploads can grow over time
+
+### Resource limits
+
+For production, consider adding resource limits in a `docker-compose.override.yml`:
+
+```yaml
+services:
+  backend:
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+  frontend:
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+```
+
+### Networking
+
+- **MongoDB** and **Redis** should not be exposed to the public internet
+- Only expose the frontend and backend ports through your reverse proxy
+- Consider using Docker networks to isolate services
+
+## Updating
+
+```bash
+# Pull latest changes
+git pull
+
+# Rebuild and restart
+docker-compose build --no-cache
+docker-compose up -d
+
+# Run any database schema updates
+docker compose run --rm backend npm run prisma
+```
+
+## Kubernetes
+
+For production Kubernetes deployments, Kraken provides an official Helm chart with:
+
+- Bundled or external MongoDB and Redis
+- Ingress with TLS via cert-manager
+- Horizontal Pod Autoscaler
+- Health checks and security contexts
+
+```bash
+helm install kraken oci://ghcr.io/krakenchat/charts/kraken \
+  --set ingress.hosts[0].host=kraken.yourdomain.com \
+  --set livekit.url=wss://your-livekit-server.com \
+  --set livekit.apiKey=YOUR_KEY \
+  --set livekit.apiSecret=YOUR_SECRET \
+  --set secrets.jwtSecret="$(openssl rand -base64 32)" \
+  --set secrets.jwtRefreshSecret="$(openssl rand -base64 32)"
+```
+
+See the [Helm chart README](https://github.com/krakenchat/kraken/tree/main/helm/kraken) for full documentation.

--- a/docs-site/docs/getting-started/configuration.md
+++ b/docs-site/docs/getting-started/configuration.md
@@ -1,0 +1,87 @@
+# Configuration
+
+Kraken is configured through environment variables. The backend reads from `backend/.env` and the frontend from `frontend/.env`.
+
+## Backend environment variables
+
+Copy `backend/env.sample` to `backend/.env` to get started.
+
+### Core
+
+| Variable | Description | Default |
+|----------|------------|---------|
+| `MONGODB_URL` | MongoDB connection string (must include `replicaSet=rs0`) | `mongodb://mongo:27017/kraken?replicaSet=rs0&retryWrites=true&w=majority&directConnection=true` |
+| `JWT_SECRET` | Secret key for signing access tokens | *(must change)* |
+| `JWT_REFRESH_SECRET` | Secret key for signing refresh tokens | *(must change)* |
+| `REDIS_HOST` | Redis hostname | `redis` |
+
+!!! danger "Change the JWT secrets"
+    The default secrets in `env.sample` are placeholders. Always generate strong random values for production:
+    ```bash
+    openssl rand -base64 32
+    ```
+
+### LiveKit (voice/video)
+
+These are optional — voice and video features are disabled if not configured.
+
+| Variable | Description | Example |
+|----------|------------|---------|
+| `LIVEKIT_URL` | LiveKit server WebSocket URL | `wss://your-livekit-server.com` |
+| `LIVEKIT_API_KEY` | LiveKit API key | `your-api-key` |
+| `LIVEKIT_API_SECRET` | LiveKit API secret | `your-api-secret` |
+| `LIVEKIT_WEBHOOK_SECRET` | Secret for verifying LiveKit webhook payloads | `your-webhook-secret` |
+
+### Replay buffer
+
+Configuration for the replay buffer / screen recording feature. Requires LiveKit egress to be set up.
+
+| Variable | Description | Default |
+|----------|------------|---------|
+| `REPLAY_SEGMENTS_PATH` | Backend storage path for replay metadata | `/app/storage/replay-segments` |
+| `REPLAY_EGRESS_OUTPUT_PATH` | LiveKit egress output path (must be accessible by egress pods) | `/out` |
+| `REPLAY_SEGMENT_CLEANUP_AGE_MINUTES` | How long to keep replay segments before cleanup | `20` |
+
+### Push notifications (VAPID)
+
+Web Push notifications require VAPID keys. Each instance needs its own unique key pair.
+
+| Variable | Description | Example |
+|----------|------------|---------|
+| `VAPID_PUBLIC_KEY` | VAPID public key | *(generate with command below)* |
+| `VAPID_PRIVATE_KEY` | VAPID private key | *(generate with command below)* |
+| `VAPID_SUBJECT` | Contact email for VAPID | `mailto:admin@your-instance.com` |
+
+Generate VAPID keys:
+
+```bash
+docker compose run --rm backend npx web-push generate-vapid-keys
+```
+
+## Frontend environment variables
+
+Copy `frontend/.env.sample` to `frontend/.env`. The defaults work for local Docker development.
+
+| Variable | Description | Default |
+|----------|------------|---------|
+| `VITE_API_URL` | Backend API URL (Vite proxies this in dev; nginx proxies in production) | `/api` |
+| `VITE_WS_URL` | WebSocket URL for Socket.IO | `http://localhost:3000` |
+
+### Telemetry (optional)
+
+| Variable | Description |
+|----------|------------|
+| `VITE_TELEMETRY_ENDPOINT` | OpenObserve instance URL |
+| `VITE_TELEMETRY_CLIENT_TOKEN` | OpenObserve client token |
+| `VITE_TELEMETRY_ORG_ID` | OpenObserve organization ID |
+| `VITE_APP_VERSION` | App version reported to telemetry |
+
+Leave telemetry variables blank to disable.
+
+## Production considerations
+
+- **JWT secrets** — Use long, random strings. Never reuse across environments.
+- **MongoDB** — Use a replica set with authentication enabled. Restrict network access.
+- **Redis** — Enable authentication and restrict network access.
+- **HTTPS** — Always use TLS in production. Configure via your reverse proxy or Kubernetes ingress.
+- **VAPID keys** — Generate once per instance and keep stable. Changing them invalidates existing push subscriptions.

--- a/docs-site/docs/getting-started/first-run.md
+++ b/docs-site/docs/getting-started/first-run.md
@@ -1,0 +1,48 @@
+# First Run
+
+After [installing](installation.md) Kraken, follow these steps to set up your instance.
+
+## 1. Register your account
+
+Open [http://localhost:5173](http://localhost:5173) and create a new account. The first user registered on a fresh instance can be promoted to instance admin.
+
+## 2. Create a community
+
+1. Click the **+** button in the sidebar
+2. Enter a community name and optional description
+3. Click **Create**
+
+Your new community appears in the sidebar — similar to a Discord server.
+
+## 3. Create channels
+
+Inside your community:
+
+1. Click the **+** next to the channel list
+2. Choose a channel type:
+    - **Text** — for messaging
+    - **Voice** — for voice and video calls (requires [LiveKit configuration](configuration.md#livekit-voicevideo))
+3. Name the channel and click **Create**
+
+## 4. Invite others
+
+1. Open your community settings
+2. Go to the **Invites** section
+3. Create an invite link
+4. Share the link with others — they can register and join your community
+
+## 5. Start chatting
+
+- Send messages in text channels with mentions, reactions, and file attachments
+- Join voice channels for real-time audio and video (if LiveKit is configured)
+- Use direct messages for private conversations
+
+## Optional: Set up voice and video
+
+If you haven't configured LiveKit yet, voice channels will be visible but non-functional. See the [LiveKit setup instructions](installation.md#voice-and-video-optional) to enable voice and video calls, including screen sharing and replay buffer features.
+
+## Next steps
+
+- [Configuration](configuration.md) — Tune environment variables
+- [Deployment](../deployment/docker-compose.md) — Self-host in production
+- [Contributing](../contributing/index.md) — Help improve Kraken

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -1,0 +1,142 @@
+# Installation
+
+Get Kraken running locally with Docker Compose. This is the fastest way to start — all services (backend, frontend, MongoDB, Redis) are managed for you.
+
+## Prerequisites
+
+- **[Docker](https://docs.docker.com/get-docker/)** (v20+) and **Docker Compose** (v2+)
+- **[Git](https://git-scm.com/)**
+
+## Quick start
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/krakenchat/kraken.git
+cd kraken
+```
+
+### 2. Configure environment
+
+```bash
+cp backend/env.sample backend/.env
+```
+
+Edit `backend/.env` and **change the JWT secrets**:
+
+```env
+JWT_SECRET=replace-with-a-long-random-string
+JWT_REFRESH_SECRET=replace-with-a-different-long-random-string
+```
+
+!!! warning "Security"
+    Never use the default secrets in production. Generate strong values with `openssl rand -base64 32`.
+
+See the [Configuration](configuration.md) page for the full environment variable reference.
+
+### 3. Start all services
+
+```bash
+docker-compose up
+```
+
+This brings up:
+
+| Service | Description | URL |
+|---------|------------|-----|
+| **Frontend** | React + Vite (hot reload) | [http://localhost:5173](http://localhost:5173) |
+| **Backend** | NestJS API (hot reload) | [http://localhost:3000](http://localhost:3000) |
+| **MongoDB** | Database (replica set) | `localhost:27017` |
+| **Redis** | Cache and pub/sub | `localhost:6379` |
+
+### 4. Initialize the database
+
+On first run, push the Prisma schema to MongoDB:
+
+```bash
+docker compose run --rm backend npm run prisma
+```
+
+This generates the Prisma client and pushes the schema to the database.
+
+### 5. Open Kraken
+
+Visit [http://localhost:5173](http://localhost:5173) in your browser. You're ready to [create your first account](first-run.md).
+
+## Stopping and restarting
+
+```bash
+# Stop all services
+docker-compose down
+
+# Start again (data is persisted in Docker volumes)
+docker-compose up
+
+# Full reset (removes all data)
+docker-compose down -v
+```
+
+## Voice and video (optional)
+
+Kraken uses [LiveKit](https://livekit.io/) for voice and video calls. Without LiveKit configured, everything else works — voice/video features are simply disabled.
+
+To enable voice and video:
+
+1. **Sign up** at [LiveKit Cloud](https://cloud.livekit.io/) or run a [self-hosted LiveKit server](https://docs.livekit.io/home/self-hosting/local/)
+2. **Add credentials** to `backend/.env`:
+    ```env
+    LIVEKIT_URL=wss://your-livekit-server.com
+    LIVEKIT_API_KEY=your-api-key
+    LIVEKIT_API_SECRET=your-api-secret
+    ```
+3. **Configure webhooks** — LiveKit needs to send events back to Kraken for voice presence tracking. Set the webhook URL to `https://your-kraken-domain.com/api/livekit/webhook` and enable these events:
+    - `participant_joined`
+    - `participant_left`
+    - `egress_started`
+    - `egress_updated`
+    - `egress_ended`
+
+See the [Configuration](configuration.md) page for all LiveKit-related variables.
+
+## Troubleshooting
+
+### "Replica set not initialized"
+
+The Docker Compose setup automatically configures the MongoDB replica set. If you see this error, restart the containers:
+
+```bash
+docker-compose down && docker-compose up
+```
+
+### "Port already in use"
+
+Check what's using the port and stop it:
+
+```bash
+lsof -i :3000  # Backend
+lsof -i :5173  # Frontend
+```
+
+### "Prisma client not generated"
+
+Run the Prisma setup again:
+
+```bash
+docker compose run --rm backend npm run prisma
+```
+
+### Containers won't start
+
+Rebuild from scratch:
+
+```bash
+docker-compose down -v
+docker-compose build --no-cache
+docker-compose up
+```
+
+## Next steps
+
+- [Configuration](configuration.md) — Full environment variable reference
+- [First Run](first-run.md) — Create your first user, community, and channels
+- [Development Setup](../contributing/development-setup.md) — Set up for contributing

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -1,0 +1,69 @@
+---
+hide:
+  - navigation
+---
+
+# Kraken
+
+**Self-hosted Discord-like voice and text chat.**
+
+Kraken is an open-source communication platform that gives you full control over your data. Built with a modern stack — NestJS, React, MongoDB, and LiveKit — it provides real-time messaging, voice and video calls, and community management out of the box.
+
+---
+
+## Features
+
+- **Real-time messaging** — WebSocket-powered text channels with mentions, reactions, attachments, and threads
+- **Voice & video calls** — Powered by [LiveKit](https://livekit.io/) with screen sharing and replay buffer support
+- **Communities** — Create servers with text and voice channels, roles, and permissions
+- **Direct messages** — Private conversations and group DMs with file attachments
+- **Role-based access control** — Granular permissions at the instance and community level
+- **Desktop app** — Electron-based desktop client alongside the web interface
+- **Self-hosted** — Run on your own infrastructure with Docker Compose or Kubernetes
+
+---
+
+## Quick links
+
+<div class="grid cards" markdown>
+
+- :material-rocket-launch: **[Installation](getting-started/installation.md)**
+
+    Get Kraken running locally in under 5 minutes with Docker Compose.
+
+- :material-cog: **[Configuration](getting-started/configuration.md)**
+
+    Environment variables reference for backend and frontend.
+
+- :material-server: **[Deployment](deployment/docker-compose.md)**
+
+    Self-host Kraken in production with Docker Compose or Kubernetes.
+
+- :material-account-group: **[Contributing](contributing/index.md)**
+
+    Help improve Kraken — bug reports, features, and code contributions.
+
+</div>
+
+---
+
+## Tech stack
+
+| Layer | Technology |
+|-------|-----------|
+| Backend | [NestJS](https://nestjs.com/) (TypeScript) |
+| Frontend | [React 19](https://react.dev/) + [Vite](https://vitejs.dev/) + [Material UI](https://mui.com/) |
+| Database | [MongoDB](https://www.mongodb.com/) with [Prisma ORM](https://www.prisma.io/) |
+| Real-time | [Socket.IO](https://socket.io/) with Redis adapter |
+| Voice/Video | [LiveKit](https://livekit.io/) |
+| State | [Redux Toolkit](https://redux-toolkit.js.org/) with RTK Query |
+| Auth | JWT with [Passport.js](https://www.passportjs.org/) |
+| Desktop | [Electron](https://www.electronjs.org/) |
+
+---
+
+## License
+
+Kraken is **dual-licensed** under the [AGPLv3](license.md) and a commercial license. Free for everyone — including commercial use — as long as you comply with AGPL terms. A commercial license is available for proprietary deployments.
+
+Contact: licensing {at} krakenchat [dot] app

--- a/docs-site/docs/license.md
+++ b/docs-site/docs/license.md
@@ -1,0 +1,46 @@
+# License
+
+Kraken is **dual-licensed** under the AGPLv3 and a commercial license.
+
+## AGPLv3 (default)
+
+The [GNU Affero General Public License v3](https://www.gnu.org/licenses/agpl-3.0.html) is the default license. It's free for everyone — including commercial use — as long as you comply with its terms. The primary requirement: if you modify and deploy Kraken, you must share your source code.
+
+## Commercial license
+
+A commercial license is available for those who want to keep modifications proprietary or avoid AGPL source-sharing obligations. Contact **licensing {at} krakenchat [dot] app** for details.
+
+---
+
+## Frequently asked questions
+
+**Can I use Kraken for free?**
+:   Yes. Anyone may use Kraken under the AGPLv3, including for commercial purposes, as long as you comply with the AGPL terms (share your source code if you modify and deploy it).
+
+**I'm a student, educator, or non-profit. Do I need a commercial license?**
+:   No. Use under AGPLv3 is free for everyone, including academic and non-profit organizations.
+
+**I want to self-host Kraken for myself, my friends, or my community. Do I need a commercial license?**
+:   No. Personal, hobby, and self-hosted instances — including those you run for free for your own community — do not require a commercial license. Just follow the AGPLv3 terms.
+
+**I want to host Kraken as a free public service. Do I need a commercial license?**
+:   No. Hosting Kraken as a free, open, non-profit community service is allowed under the AGPLv3.
+
+**I want to modify or contribute to Kraken. Do I need a commercial license?**
+:   Contributions and modifications are welcome under the AGPLv3. As long as you release your modified source code per the AGPL terms, no commercial license is needed.
+
+**I want to run Kraken in my startup or SaaS offering. Do I need a commercial license?**
+:   Not necessarily. Businesses can use Kraken under the AGPLv3 — but AGPL requires that you make the complete source code of your deployment (including modifications) available to your users. If you don't want that obligation, you need a commercial license.
+
+**I want to offer Kraken as a paid hosted service. What are my obligations?**
+:   You have two options: (1) comply with the AGPLv3 by making your full service source code available, or (2) purchase a commercial license to keep your source proprietary.
+
+**I want to integrate Kraken into a closed-source or proprietary product.**
+:   The AGPLv3 does not allow this — you would need to open-source the combined work. If you want to keep your product closed-source, you must purchase a commercial license.
+
+**I'm still unsure.**
+:   Email **licensing {at} krakenchat [dot] app** for clarification.
+
+---
+
+See also: [LICENSE](https://github.com/krakenchat/kraken/blob/main/LICENSE.md) | [LICENSE_COM](https://github.com/krakenchat/kraken/blob/main/LICENSE_COM.md)

--- a/docs-site/docs/security.md
+++ b/docs-site/docs/security.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 1.x.x | Yes |
+| < 1.0 | No |
+
+## Reporting a vulnerability
+
+We take security seriously. If you discover a security vulnerability, please report it responsibly.
+
+!!! danger "Do NOT open a public GitHub issue for security vulnerabilities."
+
+### How to report
+
+1. **Email**: Send details to **security@krakenchat.app**
+2. **GitHub Security Advisories**: Use [GitHub's private vulnerability reporting](https://github.com/krakenchat/kraken/security/advisories/new)
+
+### What to include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fixes (optional)
+
+### What to expect
+
+- **Acknowledgment**: Within 48 hours
+- **Initial assessment**: Within 1 week
+- **Resolution timeline**: Depends on severity, typically 30–90 days
+
+## Scope
+
+### In scope
+
+- Kraken backend API
+- Kraken frontend application
+- Electron desktop application
+- Docker images and Helm charts
+- Authentication and authorization flaws
+- Data exposure vulnerabilities
+
+### Out of scope
+
+- Self-hosted instances with modified code
+- Third-party dependencies (report to upstream maintainers)
+- Social engineering attacks
+- Physical security
+
+## Self-hosting security best practices
+
+If you're self-hosting Kraken:
+
+1. **Change all default secrets** in your `.env` and Helm values
+2. **Use HTTPS** with valid TLS certificates
+3. **Keep dependencies updated** — watch for Dependabot alerts
+4. **Restrict network access** to your MongoDB and Redis instances
+5. **Enable authentication** on all database connections
+6. **Regularly backup** your data
+7. **Monitor logs** for suspicious activity
+
+## Acknowledgments
+
+We appreciate security researchers who help keep Kraken safe. Contributors who responsibly disclose vulnerabilities will be acknowledged here (with permission).

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -1,0 +1,84 @@
+site_name: Kraken Docs
+site_url: https://docs.krakenchat.app
+site_description: Documentation for Kraken — self-hosted Discord-like voice and text chat
+repo_url: https://github.com/krakenchat/kraken
+repo_name: krakenchat/kraken
+edit_uri: edit/main/docs-site/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.footer
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: getting-started/installation.md
+      - Configuration: getting-started/configuration.md
+      - First Run: getting-started/first-run.md
+  - Deployment:
+      - Docker Compose: deployment/docker-compose.md
+  - Contributing:
+      - Overview: contributing/index.md
+      - Development Setup: contributing/development-setup.md
+  - Security: security.md
+  - License: license.md
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.snippets
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/krakenchat/kraken
+
+copyright: Copyright &copy; 2025 Kraken Chat

--- a/docs-site/requirements.txt
+++ b/docs-site/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material>=9.5
+mkdocs-minify-plugin>=0.8


### PR DESCRIPTION
## Summary

- Add MkDocs Material documentation site at `docs-site/` for `docs.krakenchat.app`
- 8 core pages: landing, installation, configuration, first run, deployment, contributing, security, license
- GitHub Actions workflow to auto-deploy to `gh-pages` on push to `main`

## Pages

| Page | Source |
|------|--------|
| Landing page | Adapted from README.md |
| Installation | Docker Compose quickstart |
| Configuration | Full env var reference from `env.sample` files |
| First Run | Account, community, channel setup |
| Docker Compose Deployment | Self-hosting guide with production notes |
| Contributing | PR guidelines, code style, legal |
| Development Setup | Docker-first dev workflow, all commands |
| Security | Adapted from SECURITY.md |
| License | Dual AGPL/Commercial FAQ from LICENSE-FAQ.md |

## Post-merge setup (manual)

1. GitHub repo Settings → Pages → Source: `gh-pages` branch
2. Set custom domain: `docs.krakenchat.app`
3. Enable "Enforce HTTPS"
4. DNS CNAME record: `docs` → `krakenchat.github.io`

## Local preview

```bash
docker run --rm -it -p 8000:8000 -v ${PWD}/docs-site:/docs squidfunk/mkdocs-material
```

## Test plan

- [x] MkDocs build succeeds (`mkdocs build` tested locally via Docker)
- [x] All content verified against actual codebase (docker-compose.yml, package.json scripts, Prisma schema)
- [x] Fixed inaccuracy: removed nonexistent `npm run type-check` frontend command
- [ ] After merge: verify GitHub Action deploys to gh-pages
- [ ] After DNS: verify https://docs.krakenchat.app loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)