### PR TITLE
feat: Discord-style channel unread indicators with mention badges

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -9596,6 +9596,9 @@
           "unreadCount": {
             "type": "number"
           },
+          "mentionCount": {
+            "type": "number"
+          },
           "lastReadMessageId": {
             "type": "string"
           },
@@ -9605,7 +9608,8 @@
           }
         },
         "required": [
-          "unreadCount"
+          "unreadCount",
+          "mentionCount"
         ]
       },
       "LastReadResponseDto": {

--- a/backend/src/read-receipts/dto/read-receipts-response.dto.ts
+++ b/backend/src/read-receipts/dto/read-receipts-response.dto.ts
@@ -11,6 +11,7 @@ export class UnreadCountDto {
   channelId?: string;
   directMessageGroupId?: string;
   unreadCount: number;
+  mentionCount: number;
   lastReadMessageId?: string;
   lastReadAt?: Date;
 }

--- a/frontend/src/hooks/useReadReceipts.ts
+++ b/frontend/src/hooks/useReadReceipts.ts
@@ -23,6 +23,11 @@ export function useReadReceipts() {
     return byId.get(id)?.unreadCount ?? 0;
   };
 
+  const mentionCount = (id?: string): number => {
+    if (!id) return 0;
+    return byId.get(id)?.mentionCount ?? 0;
+  };
+
   const lastReadMessageId = (id?: string): string | undefined => {
     if (!id) return undefined;
     return byId.get(id)?.lastReadMessageId ?? undefined;
@@ -33,5 +38,5 @@ export function useReadReceipts() {
     return (byId.get(id)?.unreadCount ?? 0) > 0;
   };
 
-  return { unreadCount, lastReadMessageId, hasUnread, allUnreadCounts: unreadCounts };
+  return { unreadCount, mentionCount, lastReadMessageId, hasUnread, allUnreadCounts: unreadCounts };
 }


### PR DESCRIPTION
## Summary

Closes #101

- **Backend**: Add `mentionCount` to `UnreadCountDto` by querying the `notification` table for `USER_MENTION`/`SPECIAL_MENTION` types (and `DIRECT_MESSAGE` for DMs). Batch queries via `notification.groupBy` for performance.
- **Frontend real-time**: Increment `unreadCount` on `NEW_MESSAGE` (skipping own messages), increment `mentionCount` on mention-type `NEW_NOTIFICATION`, optimistically clear both on mark-as-read, reset both on `READ_RECEIPT_UPDATED`.
- **Frontend UI**: Discord-style channel sidebar — bold text + left pill indicator for unread channels, red number badge for @mention count, all hidden when channel is selected.

## Changes

| File | Change |
|------|--------|
| `read-receipts-response.dto.ts` | Add `mentionCount: number` field |
| `read-receipts.service.ts` | Query notification table for mention counts (batch + single) |
| `read-receipts.service.spec.ts` | Update all tests for `mentionCount`, add notification mocks |
| `openapi.json` | Regenerated with `mentionCount` |
| `useChannelWebSocket.ts` | Increment unread on NEW_MESSAGE (skip own), reset mentionCount on READ_RECEIPT_UPDATED |
| `useMessageVisibility.ts` | Optimistic cache clear on mark-as-read |
| `useNotifications.ts` | Increment mentionCount on mention-type notifications |
| `useReadReceipts.ts` | Add `mentionCount()` helper |
| `Channel.tsx` | Discord-style unread pill + bold text + mention badge |
| `Channel.test.tsx` | Updated tests for new UI indicators |
| `useChannelWebSocket.test.ts` | +3 tests: unread increment, own-message skip, new entry creation |
| `useNotifications.test.ts` | +7 tests: mention increment by type, read skip, new entry creation |

## Test plan

- [x] Backend: `docker compose run --rm backend npx jest read-receipts` — 34 tests pass
- [x] Frontend: `npx tsc --noEmit` — clean type check
- [x] Frontend: Channel component tests — 13 tests pass
- [x] Frontend: useChannelWebSocket tests — 22 tests pass
- [x] Frontend: useNotifications tests — 18 tests pass
- [ ] Manual: Send messages in channel B while viewing channel A → unread indicator appears on B in real-time
- [ ] Manual: Navigate to channel B → indicators clear immediately
- [ ] Manual: Send @mention in channel B while viewing A → red mention badge appears
- [ ] Manual: Selected channel never shows indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)