### PR TITLE
fix: add missing RBAC actions, fix TrimPreview reset, add deafen indicator

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4565,6 +4565,32 @@
         ]
       }
     },
+    "/api/livekit/channels/{channelId}/mute-participant": {
+      "post": {
+        "operationId": "LivekitController_muteParticipant",
+        "parameters": [
+          {
+            "name": "channelId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Participant muted/unmuted successfully"
+          },
+          "201": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Livekit"
+        ]
+      }
+    },
     "/api/livekit/connection-info": {
       "get": {
         "operationId": "LivekitController_getConnectionInfo",
@@ -5101,6 +5127,46 @@
             }
           }
         ],
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefreshPresenceResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "VoicePresence"
+        ]
+      }
+    },
+    "/api/channels/{channelId}/voice-presence/deafen": {
+      "post": {
+        "operationId": "VoicePresenceController_updateDeafenState",
+        "parameters": [
+          {
+            "name": "channelId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDeafenStateDto"
+              }
+            }
+          }
+        },
         "responses": {
           "201": {
             "description": "",
@@ -7109,7 +7175,8 @@
                 "UNPIN_MESSAGE",
                 "DELETE_ANY_MESSAGE",
                 "VIEW_BAN_LIST",
-                "VIEW_MODERATION_LOGS"
+                "VIEW_MODERATION_LOGS",
+                "MUTE_PARTICIPANT"
               ]
             }
           },
@@ -7250,7 +7317,8 @@
                 "UNPIN_MESSAGE",
                 "DELETE_ANY_MESSAGE",
                 "VIEW_BAN_LIST",
-                "VIEW_MODERATION_LOGS"
+                "VIEW_MODERATION_LOGS",
+                "MUTE_PARTICIPANT"
               ]
             }
           },
@@ -7328,7 +7396,8 @@
                 "UNPIN_MESSAGE",
                 "DELETE_ANY_MESSAGE",
                 "VIEW_BAN_LIST",
-                "VIEW_MODERATION_LOGS"
+                "VIEW_MODERATION_LOGS",
+                "MUTE_PARTICIPANT"
               ]
             }
           },
@@ -8601,6 +8670,10 @@
             "nullable": true
           },
           "directMessageGroupId": {
+            "type": "string",
+            "nullable": true
+          },
+          "communityId": {
             "type": "string",
             "nullable": true
           },
@@ -10144,6 +10217,17 @@
           "success",
           "message",
           "channelId"
+        ]
+      },
+      "UpdateDeafenStateDto": {
+        "type": "object",
+        "properties": {
+          "isDeafened": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "isDeafened"
         ]
       },
       "UserVoiceChannelsResponseDto": {

--- a/backend/src/roles/default-roles.config.ts
+++ b/backend/src/roles/default-roles.config.ts
@@ -88,6 +88,7 @@ export const DEFAULT_COMMUNITY_CREATOR_ROLE: DefaultRoleConfig = {
     RbacActions.CREATE_ALIAS_GROUP_MEMBER,
     RbacActions.DELETE_ALIAS_GROUP_MEMBER,
     RbacActions.READ_ALIAS_GROUP_MEMBER,
+    RbacActions.UPDATE_ALIAS_GROUP_MEMBER,
 
     // Reaction management
     RbacActions.CREATE_REACTION,
@@ -105,6 +106,7 @@ export const DEFAULT_COMMUNITY_CREATOR_ROLE: DefaultRoleConfig = {
     RbacActions.DELETE_ANY_MESSAGE,
     RbacActions.VIEW_BAN_LIST,
     RbacActions.VIEW_MODERATION_LOGS,
+    RbacActions.MUTE_PARTICIPANT,
   ],
 };
 
@@ -210,6 +212,7 @@ export const DEFAULT_ADMIN_ROLE: DefaultRoleConfig = {
     RbacActions.CREATE_ALIAS_GROUP_MEMBER,
     RbacActions.DELETE_ALIAS_GROUP_MEMBER,
     RbacActions.READ_ALIAS_GROUP_MEMBER,
+    RbacActions.UPDATE_ALIAS_GROUP_MEMBER,
 
     // Reaction management
     RbacActions.CREATE_REACTION,
@@ -227,6 +230,7 @@ export const DEFAULT_ADMIN_ROLE: DefaultRoleConfig = {
     RbacActions.DELETE_ANY_MESSAGE,
     RbacActions.VIEW_BAN_LIST,
     RbacActions.VIEW_MODERATION_LOGS,
+    RbacActions.MUTE_PARTICIPANT,
   ],
 };
 
@@ -276,6 +280,7 @@ export const DEFAULT_MODERATOR_ROLE: DefaultRoleConfig = {
     RbacActions.UNPIN_MESSAGE,
     RbacActions.DELETE_ANY_MESSAGE,
     RbacActions.VIEW_BAN_LIST,
+    RbacActions.MUTE_PARTICIPANT,
   ],
 };
 

--- a/backend/src/voice-presence/dto/update-deafen-state.dto.ts
+++ b/backend/src/voice-presence/dto/update-deafen-state.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator';
+
+export class UpdateDeafenStateDto {
+  @IsBoolean()
+  isDeafened: boolean;
+}

--- a/backend/src/voice-presence/voice-presence.controller.spec.ts
+++ b/backend/src/voice-presence/voice-presence.controller.spec.ts
@@ -135,6 +135,51 @@ describe('VoicePresenceController', () => {
       });
     });
   });
+  describe('updateDeafenState', () => {
+    it('should update deafen state and return success', async () => {
+      const channelId = 'channel-123';
+      const body = { isDeafened: true };
+
+      service.updateDeafenState.mockResolvedValue();
+
+      const result = await controller.updateDeafenState(
+        channelId,
+        body,
+        mockRequest,
+      );
+
+      expect(service.updateDeafenState).toHaveBeenCalledWith(
+        channelId,
+        mockUser.id,
+        true,
+      );
+      expect(result).toEqual({
+        success: true,
+        message: 'Deafen state updated to true',
+        channelId,
+      });
+    });
+
+    it('should handle undeafen', async () => {
+      const channelId = 'channel-123';
+      const body = { isDeafened: false };
+
+      service.updateDeafenState.mockResolvedValue();
+
+      const result = await controller.updateDeafenState(
+        channelId,
+        body,
+        mockRequest,
+      );
+
+      expect(service.updateDeafenState).toHaveBeenCalledWith(
+        channelId,
+        mockUser.id,
+        false,
+      );
+      expect(result.message).toBe('Deafen state updated to false');
+    });
+  });
 });
 
 describe('DmVoicePresenceController', () => {

--- a/backend/src/voice-presence/voice-presence.controller.ts
+++ b/backend/src/voice-presence/voice-presence.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Param, UseGuards, Req } from '@nestjs/common';
+import { Controller, Get, Post, Param, Body, UseGuards, Req } from '@nestjs/common';
 import { ApiOkResponse, ApiCreatedResponse } from '@nestjs/swagger';
 import { VoicePresenceService } from './voice-presence.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -18,6 +18,7 @@ import {
   RefreshDmPresenceResponseDto,
   UserVoiceChannelsResponseDto,
 } from './dto/voice-presence-response.dto';
+import { UpdateDeafenStateDto } from './dto/update-deafen-state.dto';
 
 @Controller('channels/:channelId/voice-presence')
 @UseGuards(JwtAuthGuard, RbacGuard)
@@ -102,6 +103,31 @@ export class VoicePresenceController {
     return {
       success: true,
       message: 'Voice presence removed',
+      channelId,
+    };
+  }
+
+  @Post('deafen')
+  @RequiredActions(RbacActions.JOIN_CHANNEL)
+  @RbacResource({
+    type: RbacResourceType.CHANNEL,
+    idKey: 'channelId',
+    source: ResourceIdSource.PARAM,
+  })
+  @ApiCreatedResponse({ type: RefreshPresenceResponseDto })
+  async updateDeafenState(
+    @Param('channelId') channelId: string,
+    @Body() body: UpdateDeafenStateDto,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<RefreshPresenceResponseDto> {
+    await this.voicePresenceService.updateDeafenState(
+      channelId,
+      req.user.id,
+      body.isDeafened,
+    );
+    return {
+      success: true,
+      message: `Deafen state updated to ${body.isDeafened}`,
       channelId,
     };
   }


### PR DESCRIPTION
## Summary

Fixes #149, #151, #155 — three independent bug/feature fixes shipped together.

### #149: MUTE_PARTICIPANT & UPDATE_ALIAS_GROUP_MEMBER missing from default roles
- Added `MUTE_PARTICIPANT` to Community Creator, Admin, and Moderator default roles
- Added `UPDATE_ALIAS_GROUP_MEMBER` to Community Creator and Admin default roles
- These actions were guarded on controllers but missing from all default roles, making them unusable

### #155: TrimPreview resets when new segments load
- Stopped polling (`refetchInterval`) after initial session info load to prevent `maxDuration` changes from destabilizing the timeline
- Decoupled HLS player lifecycle from `maxDuration` (was causing player destruction/recreation)
- Added "Refresh segments" button for manual segment reload when needed

### #151: Deafen has no visual indicator for other users
- **Frontend**: `useParticipantTracks` now parses `isDeafened` from LiveKit participant metadata and listens for `participantMetadataChanged` events
- **Frontend**: `VoiceChannelUserList` reads `isDeafened` from metadata for both local and remote participants (was hardcoded `false`), added `ParticipantMetadataChanged` room listener, both display modes prefer LiveKit state
- **Backend**: Added `updateDeafenState()` service method (Redis update + WebSocket broadcast via `VOICE_CHANNEL_USER_UPDATED`)
- **Backend**: Added `POST channels/:channelId/voice-presence/deafen` endpoint with JWT/RBAC guards
- **Frontend**: `toggleDeafenUnified()` now fire-and-forget calls the deafen endpoint after setting LiveKit metadata
- Regenerated OpenAPI spec and frontend SDK

## Test plan

- [x] Backend default-roles tests pass (27 tests)
- [x] Backend voice-presence tests pass (50 tests, +5 new)
- [x] Frontend voiceActions tests pass (22 tests, +2 new)
- [x] Frontend type-check passes
- [ ] Manual: verify mute participant works for admin/moderator roles
- [ ] Manual: open TrimPreview, verify timeline stays stable while trimming; use refresh button to load new segments
- [ ] Manual: toggle deafen, verify other users see the deafen indicator in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)