### PR TITLE
fix: batch bug hunt fixes

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2646,6 +2646,29 @@
         ]
       }
     },
+    "/api/file/{id}/thumbnail": {
+      "get": {
+        "operationId": "FileController_getFileThumbnail",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "File"
+        ]
+      }
+    },
     "/api/file/{id}": {
       "get": {
         "operationId": "FileController_getFile",
@@ -8041,6 +8064,9 @@
           },
           "size": {
             "type": "number"
+          },
+          "hasThumbnail": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -8048,7 +8074,8 @@
           "id",
           "filename",
           "mimeType",
-          "size"
+          "size",
+          "hasThumbnail"
         ]
       },
       "ReactionDto": {
@@ -8461,6 +8488,9 @@
           },
           "size": {
             "type": "number"
+          },
+          "hasThumbnail": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -8468,7 +8498,8 @@
           "id",
           "filename",
           "mimeType",
-          "size"
+          "size",
+          "hasThumbnail"
         ]
       },
       "CreateMembershipDto": {
@@ -9128,9 +9159,79 @@
           }
         }
       },
+      "ModerationUserDto": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "OWNER",
+              "USER"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "avatarUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "bannerUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastSeen": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "bio": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "role",
+          "id",
+          "username",
+          "avatarUrl",
+          "bannerUrl",
+          "lastSeen",
+          "displayName",
+          "bio",
+          "status"
+        ]
+      },
       "CommunityBanDto": {
         "type": "object",
         "properties": {
+          "user": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ModerationUserDto"
+              }
+            ]
+          },
+          "moderator": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ModerationUserDto"
+              }
+            ]
+          },
           "id": {
             "type": "string"
           },
@@ -9161,6 +9262,8 @@
           }
         },
         "required": [
+          "user",
+          "moderator",
           "id",
           "communityId",
           "userId",
@@ -9206,6 +9309,22 @@
       "CommunityTimeoutDto": {
         "type": "object",
         "properties": {
+          "user": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ModerationUserDto"
+              }
+            ]
+          },
+          "moderator": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ModerationUserDto"
+              }
+            ]
+          },
           "id": {
             "type": "string"
           },
@@ -9232,6 +9351,8 @@
           }
         },
         "required": [
+          "user",
+          "moderator",
           "id",
           "communityId",
           "userId",
@@ -9482,6 +9603,22 @@
             "nullable": true,
             "additionalProperties": true
           },
+          "moderator": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ModerationUserDto"
+              }
+            ]
+          },
+          "targetUser": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ModerationUserDto"
+              }
+            ]
+          },
           "id": {
             "type": "string"
           },
@@ -9507,6 +9644,8 @@
         "required": [
           "action",
           "metadata",
+          "moderator",
+          "targetUser",
           "id",
           "communityId",
           "moderatorId",

--- a/backend/src/moderation/dto/moderation-response.dto.ts
+++ b/backend/src/moderation/dto/moderation-response.dto.ts
@@ -1,12 +1,26 @@
-import { FileType, ModerationAction, Prisma } from '@prisma/client';
+import { FileType, ModerationAction, Prisma, InstanceRole } from '@prisma/client';
 import { ApiProperty } from '@nestjs/swagger';
 import {
   FileTypeValues,
   ModerationActionValues,
+  InstanceRoleValues,
 } from '@/common/enums/swagger-enums';
 import { SpanDto, ReactionDto } from '@/messages/dto/message-response.dto';
 
 export { SuccessMessageDto } from '@/common/dto/common-response.dto';
+
+export class ModerationUserDto {
+  id: string;
+  username: string;
+  @ApiProperty({ enum: InstanceRoleValues })
+  role: InstanceRole;
+  avatarUrl: string | null;
+  bannerUrl: string | null;
+  lastSeen: Date | null;
+  displayName: string | null;
+  bio: string | null;
+  status: string | null;
+}
 
 export class PinnedMessageAuthorDto {
   id: string;
@@ -57,6 +71,10 @@ export class CommunityBanDto {
   createdAt: Date;
   expiresAt: Date | null;
   active: boolean;
+  @ApiProperty({ type: ModerationUserDto, nullable: true })
+  user: ModerationUserDto | null;
+  @ApiProperty({ type: ModerationUserDto, nullable: true })
+  moderator: ModerationUserDto | null;
 }
 
 export class CommunityTimeoutDto {
@@ -67,6 +85,10 @@ export class CommunityTimeoutDto {
   reason: string | null;
   createdAt: Date;
   expiresAt: Date;
+  @ApiProperty({ type: ModerationUserDto, nullable: true })
+  user: ModerationUserDto | null;
+  @ApiProperty({ type: ModerationUserDto, nullable: true })
+  moderator: ModerationUserDto | null;
 }
 
 export class ModerationLogDto {
@@ -80,6 +102,10 @@ export class ModerationLogDto {
   @ApiProperty({ type: 'object', nullable: true, additionalProperties: true })
   metadata: Prisma.JsonValue | null;
   createdAt: Date;
+  @ApiProperty({ type: ModerationUserDto, nullable: true })
+  moderator: ModerationUserDto | null;
+  @ApiProperty({ type: ModerationUserDto, nullable: true })
+  targetUser: ModerationUserDto | null;
 }
 
 export class TimeoutStatusResponseDto {

--- a/backend/src/moderation/moderation.service.spec.ts
+++ b/backend/src/moderation/moderation.service.spec.ts
@@ -47,6 +47,9 @@ describe('ModerationService', () => {
     membershipService = unitRef.get(MembershipService);
     websocketService = unitRef.get(WebsocketService);
     eventEmitter = unitRef.get(EventEmitter2);
+
+    // Default: user lookups return empty (enrichment queries)
+    mockDatabase.user.findMany.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -628,15 +631,18 @@ describe('ModerationService', () => {
   describe('getModerationLogs', () => {
     it('should return logs with total count', async () => {
       const logs = [
-        { id: 'log-1', action: ModerationAction.BAN_USER },
-        { id: 'log-2', action: ModerationAction.KICK_USER },
+        { id: 'log-1', action: ModerationAction.BAN_USER, moderatorId: 'mod-1', targetUserId: null },
+        { id: 'log-2', action: ModerationAction.KICK_USER, moderatorId: 'mod-1', targetUserId: null },
       ];
       mockDatabase.moderationLog.findMany.mockResolvedValue(logs as any);
       mockDatabase.moderationLog.count.mockResolvedValue(2);
 
       const result = await service.getModerationLogs(communityId);
 
-      expect(result).toEqual({ logs, total: 2 });
+      expect(result.total).toBe(2);
+      expect(result.logs).toHaveLength(2);
+      expect(result.logs[0]).toMatchObject({ id: 'log-1' });
+      expect(result.logs[1]).toMatchObject({ id: 'log-2' });
     });
 
     it('should support filtering by action', async () => {

--- a/backend/src/moderation/moderation.service.ts
+++ b/backend/src/moderation/moderation.service.ts
@@ -13,6 +13,7 @@ import { WebsocketService } from '@/websocket/websocket.service';
 import { ServerEvents } from '@kraken/shared';
 import { RoomEvents } from '@/rooms/room-subscription.events';
 import { RoomName } from '@/common/utils/room-name.util';
+import { PUBLIC_USER_SELECT } from '@/common/constants/user-select.constant';
 import {
   ModerationAction,
   Prisma,
@@ -287,7 +288,21 @@ export class ModerationService {
       }
     }
 
-    return activeBans;
+    // Enrich with user data
+    const userIds = [
+      ...new Set(activeBans.flatMap((b) => [b.userId, b.moderatorId])),
+    ];
+    const users = await this.databaseService.user.findMany({
+      where: { id: { in: userIds } },
+      select: PUBLIC_USER_SELECT,
+    });
+    const userMap = new Map(users.map((u) => [u.id, u]));
+
+    return activeBans.map((ban) => ({
+      ...ban,
+      user: userMap.get(ban.userId) ?? null,
+      moderator: userMap.get(ban.moderatorId) ?? null,
+    }));
   }
 
   // =========================================
@@ -546,7 +561,21 @@ export class ModerationService {
       }
     }
 
-    return activeTimeouts;
+    // Enrich with user data
+    const userIds = [
+      ...new Set(activeTimeouts.flatMap((t) => [t.userId, t.moderatorId])),
+    ];
+    const users = await this.databaseService.user.findMany({
+      where: { id: { in: userIds } },
+      select: PUBLIC_USER_SELECT,
+    });
+    const userMap = new Map(users.map((u) => [u.id, u]));
+
+    return activeTimeouts.map((timeout) => ({
+      ...timeout,
+      user: userMap.get(timeout.userId) ?? null,
+      moderator: userMap.get(timeout.moderatorId) ?? null,
+    }));
   }
 
   // =========================================
@@ -821,7 +850,29 @@ export class ModerationService {
       this.databaseService.moderationLog.count({ where }),
     ]);
 
-    return { logs, total };
+    // Enrich with user data
+    const userIds = [
+      ...new Set(
+        logs.flatMap((l) =>
+          [l.moderatorId, l.targetUserId].filter(Boolean),
+        ) as string[],
+      ),
+    ];
+    const users = await this.databaseService.user.findMany({
+      where: { id: { in: userIds } },
+      select: PUBLIC_USER_SELECT,
+    });
+    const userMap = new Map(users.map((u) => [u.id, u]));
+
+    const enrichedLogs = logs.map((log) => ({
+      ...log,
+      moderator: userMap.get(log.moderatorId) ?? null,
+      targetUser: log.targetUserId
+        ? (userMap.get(log.targetUserId) ?? null)
+        : null,
+    }));
+
+    return { logs: enrichedLogs, total };
   }
 
   // =========================================

--- a/frontend/src/__tests__/components/RegisterPage.test.tsx
+++ b/frontend/src/__tests__/components/RegisterPage.test.tsx
@@ -85,7 +85,7 @@ describe('RegisterPage', () => {
     await user.click(screen.getByRole('button', { name: /register/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Registration failed. Please try again.');
+      expect(screen.getByRole('alert')).toHaveTextContent('Registration failed');
     });
     expect(mockNavigate).not.toHaveBeenCalled();
   });

--- a/frontend/src/components/Message/MessageComponent.tsx
+++ b/frontend/src/components/Message/MessageComponent.tsx
@@ -238,11 +238,15 @@ const MessageComponent = React.memo(MessageComponentInner, (prevProps, nextProps
     ) &&
     // Deep compare reactions array (including userIds content)
     prevMsg.reactions.length === nextMsg.reactions.length &&
-    prevMsg.reactions.every((r, i) =>
-      r.emoji === nextMsg.reactions[i]?.emoji &&
-      r.userIds.length === nextMsg.reactions[i]?.userIds.length &&
-      r.userIds.every((uid, j) => uid === nextMsg.reactions[i]?.userIds[j])
-    ) &&
+    prevMsg.reactions.every((r, i) => {
+      const prevIds = r.userIds ?? [];
+      const nextIds = nextMsg.reactions[i]?.userIds ?? [];
+      return (
+        r.emoji === nextMsg.reactions[i]?.emoji &&
+        prevIds.length === nextIds.length &&
+        prevIds.every((uid, j) => uid === nextIds[j])
+      );
+    }) &&
     // Deep compare attachments array
     prevMsg.attachments?.length === nextMsg.attachments?.length &&
     prevMsg.attachments?.every((a, i) => a.id === nextMsg.attachments?.[i]?.id)

--- a/frontend/src/components/Message/MessageReactions.tsx
+++ b/frontend/src/components/Message/MessageReactions.tsx
@@ -19,10 +19,11 @@ const SingleReactionChip: React.FC<{
   onReactionClick: (emoji: string) => void
 }> = ({ reaction, userHasReacted, onReactionClick }) => {
   const theme = useTheme();
-  const count = reaction.userIds.length;
+  const userIds = reaction.userIds ?? [];
+  const count = userIds.length;
 
   return (
-    <ReactionTooltip userIds={reaction.userIds}>
+    <ReactionTooltip userIds={userIds}>
       <Chip
         label={`${reaction.emoji} ${count}`}
         size="small"
@@ -78,7 +79,7 @@ export const MessageReactions: React.FC<MessageReactionsProps> = ({
   return (
     <Box display="flex" gap={0.5} mt={0.5} flexWrap="wrap">
       {reactions.map((reaction) => {
-        const userHasReacted = currentUser ? reaction.userIds.includes(currentUser.id) : false;
+        const userHasReacted = currentUser ? (reaction.userIds ?? []).includes(currentUser.id) : false;
 
         return (
           <SingleReactionChip

--- a/frontend/src/components/Message/ReactionTooltip.tsx
+++ b/frontend/src/components/Message/ReactionTooltip.tsx
@@ -24,8 +24,9 @@ const UserName: React.FC<{ userId: string }> = ({ userId }) => {
 };
 
 export const ReactionTooltip: React.FC<ReactionTooltipProps> = ({ userIds, children }) => {
-  const displayUserIds = useMemo(() => userIds.slice(0, 15), [userIds]);
-  const remainingCount = userIds.length - displayUserIds.length;
+  const safeUserIds = userIds ?? [];
+  const displayUserIds = useMemo(() => safeUserIds.slice(0, 15), [safeUserIds]);
+  const remainingCount = safeUserIds.length - displayUserIds.length;
   
   const tooltipContent = (
     <Box sx={{ maxWidth: 200 }}>

--- a/frontend/src/components/Message/useMessageActions.ts
+++ b/frontend/src/components/Message/useMessageActions.ts
@@ -247,7 +247,7 @@ export function useMessageActions(
     if (!currentUserId) return;
 
     const reaction = message.reactions.find(r => r.emoji === emoji);
-    const userHasReacted = reaction?.userIds.includes(currentUserId) ?? false;
+    const userHasReacted = reaction?.userIds?.includes(currentUserId) ?? false;
 
     try {
       if (userHasReacted) {

--- a/frontend/src/components/Moderation/BanListPanel.tsx
+++ b/frontend/src/components/Moderation/BanListPanel.tsx
@@ -229,7 +229,7 @@ const BanListPanel: React.FC<BanListPanelProps> = ({ communityId }) => {
               >
                 <ListItemAvatar>
                   <UserAvatar
-                    user={{ id: ban.userId, username: ban.userId }}
+                    user={ban.user ? { id: ban.userId, username: ban.user.username, avatarUrl: ban.user.avatarUrl } : { id: ban.userId, username: ban.userId }}
                     size="medium"
                   />
                 </ListItemAvatar>
@@ -237,7 +237,7 @@ const BanListPanel: React.FC<BanListPanelProps> = ({ communityId }) => {
                   primary={
                     <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                       <Typography variant="subtitle2">
-                        User ID: {ban.userId.slice(0, 8)}...
+                        {ban.user?.displayName || ban.user?.username || `User ${ban.userId.slice(0, 8)}...`}
                       </Typography>
                       <Chip
                         label={status.label}

--- a/frontend/src/components/Moderation/ModerationLogsPanel.tsx
+++ b/frontend/src/components/Moderation/ModerationLogsPanel.tsx
@@ -93,7 +93,8 @@ const ModerationLogsPanel: React.FC<ModerationLogsPanelProps> = ({ communityId }
     const parts: string[] = [];
 
     if (log.targetUserId) {
-      parts.push(`Target: ${log.targetUserId.slice(0, 8)}...`);
+      const targetName = log.targetUser?.displayName || log.targetUser?.username || `${log.targetUserId.slice(0, 8)}...`;
+      parts.push(`Target: ${targetName}`);
     }
     if (log.targetMessageId) {
       parts.push(`Message: ${log.targetMessageId.slice(0, 8)}...`);
@@ -204,7 +205,7 @@ const ModerationLogsPanel: React.FC<ModerationLogsPanelProps> = ({ communityId }
                           }}
                         />
                         <Typography variant="caption" color="text.secondary">
-                          by {log.moderatorId.slice(0, 8)}...
+                          by {log.moderator?.displayName || log.moderator?.username || `${log.moderatorId.slice(0, 8)}...`}
                         </Typography>
                       </Box>
                     }

--- a/frontend/src/components/Moderation/TimeoutListPanel.tsx
+++ b/frontend/src/components/Moderation/TimeoutListPanel.tsx
@@ -242,7 +242,7 @@ const TimeoutListPanel: React.FC<TimeoutListPanelProps> = ({ communityId }) => {
             >
               <ListItemAvatar>
                 <UserAvatar
-                  user={{ id: timeout.userId, username: timeout.userId }}
+                  user={timeout.user ? { id: timeout.userId, username: timeout.user.username, avatarUrl: timeout.user.avatarUrl } : { id: timeout.userId, username: timeout.userId }}
                   size="medium"
                 />
               </ListItemAvatar>
@@ -250,7 +250,7 @@ const TimeoutListPanel: React.FC<TimeoutListPanelProps> = ({ communityId }) => {
                 primary={
                   <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                     <Typography variant="subtitle2">
-                      User ID: {timeout.userId.slice(0, 8)}...
+                      {timeout.user?.displayName || timeout.user?.username || `User ${timeout.userId.slice(0, 8)}...`}
                     </Typography>
                     <Chip
                       label={formatTimeRemaining(timeout.expiresAt)}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -33,6 +33,13 @@ const FormBox = styled(Box)({
   maxWidth: "400px",
 });
 
+const getErrorMessage = (err: unknown): string => {
+  const msg = (err as Record<string, unknown>)?.message;
+  if (Array.isArray(msg)) return msg.join(', ');
+  if (typeof msg === 'string') return msg;
+  return 'Registration failed. Please try again.';
+};
+
 const RegisterPage: React.FC = () => {
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
@@ -78,7 +85,7 @@ const RegisterPage: React.FC = () => {
             sx={{ width: "100%", marginBottom: 2 }}
             role="alert"
           >
-            Registration failed. Please try again.
+            {getErrorMessage(error)}
           </Alert>
         )}
         <TextField
@@ -112,6 +119,7 @@ const RegisterPage: React.FC = () => {
           onChange={(e) => setPassword(e.target.value)}
           sx={{ marginBottom: 2 }}
           required
+          helperText="Must be at least 8 characters"
         />
         <TextField
           id="code"

--- a/frontend/src/socket-hub/handlers/messageHandlers.ts
+++ b/frontend/src/socket-hub/handlers/messageHandlers.ts
@@ -16,6 +16,8 @@ import { messageQueryKeyForContext, channelMessagesQueryKey } from '../../utils/
 import {
   readReceiptsControllerGetUnreadCountsQueryKey,
   userControllerGetProfileQueryKey,
+  moderationControllerGetPinnedMessagesQueryKey,
+  directMessagesControllerFindUserDmGroupsQueryKey,
 } from '../../api-client/@tanstack/react-query.gen';
 import {
   prependMessageToInfinite,
@@ -39,6 +41,13 @@ export const handleNewMessage: SocketEventHandler<typeof ServerEvents.NEW_MESSAG
   queryClient.setQueryData(queryKey, (old: unknown) =>
     prependMessageToInfinite(old as never, message as Message),
   );
+
+  // Invalidate DM groups list so sidebar preview updates
+  if (message.directMessageGroupId) {
+    queryClient.invalidateQueries({
+      queryKey: directMessagesControllerFindUserDmGroupsQueryKey(),
+    });
+  }
 
   // Increment unread count — skip for own messages
   const currentUser = queryClient.getQueryData<UserControllerGetProfileResponse>(
@@ -154,6 +163,9 @@ export const handleMessagePinned: SocketEventHandler<typeof ServerEvents.MESSAGE
       pinnedAt,
     });
   });
+  queryClient.invalidateQueries({
+    queryKey: moderationControllerGetPinnedMessagesQueryKey({ path: { channelId } }),
+  });
 };
 
 export const handleMessageUnpinned: SocketEventHandler<typeof ServerEvents.MESSAGE_UNPINNED> = async (
@@ -171,6 +183,9 @@ export const handleMessageUnpinned: SocketEventHandler<typeof ServerEvents.MESSA
       pinnedBy: null,
       pinnedAt: null,
     });
+  });
+  queryClient.invalidateQueries({
+    queryKey: moderationControllerGetPinnedMessagesQueryKey({ path: { channelId } }),
   });
 };
 


### PR DESCRIPTION
## Summary

- **Reaction crash guards**: Add defensive `?? []` fallbacks for `reaction.userIds` across message components (backend sends correctly, this is defense-in-depth for data robustness)
- **DM sidebar preview**: Invalidate DM groups query when new DM messages arrive so `DmListItem` shows updated `lastMessage`
- **Pinned message badge**: Invalidate pinned messages query on pin/unpin WebSocket events so the count updates in real-time
- **Registration errors**: Show actual server validation messages instead of generic "Registration failed" text; add password minimum length hint
- **Moderation UI usernames**: Enrich ban list, timeout list, and moderation logs endpoints with user data via `PUBLIC_USER_SELECT`; display usernames/avatars instead of raw IDs in all moderation panels

## Test plan

- [x] Backend moderation tests pass (59/59)
- [x] Frontend tests pass (907/907)
- [x] TypeScript compiles cleanly (frontend + backend)
- [ ] Manual: React to a message, verify no crash
- [ ] Manual: Pin/unpin a message, verify badge count updates without refresh
- [ ] Manual: Send a DM, verify sidebar preview updates
- [ ] Manual: Register with short password, verify error message shown
- [ ] Manual: Open moderation panel, verify usernames displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)