### PR TITLE
fix: batch of frontend UI fixes

### DIFF
--- a/frontend/src/components/Channel/ChannelMessageContainer.tsx
+++ b/frontend/src/components/Channel/ChannelMessageContainer.tsx
@@ -214,7 +214,9 @@ const ChannelMessageContainer: React.FC<ChannelMessageContainerProps> = ({
     // Await the send so callers (MessageInput) can catch failures
     const result = await sendMessage(msg);
     if (!result.success) {
-      throw result.error || new Error("Failed to send message");
+      const errorMessage = result.error instanceof Error ? result.error.message : "Failed to send message";
+      showNotification(errorMessage, "error");
+      return;
     }
   };
 

--- a/frontend/src/components/CommunityList/CommunityToggle.tsx
+++ b/frontend/src/components/CommunityList/CommunityToggle.tsx
@@ -11,6 +11,8 @@ import CreateCommunityButton from "./CreateCommunityButton";
 import { useParams, useNavigate } from "react-router-dom";
 import { Tooltip, Button, Avatar } from "@mui/material";
 import ChatIcon from "@mui/icons-material/Chat";
+import { useCanPerformAction } from "../../features/roles/useUserPermissions";
+import { RBAC_ACTIONS } from "../../constants/rbacActions";
 
 export interface Community {
   id: string;
@@ -83,6 +85,7 @@ const CommunityToggle: React.FC<CommunityToggleProps> = ({
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const { communityId } = useParams();
   const navigate = useNavigate();
+  const canCreateCommunity = useCanPerformAction("INSTANCE", undefined, RBAC_ACTIONS.CREATE_COMMUNITY);
 
   const handleCreateCommunity = () => {
     // Navigate to create community page (you may need to adjust this route)
@@ -191,10 +194,12 @@ const CommunityToggle: React.FC<CommunityToggleProps> = ({
                 No communities
               </Box>
             )}
-        <CreateCommunityButton
-          isExpanded={isExpanded}
-          onClick={handleCreateCommunity}
-        />
+        {canCreateCommunity && (
+          <CreateCommunityButton
+            isExpanded={isExpanded}
+            onClick={handleCreateCommunity}
+          />
+        )}
       </CommunityList>
     </Sidebar>
   );

--- a/frontend/src/components/DirectMessages/DirectMessageContainer.tsx
+++ b/frontend/src/components/DirectMessages/DirectMessageContainer.tsx
@@ -141,7 +141,9 @@ const DirectMessageContainer: React.FC<DirectMessageContainerProps> = ({
     // Await the send so callers (MessageInput) can catch failures
     const result = await sendMessage(msg);
     if (!result.success) {
-      throw result.error || new Error("Failed to send message");
+      const errorMessage = result.error instanceof Error ? result.error.message : "Failed to send message";
+      showNotification(errorMessage, "error");
+      return;
     }
   };
 

--- a/frontend/src/components/Friends/FriendRequestList.tsx
+++ b/frontend/src/components/Friends/FriendRequestList.tsx
@@ -60,7 +60,7 @@ const FriendRequestList: React.FC<FriendRequestListProps> = ({
 
   const handleAccept = async (friendshipId: string) => {
     try {
-      await acceptRequest({ path: { friendshipId } });
+      await acceptRequest({ path: { id: friendshipId } });
     } catch (err) {
       logger.error("Failed to accept friend request:", err);
     }
@@ -68,7 +68,7 @@ const FriendRequestList: React.FC<FriendRequestListProps> = ({
 
   const handleDecline = async (friendshipId: string) => {
     try {
-      await declineRequest({ path: { friendshipId } });
+      await declineRequest({ path: { id: friendshipId } });
     } catch (err) {
       logger.error("Failed to decline friend request:", err);
     }
@@ -76,7 +76,7 @@ const FriendRequestList: React.FC<FriendRequestListProps> = ({
 
   const handleCancel = async (friendshipId: string) => {
     try {
-      await cancelRequest({ path: { friendshipId } });
+      await cancelRequest({ path: { id: friendshipId } });
     } catch (err) {
       logger.error("Failed to cancel friend request:", err);
     }

--- a/frontend/src/components/Message/MemberList.tsx
+++ b/frontend/src/components/Message/MemberList.tsx
@@ -47,7 +47,7 @@ const MemberListSkeleton: React.FC = () => (
 );
 
 interface ContextMenuState {
-  anchorEl: HTMLElement | null;
+  position: { top: number; left: number } | null;
   member: MemberData | null;
 }
 
@@ -62,20 +62,20 @@ const MemberList: React.FC<MemberListProps> = ({
   const theme = useTheme();
   const { openProfile } = useUserProfile();
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
-    anchorEl: null,
+    position: null,
     member: null,
   });
 
   const handleContextMenu = (event: React.MouseEvent<HTMLElement>, member: MemberData) => {
     event.preventDefault();
     setContextMenu({
-      anchorEl: event.currentTarget,
+      position: { top: event.clientY, left: event.clientX },
       member,
     });
   };
 
   const handleCloseContextMenu = () => {
-    setContextMenu({ anchorEl: null, member: null });
+    setContextMenu({ position: null, member: null });
   };
 
   if (error) {
@@ -204,14 +204,19 @@ const MemberList: React.FC<MemberListProps> = ({
       </Box>
 
       {/* Moderation Context Menu */}
-      {communityId && contextMenu.member && (
+      {contextMenu.member && (
         <UserModerationMenu
-          anchorEl={contextMenu.anchorEl}
-          open={Boolean(contextMenu.anchorEl)}
+          anchorEl={null}
+          anchorPosition={contextMenu.position ?? undefined}
+          open={Boolean(contextMenu.position)}
           onClose={handleCloseContextMenu}
           targetUserId={contextMenu.member.id}
           targetUserName={contextMenu.member.username}
-          communityId={communityId}
+          communityId={communityId || ""}
+          onViewProfile={() => {
+            handleCloseContextMenu();
+            openProfile(contextMenu.member!.id);
+          }}
         />
       )}
     </Box>

--- a/frontend/src/components/Moderation/UserModerationMenu.tsx
+++ b/frontend/src/components/Moderation/UserModerationMenu.tsx
@@ -25,6 +25,7 @@ import KickConfirmDialog from "./KickConfirmDialog";
 
 export interface UserModerationMenuProps {
   anchorEl: HTMLElement | null;
+  anchorPosition?: { top: number; left: number };
   open: boolean;
   onClose: () => void;
   communityId: string;
@@ -35,6 +36,7 @@ export interface UserModerationMenuProps {
 
 const UserModerationMenu: React.FC<UserModerationMenuProps> = ({
   anchorEl,
+  anchorPosition,
   open,
   onClose,
   communityId,
@@ -76,16 +78,12 @@ const UserModerationMenu: React.FC<UserModerationMenuProps> = ({
     <>
       <Menu
         anchorEl={anchorEl}
+        {...(anchorPosition ? { anchorReference: "anchorPosition" as const, anchorPosition } : {
+          anchorOrigin: { vertical: "bottom" as const, horizontal: "left" as const },
+          transformOrigin: { vertical: "top" as const, horizontal: "left" as const },
+        })}
         open={open}
         onClose={onClose}
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: "left",
-        }}
-        transformOrigin={{
-          vertical: "top",
-          horizontal: "left",
-        }}
       >
         {onViewProfile && (
           <MenuItem onClick={handleViewProfile}>

--- a/frontend/src/components/Voice/VoiceChannelUserList.tsx
+++ b/frontend/src/components/Voice/VoiceChannelUserList.tsx
@@ -49,17 +49,17 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
   const [livekitParticipants, setLivekitParticipants] = useState<VoicePresenceUserDto[]>([]);
   const { openProfile } = useUserProfile();
   const [contextMenu, setContextMenu] = useState<{
-    anchorEl: HTMLElement | null;
+    position: { top: number; left: number } | null;
     user: VoicePresenceUserDto | null;
-  }>({ anchorEl: null, user: null });
+  }>({ position: null, user: null });
 
   const handleContextMenu = (event: React.MouseEvent<HTMLElement>, user: VoicePresenceUserDto) => {
     event.preventDefault();
-    setContextMenu({ anchorEl: event.currentTarget, user });
+    setContextMenu({ position: { top: event.clientY, left: event.clientX }, user });
   };
 
   const handleCloseContextMenu = () => {
-    setContextMenu({ anchorEl: null, user: null });
+    setContextMenu({ position: null, user: null });
   };
 
   // Check if we're connected to this specific channel
@@ -474,8 +474,8 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
         </Box>
         {contextMenu.user && (
           <VoiceUserContextMenu
-            anchorEl={contextMenu.anchorEl}
-            open={Boolean(contextMenu.anchorEl)}
+            anchorPosition={contextMenu.position}
+            open={Boolean(contextMenu.position)}
             onClose={handleCloseContextMenu}
             user={contextMenu.user}
             communityId={channel.communityId}
@@ -497,8 +497,8 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
         </Box>
         {contextMenu.user && (
           <VoiceUserContextMenu
-            anchorEl={contextMenu.anchorEl}
-            open={Boolean(contextMenu.anchorEl)}
+            anchorPosition={contextMenu.position}
+            open={Boolean(contextMenu.position)}
             onClose={handleCloseContextMenu}
             user={contextMenu.user}
             communityId={channel.communityId}
@@ -540,8 +540,8 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
       </Paper>
       {contextMenu.user && (
         <VoiceUserContextMenu
-          anchorEl={contextMenu.anchorEl}
-          open={Boolean(contextMenu.anchorEl)}
+          anchorPosition={contextMenu.position}
+          open={Boolean(contextMenu.position)}
           onClose={handleCloseContextMenu}
           user={contextMenu.user}
           communityId={channel.communityId}

--- a/frontend/src/components/Voice/VoiceUserContextMenu.tsx
+++ b/frontend/src/components/Voice/VoiceUserContextMenu.tsx
@@ -48,7 +48,7 @@ function setStoredVolume(userId: string, volume: number): void {
 }
 
 interface VoiceUserContextMenuProps {
-  anchorEl: HTMLElement | null;
+  anchorPosition: { top: number; left: number } | null;
   open: boolean;
   onClose: () => void;
   user: VoicePresenceUserDto;
@@ -57,7 +57,7 @@ interface VoiceUserContextMenuProps {
 }
 
 const VoiceUserContextMenu: React.FC<VoiceUserContextMenuProps> = ({
-  anchorEl,
+  anchorPosition,
   open,
   onClose,
   user,
@@ -183,11 +183,10 @@ const VoiceUserContextMenu: React.FC<VoiceUserContextMenuProps> = ({
   return (
     <>
       <Menu
-        anchorEl={anchorEl}
+        anchorReference="anchorPosition"
+        anchorPosition={anchorPosition ?? undefined}
         open={open}
         onClose={onClose}
-        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-        transformOrigin={{ vertical: "top", horizontal: "left" }}
       >
         <MenuItem onClick={handleViewProfile}>
           <ListItemIcon>

--- a/frontend/src/utils/SocketProvider.tsx
+++ b/frontend/src/utils/SocketProvider.tsx
@@ -6,6 +6,7 @@ import {
   ServerToClientEvents,
   ClientToServerEvents,
 } from "./SocketContext";
+import { getAccessToken } from "./tokenService";
 import { logger } from "./logger";
 
 const MAX_RETRY_COUNT = 3;
@@ -45,10 +46,18 @@ export function SocketProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
-  // Initial connection + cleanup
+  // Re-read token on every render to detect login/logout transitions.
+  // After login, HashRouter re-renders SocketProvider, so this picks up
+  // the newly stored token and triggers a connection attempt.
+  const hasToken = Boolean(getAccessToken());
+
+  // Connect when token becomes available; skip when no token (pre-login)
   useEffect(() => {
     mountedRef.current = true;
-    connectSocket(0);
+
+    if (hasToken && !socket) {
+      connectSocket(0);
+    }
 
     return () => {
       mountedRef.current = false;
@@ -57,7 +66,7 @@ export function SocketProvider({ children }: { children: React.ReactNode }) {
         retryTimeoutRef.current = null;
       }
     };
-  }, [connectSocket]);
+  }, [hasToken, socket, connectSocket]);
 
   // Track connection state via socket events
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **Friend requests broken (#164):** `FriendRequestList.tsx` passed `{ friendshipId }` as the path param but the OpenAPI SDK expects `{ id }` — every request 404'd
- **Create Community button visible to all (#187):** `CommunityToggle.tsx` now checks `CREATE_COMMUNITY` permission before rendering the button
- **DM text box wipes on send error (#202):** Replaced `throw` with `showNotification` + `return` in both `DirectMessageContainer` and `ChannelMessageContainer` so typed text is preserved on failure
- **Right-click username shows empty square (#205):** Added `onViewProfile` to `UserModerationMenu` in `MemberList.tsx` so there's always at least one menu item; also switched to `anchorPosition` for mouse-position-based placement
- **Voice user context menu appears in top-left (#160):** Switched `VoiceUserContextMenu` and `VoiceChannelUserList` from `anchorEl` to `anchorPosition` using `event.clientY/clientX`; also applied the same pattern to `MemberList.tsx` for consistency
- **WebSocket "Reconnecting..." stuck on login:** `SocketProvider` now reads the JWT on each render and only attempts connection when a token is available, so it correctly connects after login instead of exhausting retries pre-auth and never recovering

## Test plan

- [ ] Log in as user A, send friend request; accept/decline/cancel from user B — should succeed (no 404)
- [ ] Log in as non-owner without CREATE_COMMUNITY role — button should be hidden
- [ ] Disconnect network, try sending a DM — error notification appears, typed text stays in input
- [ ] Right-click a username in the member list — "View Profile" menu item should appear
- [ ] Right-click a voice channel user — menu appears at mouse position, not top-left
- [ ] Log in fresh — "Reconnecting..." indicator should resolve within a few seconds
- [ ] `tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)