### PR TITLE
fix: add AuthGate to prevent expired token boot hangs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,23 +1,16 @@
 import React, { Suspense, useState } from "react";
-import { Routes, Route, Navigate, useLocation } from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
 import Layout from "./Layout";
 import CssBaseline from "@mui/material/CssBaseline";
 import { CircularProgress, Box } from "@mui/material";
-import { RoomProvider } from "./contexts/RoomContext";
-import { NotificationProvider } from "./contexts/NotificationContext";
-import { AvatarCacheProvider } from "./contexts/AvatarCacheContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
-import { UserProfileProvider } from "./contexts/UserProfileContext";
-import { ThreadPanelProvider } from "./contexts/ThreadPanelContext";
-import { VoiceProvider } from "./contexts/VoiceContext";
-import { useQuery } from "@tanstack/react-query";
-import { onboardingControllerGetStatusOptions } from "./api-client/@tanstack/react-query.gen";
 import AutoUpdater from "./components/Electron/AutoUpdater";
 import { ConnectionWizard } from "./components/Electron/ConnectionWizard";
 import { PWAInstallPrompt } from "./components/PWA/PWAInstallPrompt";
-import { ConnectionStatusBanner } from "./components/ConnectionStatusBanner";
 import { hasServers } from "./utils/serverStorage";
 import { isElectron } from "./utils/platform";
+import { AuthGate } from "./components/AuthGate";
+import { PublicRoute } from "./components/PublicRoute";
 
 // Eager imports - first-paint routes
 import LoginPage from "./pages/LoginPage";
@@ -47,19 +40,9 @@ const CommunityPage = React.lazy(() => import("./pages/CommunityPage"));
 const NotFoundPage = React.lazy(() => import("./pages/NotFoundPage"));
 
 function App() {
-  const location = useLocation();
-  const token = localStorage.getItem("accessToken");
-
   // Check if running in Electron and needs server configuration
   const needsServerSetup = isElectron() && !hasServers();
   const [showWizard, setShowWizard] = useState(needsServerSetup);
-
-  // Check if onboarding is needed - but only make the request if we're not already on the onboarding page
-  const shouldCheckOnboarding = location.pathname !== "/onboarding";
-  const { data: onboardingStatus, isLoading: isCheckingOnboarding } = useQuery({
-    ...onboardingControllerGetStatusOptions(),
-    enabled: shouldCheckOnboarding && !showWizard,
-  });
 
   // Show connection wizard for Electron if no servers configured
   if (showWizard) {
@@ -78,109 +61,58 @@ function App() {
       </ThemeProvider>
     );
   }
-  
-  // Allow access to certain routes without authentication
-  const publicRoutes = ["/login", "/register", "/join", "/onboarding"];
-  const isPublicRoute = publicRoutes.some(route => 
-    location.pathname === route || location.pathname.startsWith(route + "/")
-  );
-  
-  // Show loading spinner while checking onboarding status
-  if (shouldCheckOnboarding && isCheckingOnboarding) {
-    return (
-      <ThemeProvider>
-        <CssBaseline />
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            minHeight: '100vh',
-          }}
-        >
-          <CircularProgress />
-        </Box>
-      </ThemeProvider>
-    );
-  }
-  
-  // Redirect to onboarding if setup is needed
-  if (onboardingStatus?.needsSetup && location.pathname !== "/onboarding") {
-    return (
-      <ThemeProvider>
-        <CssBaseline />
-        <AutoUpdater />
-        <OnboardingPage />
-      </ThemeProvider>
-    );
-  }
-
-  if (!token && !isPublicRoute) {
-    return <Navigate to="/login" replace />;
-  }
 
   return (
     <ThemeProvider>
       <CssBaseline />
       <AutoUpdater />
       <PWAInstallPrompt />
-      <AvatarCacheProvider>
-        <NotificationProvider>
-          <VoiceProvider>
-          {token && !isPublicRoute && <ConnectionStatusBanner />}
-          <RoomProvider>
-            <ThreadPanelProvider>
-            <UserProfileProvider>
-            <Suspense fallback={
-              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
-                <CircularProgress />
-              </Box>
-            }>
-            <Routes>
-              {/* Public routes */}
-              <Route path="/onboarding" element={<OnboardingPage />} />
-              <Route path="/join/:inviteCode" element={<JoinInvitePage />} />
-              <Route path="/login" element={<LoginPage />} />
-              <Route path="/register" element={<RegisterPage />} />
+      <Suspense fallback={
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
+          <CircularProgress />
+        </Box>
+      }>
+        <Routes>
+          {/* Public routes */}
+          <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
+          <Route path="/register" element={<PublicRoute><RegisterPage /></PublicRoute>} />
+          <Route path="/onboarding" element={<OnboardingPage />} />
+          <Route path="/join/:inviteCode" element={<JoinInvitePage />} />
 
-              {/* Authenticated routes */}
-              <Route path="/" element={<Layout />}>
-                <Route index element={<HomePage />} />
-                <Route path="direct-messages" element={<DirectMessagesPage />} />
-                <Route path="friends" element={<FriendsPage />} />
-                <Route path="settings" element={<SettingsPage />} />
+          {/* Authenticated routes — AuthGate validates token + mounts providers */}
+          <Route element={<AuthGate />}>
+            <Route path="/" element={<Layout />}>
+              <Route index element={<HomePage />} />
+              <Route path="direct-messages" element={<DirectMessagesPage />} />
+              <Route path="friends" element={<FriendsPage />} />
+              <Route path="settings" element={<SettingsPage />} />
 
-                {/* Admin routes with dedicated layout */}
-                <Route path="admin" element={<AdminLayout />}>
-                  <Route index element={<AdminDashboard />} />
-                  <Route path="users" element={<AdminUsersPage />} />
-                  <Route path="communities" element={<AdminCommunitiesPage />} />
-                  <Route path="invites" element={<AdminInvitePage />} />
-                  <Route path="roles" element={<AdminRolesPage />} />
-                  <Route path="storage" element={<AdminStoragePage />} />
-                  <Route path="settings" element={<AdminSettingsPage />} />
-                </Route>
-
-                {/* Debug routes (admin only - access check in component) */}
-                <Route path="debug/notifications" element={<NotificationDebugPage />} />
-                <Route path="profile/edit" element={<ProfileEditPage />} />
-                <Route path="profile/:userId" element={<ProfilePage />} />
-                <Route path="community/create" element={<CreateCommunityPage />} />
-                <Route path="community/:communityId">
-                  <Route index element={<CommunityPage />} />
-                  <Route path="edit" element={<EditCommunityPage />} />
-                  <Route path="channel/:channelId" element={<CommunityPage />} />
-                </Route>
-                <Route path="*" element={<NotFoundPage />} />
+              {/* Admin routes with dedicated layout */}
+              <Route path="admin" element={<AdminLayout />}>
+                <Route index element={<AdminDashboard />} />
+                <Route path="users" element={<AdminUsersPage />} />
+                <Route path="communities" element={<AdminCommunitiesPage />} />
+                <Route path="invites" element={<AdminInvitePage />} />
+                <Route path="roles" element={<AdminRolesPage />} />
+                <Route path="storage" element={<AdminStoragePage />} />
+                <Route path="settings" element={<AdminSettingsPage />} />
               </Route>
-            </Routes>
-            </Suspense>
-            </UserProfileProvider>
-            </ThreadPanelProvider>
-          </RoomProvider>
-          </VoiceProvider>
-        </NotificationProvider>
-      </AvatarCacheProvider>
+
+              {/* Debug routes (admin only - access check in component) */}
+              <Route path="debug/notifications" element={<NotificationDebugPage />} />
+              <Route path="profile/edit" element={<ProfileEditPage />} />
+              <Route path="profile/:userId" element={<ProfilePage />} />
+              <Route path="community/create" element={<CreateCommunityPage />} />
+              <Route path="community/:communityId">
+                <Route index element={<CommunityPage />} />
+                <Route path="edit" element={<EditCommunityPage />} />
+                <Route path="channel/:channelId" element={<CommunityPage />} />
+              </Route>
+              <Route path="*" element={<NotFoundPage />} />
+            </Route>
+          </Route>
+        </Routes>
+      </Suspense>
     </ThemeProvider>
   );
 }

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -27,6 +27,7 @@ import { setTelemetryUser, clearTelemetryUser } from "./services/telemetry";
 import { useThemeSync } from "./hooks/useThemeSync";
 import { disconnectSocket } from "./utils/socketSingleton";
 import { clearSavedConnection } from "./features/voice/voiceActions";
+import { clearTokens } from "./utils/tokenService";
 
 const settings = ["My Profile", "Settings", "Logout"];
 
@@ -131,7 +132,7 @@ const Layout: React.FC = () => {
     clearSavedConnection();
     disconnectSocket();
     await logout({});
-    localStorage.removeItem("accessToken");
+    clearTokens();
     clearTelemetryUser();
     navigate("/login");
   };

--- a/frontend/src/__tests__/components/AuthGate.test.tsx
+++ b/frontend/src/__tests__/components/AuthGate.test.tsx
@@ -1,0 +1,538 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../msw/server';
+import { renderWithProviders } from '../test-utils';
+import { AuthGate } from '../../components/AuthGate';
+import { Route, Routes } from 'react-router-dom';
+
+vi.mock('../../api-client/client.gen', async (importOriginal) => {
+  const { createClient, createConfig } = await import('../../api-client/client');
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    client: createClient(createConfig({ baseUrl: 'http://localhost:3000' })),
+  };
+});
+
+// Track whether SocketProvider mounted — this is the key invariant
+// (no socket connection should happen without validated auth)
+let socketProviderMounted = false;
+
+vi.mock('../../utils/SocketProvider', () => ({
+  SocketProvider: ({ children }: { children: React.ReactNode }) => {
+    socketProviderMounted = true;
+    return <div data-testid="socket-provider">{children}</div>;
+  },
+}));
+
+// Mock remaining providers to simplify tests
+vi.mock('../../contexts/AvatarCacheContext', () => ({
+  AvatarCacheProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../contexts/VoiceContext', () => ({
+  VoiceProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../contexts/RoomContext', () => ({
+  RoomProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../contexts/ThreadPanelContext', () => ({
+  ThreadPanelProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../contexts/UserProfileContext', () => ({
+  UserProfileProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../components/ConnectionStatusBanner', () => ({
+  ConnectionStatusBanner: () => null,
+}));
+
+const BASE_URL = 'http://localhost:3000';
+
+/** Helper: create a fake JWT with a given exp */
+function makeJwt(exp: number): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = btoa(JSON.stringify({ exp, sub: 'user1' }));
+  return `${header}.${body}.fakesig`;
+}
+
+function validToken() {
+  return makeJwt(Math.floor(Date.now() / 1000) + 3600);
+}
+
+function expiredToken() {
+  return makeJwt(Math.floor(Date.now() / 1000) - 60);
+}
+
+function soonExpiringToken(secondsRemaining: number) {
+  return makeJwt(Math.floor(Date.now() / 1000) + secondsRemaining);
+}
+
+/** Standard: onboarding check passes, no setup needed */
+function mockOnboardingOk() {
+  server.use(
+    http.get(`${BASE_URL}/api/onboarding/status`, () =>
+      HttpResponse.json({ needsSetup: false }),
+    ),
+  );
+}
+
+function renderAuthGate(initialRoute = '/') {
+  return renderWithProviders(
+    <Routes>
+      <Route element={<AuthGate />}>
+        <Route path="/" element={<div data-testid="home">Home</div>} />
+        <Route path="/community/:communityId/channel/:channelId" element={<div data-testid="channel">Channel Page</div>} />
+        <Route path="/settings" element={<div data-testid="settings">Settings</div>} />
+      </Route>
+      <Route path="/login" element={<div data-testid="login">Login Page</div>} />
+      <Route path="/onboarding" element={<div data-testid="onboarding">Onboarding Page</div>} />
+    </Routes>,
+    { routerProps: { initialEntries: [initialRoute] } },
+  );
+}
+
+describe('AuthGate', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    socketProviderMounted = false;
+  });
+
+  // ─── Loading State ─────────────────────────────────────────────
+
+  describe('loading state', () => {
+    it('shows loading spinner with "Connecting..." text while onboarding check is in flight', () => {
+      server.use(
+        http.get(`${BASE_URL}/api/onboarding/status`, () => new Promise(() => {})),
+      );
+
+      renderAuthGate();
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.getByText('Connecting...')).toBeInTheDocument();
+    });
+
+    it('does not render authenticated content while loading', () => {
+      server.use(
+        http.get(`${BASE_URL}/api/onboarding/status`, () => new Promise(() => {})),
+      );
+
+      localStorage.setItem('accessToken', validToken());
+      renderAuthGate();
+
+      expect(screen.queryByTestId('home')).not.toBeInTheDocument();
+    });
+
+    it('does not mount SocketProvider while loading', () => {
+      server.use(
+        http.get(`${BASE_URL}/api/onboarding/status`, () => new Promise(() => {})),
+      );
+
+      localStorage.setItem('accessToken', validToken());
+      renderAuthGate();
+
+      expect(socketProviderMounted).toBe(false);
+    });
+  });
+
+  // ─── Onboarding ────────────────────────────────────────────────
+
+  describe('onboarding redirect', () => {
+    it('redirects to /onboarding when setup is needed', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/onboarding/status`, () =>
+          HttpResponse.json({ needsSetup: true }),
+        ),
+      );
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('onboarding')).toBeInTheDocument();
+      });
+    });
+
+    it('redirects to /onboarding even if a valid token exists', async () => {
+      localStorage.setItem('accessToken', validToken());
+
+      server.use(
+        http.get(`${BASE_URL}/api/onboarding/status`, () =>
+          HttpResponse.json({ needsSetup: true }),
+        ),
+      );
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('onboarding')).toBeInTheDocument();
+      });
+    });
+
+    it('does not mount SocketProvider when redirecting to onboarding', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/onboarding/status`, () =>
+          HttpResponse.json({ needsSetup: true }),
+        ),
+      );
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('onboarding')).toBeInTheDocument();
+      });
+      expect(socketProviderMounted).toBe(false);
+    });
+
+    it('falls through to token check when onboarding API returns a network error', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/onboarding/status`, () => HttpResponse.error()),
+      );
+
+      // No token → should end up at login, not stuck loading
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('login')).toBeInTheDocument();
+      });
+    });
+
+    it('falls through to authenticated state when onboarding API returns 500 but token is valid', async () => {
+      localStorage.setItem('accessToken', validToken());
+
+      server.use(
+        http.get(`${BASE_URL}/api/onboarding/status`, () =>
+          HttpResponse.json({ error: 'Internal Server Error' }, { status: 500 }),
+        ),
+      );
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('home')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ─── Unauthenticated ──────────────────────────────────────────
+
+  describe('unauthenticated redirect', () => {
+    it('redirects to /login when no token is present', async () => {
+      mockOnboardingOk();
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('login')).toBeInTheDocument();
+      });
+    });
+
+    it('does not mount SocketProvider when redirecting to login', async () => {
+      mockOnboardingOk();
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('login')).toBeInTheDocument();
+      });
+      expect(socketProviderMounted).toBe(false);
+    });
+
+    it('redirects deep routes (e.g. /community/.../channel/...) to /login when no token', async () => {
+      mockOnboardingOk();
+      renderAuthGate('/community/abc/channel/xyz');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('login')).toBeInTheDocument();
+      });
+    });
+
+    it('redirects /settings to /login when no token', async () => {
+      mockOnboardingOk();
+      renderAuthGate('/settings');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('login')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ─── Valid Token ───────────────────────────────────────────────
+
+  describe('valid token', () => {
+    it('renders authenticated content when token is valid', async () => {
+      localStorage.setItem('accessToken', validToken());
+      mockOnboardingOk();
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('home')).toBeInTheDocument();
+      });
+    });
+
+    it('mounts SocketProvider when authenticated', async () => {
+      localStorage.setItem('accessToken', validToken());
+      mockOnboardingOk();
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('home')).toBeInTheDocument();
+      });
+      expect(socketProviderMounted).toBe(true);
+      expect(screen.getByTestId('socket-provider')).toBeInTheDocument();
+    });
+
+    it('gates nested child routes — /community/:id/channel/:id', async () => {
+      localStorage.setItem('accessToken', validToken());
+      mockOnboardingOk();
+
+      renderAuthGate('/community/abc/channel/xyz');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('channel')).toBeInTheDocument();
+      });
+    });
+
+    it('gates /settings route', async () => {
+      localStorage.setItem('accessToken', validToken());
+      mockOnboardingOk();
+
+      renderAuthGate('/settings');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('settings')).toBeInTheDocument();
+      });
+    });
+
+    it('does not trigger token refresh when token is still valid', async () => {
+      localStorage.setItem('accessToken', validToken());
+      mockOnboardingOk();
+
+      let refreshCalled = false;
+      server.use(
+        http.post(`${BASE_URL}/api/auth/refresh`, () => {
+          refreshCalled = true;
+          return HttpResponse.json({ accessToken: validToken() });
+        }),
+      );
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('home')).toBeInTheDocument();
+      });
+      expect(refreshCalled).toBe(false);
+    });
+  });
+
+  // ─── Legacy Token Formats ─────────────────────────────────────
+
+  describe('legacy token formats (backwards compatibility)', () => {
+    it('authenticates with JSON-encoded string format (legacy LoginPage bug)', async () => {
+      // Old code did: localStorage.setItem('accessToken', JSON.stringify(token))
+      const token = validToken();
+      localStorage.setItem('accessToken', JSON.stringify(token));
+      mockOnboardingOk();
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('home')).toBeInTheDocument();
+      });
+    });
+
+    it('authenticates with { value: token } format (legacy setCachedItem)', async () => {
+      // Old code used setCachedItem which stored: { value: token }
+      const token = validToken();
+      localStorage.setItem('accessToken', JSON.stringify({ value: token }));
+      mockOnboardingOk();
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('home')).toBeInTheDocument();
+      });
+    });
+
+    it('redirects to /login when legacy-format token is expired', async () => {
+      const token = expiredToken();
+      localStorage.setItem('accessToken', JSON.stringify(token));
+      mockOnboardingOk();
+      server.use(
+        http.post(`${BASE_URL}/api/auth/refresh`, () =>
+          HttpResponse.json({ message: 'Expired' }, { status: 401 }),
+        ),
+      );
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('login')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ─── Expired Token + Refresh ──────────────────────────────────
+
+  describe('expired token refresh flow', () => {
+    it('refreshes an expired token and authenticates on success', async () => {
+      localStorage.setItem('accessToken', expiredToken());
+
+      const freshToken = validToken();
+      mockOnboardingOk();
+      server.use(
+        http.post(`${BASE_URL}/api/auth/refresh`, () =>
+          HttpResponse.json({ accessToken: freshToken }),
+        ),
+      );
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('home')).toBeInTheDocument();
+      });
+      expect(localStorage.getItem('accessToken')).toBe(freshToken);
+    });
+
+    it('triggers refresh for token expiring within 30s buffer', async () => {
+      // Token expires in 10 seconds — within the 30s buffer
+      localStorage.setItem('accessToken', soonExpiringToken(10));
+
+      const freshToken = validToken();
+      mockOnboardingOk();
+      server.use(
+        http.post(`${BASE_URL}/api/auth/refresh`, () =>
+          HttpResponse.json({ accessToken: freshToken }),
+        ),
+      );
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('home')).toBeInTheDocument();
+      });
+      expect(localStorage.getItem('accessToken')).toBe(freshToken);
+    });
+
+    it('does NOT trigger refresh for token expiring in 31+ seconds', async () => {
+      // Token expires in 60 seconds — outside the 30s buffer
+      localStorage.setItem('accessToken', soonExpiringToken(60));
+      mockOnboardingOk();
+
+      let refreshCalled = false;
+      server.use(
+        http.post(`${BASE_URL}/api/auth/refresh`, () => {
+          refreshCalled = true;
+          return HttpResponse.json({ accessToken: validToken() });
+        }),
+      );
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('home')).toBeInTheDocument();
+      });
+      expect(refreshCalled).toBe(false);
+    });
+
+    it('redirects to /login when refresh returns 401', async () => {
+      localStorage.setItem('accessToken', expiredToken());
+
+      mockOnboardingOk();
+      server.use(
+        http.post(`${BASE_URL}/api/auth/refresh`, () =>
+          HttpResponse.json({ message: 'Invalid' }, { status: 401 }),
+        ),
+      );
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('login')).toBeInTheDocument();
+      });
+    });
+
+    it('clears both access and refresh tokens on failed refresh', async () => {
+      localStorage.setItem('accessToken', expiredToken());
+      localStorage.setItem('refreshToken', 'old-refresh-token');
+
+      mockOnboardingOk();
+      server.use(
+        http.post(`${BASE_URL}/api/auth/refresh`, () =>
+          HttpResponse.json({ message: 'Expired' }, { status: 401 }),
+        ),
+      );
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('login')).toBeInTheDocument();
+      });
+      expect(localStorage.getItem('accessToken')).toBeNull();
+      expect(localStorage.getItem('refreshToken')).toBeNull();
+    });
+
+    it('redirects to /login when refresh returns a network error', async () => {
+      localStorage.setItem('accessToken', expiredToken());
+
+      mockOnboardingOk();
+      server.use(
+        http.post(`${BASE_URL}/api/auth/refresh`, () => HttpResponse.error()),
+      );
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('login')).toBeInTheDocument();
+      });
+      expect(localStorage.getItem('accessToken')).toBeNull();
+    });
+
+    it('does not mount SocketProvider during refresh attempt', async () => {
+      localStorage.setItem('accessToken', expiredToken());
+
+      // Use a delayed response so we can assert during the in-flight state
+      let refreshStarted = false;
+      mockOnboardingOk();
+      server.use(
+        http.post(`${BASE_URL}/api/auth/refresh`, async () => {
+          refreshStarted = true;
+          await new Promise((r) => setTimeout(r, 200));
+          return HttpResponse.json({ accessToken: validToken() });
+        }),
+      );
+
+      renderAuthGate();
+
+      // Wait for refresh to start, then check loading state
+      await waitFor(() => {
+        expect(refreshStarted).toBe(true);
+      });
+      // During refresh, SocketProvider should not be mounted
+      expect(socketProviderMounted).toBe(false);
+      expect(screen.getByText('Connecting...')).toBeInTheDocument();
+
+      // After refresh completes, should be authenticated
+      await waitFor(() => {
+        expect(screen.getByTestId('home')).toBeInTheDocument();
+      });
+      expect(socketProviderMounted).toBe(true);
+    });
+
+    it('does not mount SocketProvider when refresh fails', async () => {
+      localStorage.setItem('accessToken', expiredToken());
+
+      mockOnboardingOk();
+      server.use(
+        http.post(`${BASE_URL}/api/auth/refresh`, () =>
+          HttpResponse.json({ message: 'Expired' }, { status: 401 }),
+        ),
+      );
+
+      renderAuthGate();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('login')).toBeInTheDocument();
+      });
+      expect(socketProviderMounted).toBe(false);
+    });
+  });
+});

--- a/frontend/src/__tests__/components/PublicRoute.test.tsx
+++ b/frontend/src/__tests__/components/PublicRoute.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import { PublicRoute } from '../../components/PublicRoute';
+import { Route, Routes } from 'react-router-dom';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), dev: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  default: { warn: vi.fn(), error: vi.fn(), dev: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+/** Helper: create a fake JWT with a given exp */
+function makeJwt(exp: number): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = btoa(JSON.stringify({ exp, sub: 'user1' }));
+  return `${header}.${body}.fakesig`;
+}
+
+function validToken() {
+  return makeJwt(Math.floor(Date.now() / 1000) + 3600);
+}
+
+function expiredToken() {
+  return makeJwt(Math.floor(Date.now() / 1000) - 60);
+}
+
+function renderPublicRoute(initialRoute = '/login') {
+  return renderWithProviders(
+    <Routes>
+      <Route
+        path="/login"
+        element={
+          <PublicRoute>
+            <div data-testid="login-form">Login Form</div>
+          </PublicRoute>
+        }
+      />
+      <Route path="/" element={<div data-testid="home">Home</div>} />
+    </Routes>,
+    { routerProps: { initialEntries: [initialRoute] } },
+  );
+}
+
+describe('PublicRoute', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders children when no token is present', () => {
+    renderPublicRoute();
+    expect(screen.getByTestId('login-form')).toBeInTheDocument();
+    expect(screen.queryByTestId('home')).not.toBeInTheDocument();
+  });
+
+  it('renders children when token is expired', () => {
+    localStorage.setItem('accessToken', expiredToken());
+    renderPublicRoute();
+    expect(screen.getByTestId('login-form')).toBeInTheDocument();
+    expect(screen.queryByTestId('home')).not.toBeInTheDocument();
+  });
+
+  it('renders children when token is expiring within the 30s buffer', () => {
+    const soonExp = Math.floor(Date.now() / 1000) + 10;
+    localStorage.setItem('accessToken', makeJwt(soonExp));
+    renderPublicRoute();
+    expect(screen.getByTestId('login-form')).toBeInTheDocument();
+  });
+
+  it('redirects to / when user has a valid (non-expired) token', () => {
+    localStorage.setItem('accessToken', validToken());
+    renderPublicRoute();
+    expect(screen.getByTestId('home')).toBeInTheDocument();
+    expect(screen.queryByTestId('login-form')).not.toBeInTheDocument();
+  });
+
+  it('renders children when token is malformed (not a JWT)', () => {
+    localStorage.setItem('accessToken', 'not-a-jwt');
+    renderPublicRoute();
+    expect(screen.getByTestId('login-form')).toBeInTheDocument();
+  });
+
+  it('handles legacy JSON-encoded token format — redirects if valid', () => {
+    // Legacy format: JSON.stringify(token) wraps the JWT in quotes
+    localStorage.setItem('accessToken', JSON.stringify(validToken()));
+    renderPublicRoute();
+    // getAccessToken() unwraps the JSON, isTokenExpired checks inner JWT
+    expect(screen.getByTestId('home')).toBeInTheDocument();
+  });
+
+  it('handles legacy { value: token } format — redirects if valid', () => {
+    localStorage.setItem('accessToken', JSON.stringify({ value: validToken() }));
+    renderPublicRoute();
+    expect(screen.getByTestId('home')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/utils/tokenService.test.ts
+++ b/frontend/src/__tests__/utils/tokenService.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), dev: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  default: { warn: vi.fn(), error: vi.fn(), dev: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+  getAccessToken,
+  setAccessToken,
+  clearTokens,
+  isTokenExpired,
+  getAuthenticatedUrl,
+  onTokenRefreshed,
+  isRefreshing,
+  redirectToLogin,
+} from '../../utils/tokenService';
+import { logger } from '../../utils/logger';
+
+/** Helper: create a fake JWT with a given payload */
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = btoa(JSON.stringify(payload));
+  const sig = 'fakesig';
+  return `${header}.${body}.${sig}`;
+}
+
+describe('tokenService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  // ─── getAccessToken ────────────────────────────────────────────
+
+  describe('getAccessToken', () => {
+    it('returns plain string token (current format)', () => {
+      localStorage.setItem('accessToken', 'plain-tok');
+      expect(getAccessToken()).toBe('plain-tok');
+    });
+
+    it('returns value from JSON string format (backwards compat)', () => {
+      localStorage.setItem('accessToken', JSON.stringify('json-tok'));
+      expect(getAccessToken()).toBe('json-tok');
+    });
+
+    it('returns value from { value: "..." } format (backwards compat)', () => {
+      localStorage.setItem('accessToken', JSON.stringify({ value: 'obj-tok' }));
+      expect(getAccessToken()).toBe('obj-tok');
+    });
+
+    it('returns null when nothing stored', () => {
+      expect(getAccessToken()).toBeNull();
+    });
+
+    it('returns null for empty value key', () => {
+      localStorage.setItem('accessToken', JSON.stringify({ value: '' }));
+      expect(getAccessToken()).toBeNull();
+    });
+
+    it('returns null and logs warning for unexpected object format', () => {
+      localStorage.setItem('accessToken', JSON.stringify({ foo: 'bar' }));
+      expect(getAccessToken()).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Unexpected token format'),
+        expect.anything(),
+      );
+    });
+
+    it('returns null for JSON number', () => {
+      localStorage.setItem('accessToken', JSON.stringify(12345));
+      expect(getAccessToken()).toBeNull();
+    });
+
+    it('returns null for JSON boolean', () => {
+      localStorage.setItem('accessToken', JSON.stringify(true));
+      expect(getAccessToken()).toBeNull();
+    });
+
+    it('returns null for JSON null', () => {
+      localStorage.setItem('accessToken', 'null');
+      expect(getAccessToken()).toBeNull();
+    });
+
+    it('handles a real-looking JWT as a plain string', () => {
+      const jwt = makeJwt({ exp: 99999999999, sub: 'user1' });
+      localStorage.setItem('accessToken', jwt);
+      // JWTs are not valid JSON, so JSON.parse throws, falls through to raw
+      expect(getAccessToken()).toBe(jwt);
+    });
+  });
+
+  // ─── setAccessToken ────────────────────────────────────────────
+
+  describe('setAccessToken', () => {
+    it('stores token as plain string', () => {
+      setAccessToken('my-token');
+      expect(localStorage.getItem('accessToken')).toBe('my-token');
+    });
+
+    it('overwrites previous token', () => {
+      setAccessToken('old');
+      setAccessToken('new');
+      expect(localStorage.getItem('accessToken')).toBe('new');
+    });
+
+    it('roundtrips with getAccessToken', () => {
+      setAccessToken('roundtrip-tok');
+      expect(getAccessToken()).toBe('roundtrip-tok');
+    });
+
+    it('overwrites legacy format and roundtrips correctly', () => {
+      // Start with old JSON format
+      localStorage.setItem('accessToken', JSON.stringify('legacy'));
+      expect(getAccessToken()).toBe('legacy');
+
+      // Overwrite with new plain string format
+      setAccessToken('modern');
+      expect(getAccessToken()).toBe('modern');
+      expect(localStorage.getItem('accessToken')).toBe('modern');
+    });
+  });
+
+  // ─── clearTokens ──────────────────────────────────────────────
+
+  describe('clearTokens', () => {
+    it('removes both accessToken and refreshToken', () => {
+      localStorage.setItem('accessToken', 'at');
+      localStorage.setItem('refreshToken', 'rt');
+      clearTokens();
+      expect(localStorage.getItem('accessToken')).toBeNull();
+      expect(localStorage.getItem('refreshToken')).toBeNull();
+    });
+
+    it('is safe to call when no tokens exist', () => {
+      expect(() => clearTokens()).not.toThrow();
+    });
+
+    it('does not affect other localStorage keys', () => {
+      localStorage.setItem('accessToken', 'at');
+      localStorage.setItem('other', 'value');
+      clearTokens();
+      expect(localStorage.getItem('other')).toBe('value');
+    });
+  });
+
+  // ─── isTokenExpired ────────────────────────────────────────────
+
+  describe('isTokenExpired', () => {
+    it('returns false for a token expiring far in the future', () => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600;
+      const token = makeJwt({ exp: futureExp, sub: 'user1' });
+      expect(isTokenExpired(token)).toBe(false);
+    });
+
+    it('returns true for a token that expired in the past', () => {
+      const pastExp = Math.floor(Date.now() / 1000) - 60;
+      const token = makeJwt({ exp: pastExp, sub: 'user1' });
+      expect(isTokenExpired(token)).toBe(true);
+    });
+
+    it('returns true for a token expiring within the default 30s buffer', () => {
+      const soonExp = Math.floor(Date.now() / 1000) + 10;
+      const token = makeJwt({ exp: soonExp, sub: 'user1' });
+      expect(isTokenExpired(token)).toBe(true);
+    });
+
+    it('returns false for a token within a shorter custom buffer', () => {
+      const soonExp = Math.floor(Date.now() / 1000) + 10;
+      const token = makeJwt({ exp: soonExp, sub: 'user1' });
+      expect(isTokenExpired(token, 5)).toBe(false);
+    });
+
+    it('returns true at exact expiry with buffer=0', () => {
+      const now = Math.floor(Date.now() / 1000);
+      const token = makeJwt({ exp: now, sub: 'user1' });
+      expect(isTokenExpired(token, 0)).toBe(true);
+    });
+
+    it('returns false for token expiring 1s from now with buffer=0', () => {
+      const exp = Math.floor(Date.now() / 1000) + 1;
+      const token = makeJwt({ exp, sub: 'user1' });
+      expect(isTokenExpired(token, 0)).toBe(false);
+    });
+
+    it('returns true for a malformed token (no dots)', () => {
+      expect(isTokenExpired('not-a-jwt')).toBe(true);
+    });
+
+    it('returns true for a token with only 2 parts', () => {
+      expect(isTokenExpired('header.body')).toBe(true);
+    });
+
+    it('returns true for a token with 4 parts', () => {
+      expect(isTokenExpired('a.b.c.d')).toBe(true);
+    });
+
+    it('returns true for a token with no exp claim', () => {
+      const token = makeJwt({ sub: 'user1' });
+      expect(isTokenExpired(token)).toBe(true);
+    });
+
+    it('returns true for a token with exp as string', () => {
+      const token = makeJwt({ exp: 'not-a-number', sub: 'user1' });
+      expect(isTokenExpired(token)).toBe(true);
+    });
+
+    it('returns true for a token with invalid base64 payload', () => {
+      expect(isTokenExpired('header.!!!invalid-base64!!!.sig')).toBe(true);
+    });
+
+    it('returns true for an empty string', () => {
+      expect(isTokenExpired('')).toBe(true);
+    });
+  });
+
+  // ─── getAuthenticatedUrl ───────────────────────────────────────
+
+  describe('getAuthenticatedUrl', () => {
+    it('appends token as query param to relative URL', () => {
+      setAccessToken('my-token');
+      const result = getAuthenticatedUrl('/api/file/123');
+      expect(result).toContain('/api/file/123');
+      expect(result).toContain('token=my-token');
+    });
+
+    it('appends token to absolute URL', () => {
+      setAccessToken('my-token');
+      const result = getAuthenticatedUrl('http://example.com/api/file/123');
+      expect(result).toBe('http://example.com/api/file/123?token=my-token');
+    });
+
+    it('preserves existing query params when appending token', () => {
+      setAccessToken('my-token');
+      const result = getAuthenticatedUrl('/api/file/123?format=mp4');
+      expect(result).toContain('format=mp4');
+      expect(result).toContain('token=my-token');
+    });
+
+    it('does not duplicate token if already in URL', () => {
+      setAccessToken('my-token');
+      const url = '/api/file/123?token=existing';
+      expect(getAuthenticatedUrl(url)).toBe(url);
+    });
+
+    it('returns original URL when no token available', () => {
+      expect(getAuthenticatedUrl('/api/file/123')).toBe('/api/file/123');
+    });
+
+    it('logs warning when no token available', () => {
+      getAuthenticatedUrl('/api/file/123');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('No token available'),
+      );
+    });
+  });
+
+  // ─── onTokenRefreshed ─────────────────────────────────────────
+
+  describe('onTokenRefreshed', () => {
+    it('returns an unsubscribe function', () => {
+      const unsub = onTokenRefreshed(vi.fn());
+      expect(typeof unsub).toBe('function');
+      unsub();
+    });
+
+    it('notifies listener when token is refreshed via setAccessToken flow', () => {
+      // The listener system is internal (notifyTokenRefreshed is called inside performRefresh)
+      // We test the subscribe/unsubscribe API surface here
+      const listener = vi.fn();
+      const unsub = onTokenRefreshed(listener);
+
+      // Listener is not called synchronously
+      expect(listener).not.toHaveBeenCalled();
+
+      unsub();
+    });
+
+    it('does not call listener after unsubscribe', () => {
+      const listener = vi.fn();
+      const unsub = onTokenRefreshed(listener);
+      unsub();
+
+      // Even if we somehow triggered a refresh, the listener shouldn't fire
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── isRefreshing ─────────────────────────────────────────────
+
+  describe('isRefreshing', () => {
+    it('returns false when no refresh is in progress', () => {
+      expect(isRefreshing()).toBe(false);
+    });
+  });
+
+  // ─── redirectToLogin ──────────────────────────────────────────
+
+  describe('redirectToLogin', () => {
+    let originalHash: string;
+
+    beforeEach(() => {
+      originalHash = window.location.hash;
+    });
+
+    afterEach(() => {
+      window.location.hash = originalHash;
+    });
+
+    it('clears tokens', () => {
+      setAccessToken('my-token');
+      localStorage.setItem('refreshToken', 'rt');
+      redirectToLogin();
+      expect(localStorage.getItem('accessToken')).toBeNull();
+      expect(localStorage.getItem('refreshToken')).toBeNull();
+    });
+
+    it('sets window.location.hash to #/login', () => {
+      setAccessToken('my-token');
+      redirectToLogin();
+      expect(window.location.hash).toBe('#/login');
+    });
+
+    it('does not change hash if already on #/login', () => {
+      window.location.hash = '#/login';
+      redirectToLogin();
+      expect(window.location.hash).toBe('#/login');
+    });
+  });
+});

--- a/frontend/src/api-client-config.ts
+++ b/frontend/src/api-client-config.ts
@@ -1,7 +1,6 @@
 import { client } from './api-client/client.gen';
 import { getApiBaseUrl } from './config/env';
-import { getAuthToken } from './utils/auth';
-import { refreshToken, redirectToLogin } from './utils/tokenService';
+import { getAccessToken, refreshToken, redirectToLogin } from './utils/tokenService';
 
 export function configureApiClient() {
   // The generated SDK URLs already include the /api prefix (e.g. /api/auth/login),
@@ -12,7 +11,7 @@ export function configureApiClient() {
   client.setConfig({ baseUrl: clientBaseUrl });
 
   client.interceptors.request.use((request) => {
-    const token = getAuthToken();
+    const token = getAccessToken();
     if (token) {
       request.headers.set('Authorization', `Bearer ${token}`);
     }

--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect } from "react";
+import { Outlet, Navigate } from "react-router-dom";
+import { Box, CircularProgress, Typography } from "@mui/material";
+import { useQuery } from "@tanstack/react-query";
+import { onboardingControllerGetStatusOptions } from "../api-client/@tanstack/react-query.gen";
+import {
+  getAccessToken,
+  isTokenExpired,
+  refreshToken,
+  clearTokens,
+} from "../utils/tokenService";
+import { SocketProvider } from "../utils/SocketProvider";
+import { AvatarCacheProvider } from "../contexts/AvatarCacheContext";
+import { NotificationProvider } from "../contexts/NotificationContext";
+import { VoiceProvider } from "../contexts/VoiceContext";
+import { ConnectionStatusBanner } from "./ConnectionStatusBanner";
+import { RoomProvider } from "../contexts/RoomContext";
+import { ThreadPanelProvider } from "../contexts/ThreadPanelContext";
+import { UserProfileProvider } from "../contexts/UserProfileContext";
+import { logger } from "../utils/logger";
+
+type AuthState = "loading" | "needs-onboarding" | "unauthenticated" | "authenticated";
+
+export function AuthGate() {
+  const [authState, setAuthState] = useState<AuthState>("loading");
+
+  // Phase 1: Onboarding check (no auth required)
+  const {
+    data: onboardingStatus,
+    isLoading: isCheckingOnboarding,
+    isSuccess: onboardingChecked,
+    isError: onboardingCheckFailed,
+  } = useQuery(onboardingControllerGetStatusOptions());
+
+  // Phase 2: Token validation (runs after onboarding check completes)
+  useEffect(() => {
+    // Still checking onboarding
+    if (isCheckingOnboarding) return;
+
+    // Onboarding needed
+    if (onboardingChecked && onboardingStatus?.needsSetup) {
+      setAuthState("needs-onboarding");
+      return;
+    }
+
+    // Onboarding check failed — could be network error on first load.
+    // Fall through to token check so the app doesn't get stuck.
+    // If server is unreachable, authenticated requests will also fail.
+
+    // Onboarding done (or check failed) → validate token
+    if (onboardingChecked || onboardingCheckFailed) {
+      validateToken();
+    }
+  }, [isCheckingOnboarding, onboardingChecked, onboardingCheckFailed, onboardingStatus]);
+
+  async function validateToken() {
+    const token = getAccessToken();
+
+    if (!token) {
+      setAuthState("unauthenticated");
+      return;
+    }
+
+    if (!isTokenExpired(token)) {
+      // Token looks valid — proceed
+      setAuthState("authenticated");
+      return;
+    }
+
+    // Token is expired — attempt refresh
+    logger.dev("[AuthGate] Token expired, attempting refresh...");
+    try {
+      const newToken = await refreshToken();
+      if (newToken) {
+        setAuthState("authenticated");
+      } else {
+        clearTokens();
+        setAuthState("unauthenticated");
+      }
+    } catch {
+      clearTokens();
+      setAuthState("unauthenticated");
+    }
+  }
+
+  if (authState === "loading") {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+          minHeight: "100vh",
+          gap: 2,
+        }}
+      >
+        <CircularProgress />
+        <Typography variant="body2" color="text.secondary">
+          Connecting...
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (authState === "needs-onboarding") {
+    return <Navigate to="/onboarding" replace />;
+  }
+
+  if (authState === "unauthenticated") {
+    return <Navigate to="/login" replace />;
+  }
+
+  // Authenticated — render providers and child routes
+  return (
+    <SocketProvider>
+      <AvatarCacheProvider>
+        <NotificationProvider>
+          <VoiceProvider>
+            <ConnectionStatusBanner />
+            <RoomProvider>
+              <ThreadPanelProvider>
+                <UserProfileProvider>
+                  <Outlet />
+                </UserProfileProvider>
+              </ThreadPanelProvider>
+            </RoomProvider>
+          </VoiceProvider>
+        </NotificationProvider>
+      </AvatarCacheProvider>
+    </SocketProvider>
+  );
+}
+
+export default AuthGate;

--- a/frontend/src/components/Onboarding/CompletionStep.tsx
+++ b/frontend/src/components/Onboarding/CompletionStep.tsx
@@ -22,6 +22,7 @@ import { OnboardingData } from './OnboardingWizard';
 import { useMutation } from '@tanstack/react-query';
 import { onboardingControllerSetupInstanceMutation, authControllerLoginMutation } from '../../api-client/@tanstack/react-query.gen';
 import { logger } from '../../utils/logger';
+import { setAccessToken } from '../../utils/tokenService';
 
 interface CompletionStepProps {
   data: OnboardingData;
@@ -67,7 +68,7 @@ const CompletionStep: React.FC<CompletionStepProps> = ({
           });
 
           // Store the tokens
-          localStorage.setItem('accessToken', JSON.stringify(response.accessToken));
+          setAccessToken(response.accessToken);
           if (response.refreshToken) {
             localStorage.setItem('refreshToken', response.refreshToken);
           }

--- a/frontend/src/components/PublicRoute.tsx
+++ b/frontend/src/components/PublicRoute.tsx
@@ -1,0 +1,18 @@
+import { Navigate } from "react-router-dom";
+import { getAccessToken, isTokenExpired } from "../utils/tokenService";
+
+/**
+ * Wrapper for public routes (/login, /register) that redirects
+ * already-authenticated users to the home page.
+ */
+export function PublicRoute({ children }: { children: React.ReactNode }) {
+  const token = getAccessToken();
+
+  if (token && !isTokenExpired(token)) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+}
+
+export default PublicRoute;

--- a/frontend/src/contexts/RoomContext.tsx
+++ b/frontend/src/contexts/RoomContext.tsx
@@ -3,7 +3,7 @@ import { Room } from "livekit-client";
 import { useVoice } from "./VoiceContext";
 import { RoomContext, RoomContextType } from "./RoomContextDef";
 import { getApiBaseUrl } from "../config/env";
-import { getCachedItem } from "../utils/storage";
+import { getAccessToken } from "../utils/tokenService";
 
 interface RoomProviderProps {
   children: React.ReactNode;
@@ -34,7 +34,7 @@ export const RoomProvider: React.FC<RoomProviderProps> = ({ children }) => {
   // Handle page unload - notify backend before disconnect
   useEffect(() => {
     const handleBeforeUnload = () => {
-      const token = getCachedItem<string>("accessToken");
+      const token = getAccessToken();
       const baseUrl = getApiBaseUrl();
       const channelId = channelIdRef.current;
       const dmGroupId = dmGroupIdRef.current;

--- a/frontend/src/hooks/useAuthenticatedFile.ts
+++ b/frontend/src/hooks/useAuthenticatedFile.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
-import { getCachedItem } from "../utils/storage";
 import { useFileCache } from "../contexts/AvatarCacheContext";
+import { getAccessToken } from "../utils/tokenService";
 import { getApiUrl } from "../config/env";
 import type { FileMetadata } from "../types/message.type";
 
@@ -58,7 +58,7 @@ export const useAuthenticatedFile = (
         if (fetchMetadata) {
           setIsLoadingMetadata(true);
 
-          const token = getCachedItem<string>("accessToken");
+          const token = getAccessToken();
           if (!token) {
             throw new Error("No authentication token found");
           }

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { getCachedItem } from "../utils/storage";
 import { getApiUrl } from "../config/env";
+import { getAccessToken } from "../utils/tokenService";
 
 export type ResourceType =
   | "USER_AVATAR"
@@ -58,7 +58,7 @@ export const useFileUpload = (): UseFileUploadReturn => {
         formData.append("resourceId", options.resourceId || "");
       }
 
-      const token = getCachedItem<string>("accessToken");
+      const token = getAccessToken();
       if (!token) {
         throw new Error("No authentication token found");
       }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,7 +5,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import App from "./App.tsx";
 import { HashRouter } from "react-router-dom";
-import { SocketProvider } from "./utils/SocketProvider";
 import { initTelemetry } from "./services/telemetry";
 import { configureApiClient } from "./api-client-config";
 import { isElectron } from "./utils/platform";
@@ -37,9 +36,7 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <HashRouter>
-        <SocketProvider>
-          <App />
-        </SocketProvider>
+        <App />
       </HashRouter>
     </QueryClientProvider>
   </StrictMode>

--- a/frontend/src/pages/JoinInvitePage.tsx
+++ b/frontend/src/pages/JoinInvitePage.tsx
@@ -13,6 +13,7 @@ import {
 } from "@mui/material";
 import { styled } from "@mui/system";
 import { useParams, useNavigate } from "react-router-dom";
+import { setAccessToken } from "../utils/tokenService";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import {
   inviteControllerGetPublicInviteOptions,
@@ -75,7 +76,7 @@ const JoinInvitePage: React.FC = () => {
       await register({ body: { username, email, password, code: inviteCode } });
 
       const response = await login({ body: { username, password } });
-      localStorage.setItem('accessToken', JSON.stringify(response.accessToken));
+      setAccessToken(response.accessToken);
       if (response.refreshToken) {
         localStorage.setItem('refreshToken', response.refreshToken);
       }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -12,6 +12,7 @@ import { LockOutlined } from "@mui/icons-material";
 import { useMutation } from "@tanstack/react-query";
 import { authControllerLoginMutation } from "../api-client/@tanstack/react-query.gen";
 import { useNavigate, Link } from "react-router-dom";
+import { setAccessToken } from "../utils/tokenService";
 
 const LoginPage: React.FC = () => {
   const [username, setUsername] = useState("");
@@ -24,7 +25,7 @@ const LoginPage: React.FC = () => {
     try {
       const response = await login({ body: { username, password } });
       // Store the access token in localStorage
-      localStorage.setItem('accessToken', JSON.stringify(response.accessToken));
+      setAccessToken(response.accessToken);
 
       // Store refresh token for Electron clients
       if (response.refreshToken) {

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "@mui/material";
 import { styled } from "@mui/system";
 import { useNavigate, Link } from "react-router-dom";
+import { setAccessToken } from "../utils/tokenService";
 import { useMutation } from "@tanstack/react-query";
 import { userControllerRegisterMutation, authControllerLoginMutation } from "../api-client/@tanstack/react-query.gen";
 
@@ -46,7 +47,7 @@ const RegisterPage: React.FC = () => {
     try {
       await register({ body: { username, email, password, code } });
       const response = await login({ body: { username, password } });
-      localStorage.setItem('accessToken', JSON.stringify(response.accessToken));
+      setAccessToken(response.accessToken);
       if (response.refreshToken) {
         localStorage.setItem('refreshToken', response.refreshToken);
       }

--- a/frontend/src/utils/SocketProvider.tsx
+++ b/frontend/src/utils/SocketProvider.tsx
@@ -6,7 +6,6 @@ import {
   ServerToClientEvents,
   ClientToServerEvents,
 } from "./SocketContext";
-import { getAccessToken } from "./tokenService";
 import { logger } from "./logger";
 
 const MAX_RETRY_COUNT = 3;
@@ -46,18 +45,11 @@ export function SocketProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
-  // Re-read token on every render to detect login/logout transitions.
-  // After login, HashRouter re-renders SocketProvider, so this picks up
-  // the newly stored token and triggers a connection attempt.
-  const hasToken = Boolean(getAccessToken());
-
-  // Connect when token becomes available; skip when no token (pre-login)
+  // AuthGate guarantees a valid token before this component mounts,
+  // so we connect immediately.
   useEffect(() => {
     mountedRef.current = true;
-
-    if (hasToken && !socket) {
-      connectSocket(0);
-    }
+    connectSocket(0);
 
     return () => {
       mountedRef.current = false;
@@ -66,7 +58,7 @@ export function SocketProvider({ children }: { children: React.ReactNode }) {
         retryTimeoutRef.current = null;
       }
     };
-  }, [hasToken, socket, connectSocket]);
+  }, [connectSocket]);
 
   // Track connection state via socket events
   useEffect(() => {

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,137 +1,24 @@
 /**
- * Authentication Utilities
+ * Authentication Utilities — Re-export shim
  *
- * Centralized authentication token management to eliminate code duplication
- * across contexts, hooks, and API layers.
+ * All token logic now lives in tokenService.ts. This module re-exports under
+ * the old names so existing consumers continue to work without modification.
  */
 
-import { logger } from './logger';
+export {
+  getAccessToken as getAuthToken,
+  setAccessToken as setAuthToken,
+  clearTokens as clearAuthToken,
+  getAuthenticatedUrl,
+} from "./tokenService";
+
+import { getAccessToken } from "./tokenService";
 
 /**
- * Get the authentication token from localStorage
- *
- * Handles both JSON-encoded and plain string token formats for backwards compatibility.
- * This consolidates the duplicated token parsing logic found in:
- * - contexts/AvatarCacheContext.tsx
- * - hooks/useFileUpload.ts
- * - features/AuthedBaseQuery.ts
- * - utils/socketSingleton.ts
- *
- * @returns The access token string, or null if not found or invalid
- */
-export function getAuthToken(): string | null {
-  try {
-    const tokenRaw = localStorage.getItem('accessToken');
-
-    if (!tokenRaw) {
-      return null;
-    }
-
-    // Try to parse as JSON first (newer format)
-    try {
-      const parsed = JSON.parse(tokenRaw);
-
-      // Handle object format: { value: "token" }
-      if (parsed && typeof parsed === 'object' && 'value' in parsed) {
-        return parsed.value || null;
-      }
-
-      // Handle direct string value
-      if (typeof parsed === 'string') {
-        return parsed;
-      }
-
-      // Unexpected format
-      logger.warn('[Auth] Unexpected token format in localStorage:', typeof parsed);
-      return null;
-    } catch {
-      // Not JSON - treat as plain string (legacy format)
-      return tokenRaw;
-    }
-  } catch (error) {
-    logger.error('[Auth] Error retrieving auth token:', error);
-    return null;
-  }
-}
-
-/**
- * Set the authentication token in localStorage
- *
- * @param token - The token string to store
- */
-export function setAuthToken(token: string): void {
-  try {
-    // Store as plain string for consistency
-    localStorage.setItem('accessToken', token);
-  } catch (error) {
-    logger.error('[Auth] Error storing auth token:', error);
-  }
-}
-
-/**
- * Remove the authentication token from localStorage
- */
-export function clearAuthToken(): void {
-  try {
-    localStorage.removeItem('accessToken');
-  } catch (error) {
-    logger.error('[Auth] Error clearing auth token:', error);
-  }
-}
-
-/**
- * Check if user is authenticated (has a valid token)
+ * Check if user is authenticated (has a token in storage).
  *
  * Note: This only checks for token presence, not validity.
- * Token validity is checked by the backend.
  */
 export function isAuthenticated(): boolean {
-  return getAuthToken() !== null;
-}
-
-/**
- * Append authentication token to a URL as a query parameter
- *
- * This is needed for embedded resources (<img>, <video>, <source> tags) that
- * cannot use Authorization headers or may not receive cookies in cross-origin
- * contexts (e.g., Electron app loading resources from the API server).
- *
- * The backend JWT strategy accepts tokens via:
- * 1. Authorization header (primary)
- * 2. Cookie (same-origin browser requests)
- * 3. Query parameter ?token=<jwt> (for embedded resources)
- *
- * @param url - The URL to authenticate (can be relative or absolute)
- * @returns The URL with token appended, or original URL if no token available
- *
- * @example
- * // For video tags in Electron
- * <video src={getAuthenticatedUrl('/api/file/123')} />
- *
- * // For HLS.js playlist URLs
- * hls.loadSource(getAuthenticatedUrl('/api/livekit/replay/preview/playlist.m3u8'));
- */
-export function getAuthenticatedUrl(url: string): string {
-  const token = getAuthToken();
-
-  if (!token) {
-    logger.warn('[Auth] No token available for authenticated URL');
-    return url;
-  }
-
-  try {
-    // Handle both absolute and relative URLs
-    const urlObj = new URL(url, window.location.origin);
-
-    // Don't add token if it's already present
-    if (urlObj.searchParams.has('token')) {
-      return url;
-    }
-
-    urlObj.searchParams.set('token', token);
-    return urlObj.toString();
-  } catch (error) {
-    logger.error('[Auth] Error creating authenticated URL:', error);
-    return url;
-  }
+  return getAccessToken() !== null;
 }


### PR DESCRIPTION
## Summary

- **Adds `AuthGate` layout route** that validates the JWT before any authenticated component or provider (including SocketProvider) mounts — prevents the burst of 401 errors, socket reconnection loops, and "double refresh" UX when loading the app with an expired token
- **Fixes double-encoding token storage bug** where `LoginPage`/`RegisterPage`/`JoinInvitePage`/`CompletionStep` stored tokens via `JSON.stringify(token)` + `setCachedItem()` (which wraps in another `JSON.stringify`), causing format inconsistencies across consumers
- **Consolidates all token access** through `tokenService.ts` — adds `isTokenExpired()`, `getAuthenticatedUrl()`, fixes storage to plain strings with backwards-compatible reading; converts `auth.ts` to a thin re-export shim
- **Adds `PublicRoute` wrapper** that redirects already-authenticated users away from `/login` and `/register`
- **Moves SocketProvider inside AuthGate** so socket connections only happen after token validation, eliminating the infinite reconnection loop on expired tokens

### Files changed (22)

**New (5):** `AuthGate.tsx`, `PublicRoute.tsx`, `AuthGate.test.tsx`, `PublicRoute.test.tsx`, `tokenService.test.ts`

**Modified (17):** `tokenService.ts`, `auth.ts`, `App.tsx`, `main.tsx`, `SocketProvider.tsx`, `Layout.tsx`, `api-client-config.ts`, `LoginPage.tsx`, `RegisterPage.tsx`, `JoinInvitePage.tsx`, `CompletionStep.tsx`, `RoomContext.tsx`, `useAuthenticatedFile.ts`, `useFileUpload.ts`, `LoginPage.test.tsx`, `RegisterPage.test.tsx`, `auth.test.ts`

## Test plan

- [x] 99 unit tests covering the full auth path (all passing)
  - AuthGate: 28 tests (loading, onboarding, unauth, valid token, legacy formats, refresh flow, provider mounting invariants)
  - PublicRoute: 7 tests (no token, expired, valid, legacy formats)
  - tokenService: 43 tests (getAccessToken, setAccessToken, clearTokens, isTokenExpired, getAuthenticatedUrl, onTokenRefreshed, isRefreshing, redirectToLogin)
  - auth.ts shim: 11 tests
  - LoginPage/RegisterPage: cross-module contract tests verifying `getAccessToken()` reads the stored token
- [ ] Manual: expired token on load → loading spinner → refresh → app loads (or redirect to login)
- [ ] Manual: no token on load → immediate redirect to `/login`
- [ ] Manual: valid token on load → normal app load, socket connects
- [ ] Manual: login → token stored → navigate → AuthGate validates → socket connected
- [ ] Manual: logout → tokens cleared → redirect to `/login` → socket disconnected
- [ ] Manual: navigate to `/login` while logged in → redirect to `/`
- [ ] Manual: fresh server with no users → redirect to `/onboarding`
- [ ] Manual: Electron — same flows (refresh token in body instead of cookie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)