### PR TITLE
fix: prevent voice activity gate lockout by cloning analysis track

### DIFF
--- a/frontend/src/__tests__/hooks/useSpeakingDetection.test.ts
+++ b/frontend/src/__tests__/hooks/useSpeakingDetection.test.ts
@@ -44,7 +44,11 @@ type Handler = (...args: unknown[]) => void;
 const participantHandlers = new Map<string, Set<Handler>>();
 const roomHandlers = new Map<string, Set<Handler>>();
 
-const mockMediaStreamTrack = { enabled: true };
+const mockAnalysisTrack = { enabled: true, stop: vi.fn() };
+const mockMediaStreamTrack = {
+  enabled: true,
+  clone: vi.fn(() => mockAnalysisTrack),
+};
 
 const mockLocalParticipant = {
   identity: 'user-1',
@@ -116,6 +120,9 @@ describe('useSpeakingDetection', () => {
     rafCallbacks = [];
     audioLevel = 0;
     mockMediaStreamTrack.enabled = true;
+    mockMediaStreamTrack.clone.mockReturnValue(mockAnalysisTrack);
+    mockAnalysisTrack.enabled = true;
+    mockAnalysisTrack.stop.mockClear();
     currentRoom = makeRoom();
     storedSettings = {
       kraken_voice_settings: {
@@ -396,5 +403,138 @@ describe('useSpeakingDetection', () => {
 
     expect(mockLocalParticipant.off).toHaveBeenCalledWith('localTrackPublished', expect.any(Function));
     expect(mockLocalParticipant.off).toHaveBeenCalledWith('localTrackUnpublished', expect.any(Function));
+  });
+
+  // ------------------------------------------------------------------
+  // Track cloning for analysis (gate lockout fix)
+  // ------------------------------------------------------------------
+
+  it('uses a cloned track for analysis, gating the original', () => {
+    renderSpeaking();
+
+    // clone() should have been called to create the analysis track
+    expect(mockMediaStreamTrack.clone).toHaveBeenCalled();
+
+    // Close the gate — original track should be disabled, clone stays enabled
+    audioLevel = 0;
+    act(() => tickRAF(1));
+    act(() => {
+      vi.advanceTimersByTime(350);
+      tickRAF(1);
+    });
+
+    expect(mockMediaStreamTrack.enabled).toBe(false);
+    expect(mockAnalysisTrack.enabled).toBe(true);
+  });
+
+  it('reopens gate when audio rises above threshold after being closed', () => {
+    const { result } = renderSpeaking();
+
+    // Close the gate
+    audioLevel = 0;
+    act(() => tickRAF(1));
+    act(() => {
+      vi.advanceTimersByTime(350);
+      tickRAF(1);
+    });
+    expect(mockMediaStreamTrack.enabled).toBe(false);
+    expect(result.current.isSpeaking('user-1')).toBe(false);
+
+    // Because analysis uses a cloned track, the analyser still reads real audio.
+    // Raise audio above threshold and wait past min close time — gate should reopen.
+    audioLevel = 50;
+    act(() => {
+      vi.advanceTimersByTime(150);
+      tickRAF(1);
+    });
+
+    expect(mockMediaStreamTrack.enabled).toBe(true);
+    expect(result.current.isSpeaking('user-1')).toBe(true);
+  });
+
+  it('stops the cloned analysis track on cleanup', () => {
+    const { unmount } = renderSpeaking();
+
+    // Verify clone was used
+    expect(mockMediaStreamTrack.clone).toHaveBeenCalled();
+
+    unmount();
+
+    expect(mockAnalysisTrack.stop).toHaveBeenCalled();
+  });
+
+  it('stops cloned track when local track is republished', () => {
+    renderSpeaking();
+
+    expect(mockMediaStreamTrack.clone).toHaveBeenCalledTimes(1);
+
+    // Simulate track republish
+    act(() => {
+      participantHandlers.get('localTrackPublished')?.forEach(h => h());
+    });
+
+    // Old clone should be stopped
+    expect(mockAnalysisTrack.stop).toHaveBeenCalled();
+
+    // After delay, a new clone should be created
+    act(() => vi.advanceTimersByTime(250));
+    expect(mockMediaStreamTrack.clone).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to original track if clone() fails', () => {
+    mockMediaStreamTrack.clone.mockImplementation(() => { throw new Error('clone failed'); });
+
+    renderSpeaking();
+
+    // Should still work — gate controls the original track directly
+    audioLevel = 50;
+    act(() => tickRAF(1));
+    expect(mockMediaStreamTrack.enabled).toBe(true);
+
+    audioLevel = 0;
+    act(() => tickRAF(1));
+    act(() => {
+      vi.advanceTimersByTime(350);
+      tickRAF(1);
+    });
+    expect(mockMediaStreamTrack.enabled).toBe(false);
+  });
+
+  // ------------------------------------------------------------------
+  // Device change handling
+  // ------------------------------------------------------------------
+
+  it('restarts analysis when active audio device changes', () => {
+    renderSpeaking();
+
+    expect(mockMediaStreamTrack.clone).toHaveBeenCalledTimes(1);
+
+    // Simulate device change
+    act(() => {
+      roomHandlers.get('activeDeviceChanged')?.forEach(h => h('audioinput'));
+    });
+
+    // Old clone should be stopped
+    expect(mockAnalysisTrack.stop).toHaveBeenCalled();
+    expect(mockAudioContextClose).toHaveBeenCalled();
+
+    // After delay, analysis restarts with new clone
+    act(() => vi.advanceTimersByTime(250));
+    expect(mockMediaStreamTrack.clone).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not restart analysis for non-audio device changes', () => {
+    renderSpeaking();
+
+    const cloneCountBefore = mockMediaStreamTrack.clone.mock.calls.length;
+
+    act(() => {
+      roomHandlers.get('activeDeviceChanged')?.forEach(h => h('videoinput'));
+    });
+
+    act(() => vi.advanceTimersByTime(250));
+
+    // No additional clone calls — analysis was not restarted
+    expect(mockMediaStreamTrack.clone).toHaveBeenCalledTimes(cloneCountBefore);
   });
 });

--- a/frontend/src/hooks/useDeviceTest.ts
+++ b/frontend/src/hooks/useDeviceTest.ts
@@ -112,7 +112,7 @@ export function useDeviceTest({
       const microphone = audioContext.createMediaStreamSource(stream);
 
       analyser.fftSize = 256;
-      analyser.smoothingTimeConstant = 0.8;
+      analyser.smoothingTimeConstant = 0.5;
       microphone.connect(analyser);
 
       audioContextRef.current = audioContext;

--- a/frontend/src/hooks/useSpeakingDetection.ts
+++ b/frontend/src/hooks/useSpeakingDetection.ts
@@ -50,6 +50,8 @@ export const useSpeakingDetection = () => {
   const animationFrameRef = useRef<number | null>(null);
   const localAnalysisActiveRef = useRef(false);
   const localTrackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const analysisTrackRef = useRef<MediaStreamTrack | null>(null);
+  const analysisTrackIsCloneRef = useRef(false);
 
   // Gate state refs (used for both indicator and audio gating)
   const gateOpenRef = useRef(true);
@@ -142,7 +144,21 @@ export const useSpeakingDetection = () => {
         analyser.fftSize = 256;
         analyser.smoothingTimeConstant = 0.5;
 
-        const stream = new MediaStream([mediaStreamTrack]);
+        // Clone the track for analysis so its `enabled` state is independent.
+        // The analyser always reads real audio from the clone, while the gate
+        // toggles `enabled` only on the original (published) track.
+        let analysisTrack: MediaStreamTrack;
+        try {
+          analysisTrack = mediaStreamTrack.clone();
+          analysisTrackIsCloneRef.current = true;
+        } catch {
+          // Fallback: use the original (pre-fix behavior)
+          analysisTrack = mediaStreamTrack;
+          analysisTrackIsCloneRef.current = false;
+        }
+        analysisTrackRef.current = analysisTrack;
+
+        const stream = new MediaStream([analysisTrack]);
         const source = ctx.createMediaStreamSource(stream);
         source.connect(analyser);
 
@@ -283,6 +299,11 @@ export const useSpeakingDetection = () => {
         audioContextRef.current = null;
       }
       analyserRef.current = null;
+      if (analysisTrackRef.current && analysisTrackIsCloneRef.current) {
+        analysisTrackRef.current.stop();
+      }
+      analysisTrackRef.current = null;
+      analysisTrackIsCloneRef.current = false;
 
       // Only re-enable track if OUR gate disabled it — don't override
       // explicit user mute/deafen/PTT state
@@ -318,6 +339,14 @@ export const useSpeakingDetection = () => {
     local.on("localTrackPublished", handleLocalTrackPublished);
     local.on("localTrackUnpublished", handleLocalTrackUnpublished);
 
+    const handleActiveDeviceChanged = (kind: MediaDeviceKind) => {
+      if (kind === 'audioinput') {
+        stopLocalAnalysis();
+        localTrackTimeoutRef.current = setTimeout(() => startLocalAnalysis(), 200);
+      }
+    };
+    room.on("activeDeviceChanged", handleActiveDeviceChanged);
+
     // Cleanup
     return () => {
       // Remote handlers
@@ -333,6 +362,7 @@ export const useSpeakingDetection = () => {
 
       room.off("participantConnected", handleParticipantConnected);
       room.off("participantDisconnected", handleParticipantDisconnected);
+      room.off("activeDeviceChanged", handleActiveDeviceChanged);
 
       // Local analysis + gating cleanup
       stopLocalAnalysis();


### PR DESCRIPTION
## Summary

- **Fix gate lockout**: Clone `mediaStreamTrack` for the AnalyserNode so its `enabled` state is independent from the published track. The analyser always reads real mic audio from the clone, while gating toggles `enabled` only on the original track. This prevents the bug where closing the gate (setting `enabled = false`) caused the analyser to read silence permanently, locking out the user until they toggled mute.
- **Fix device switching**: Add `activeDeviceChanged` listener to restart audio analysis when the user switches mic devices mid-call, preventing the analyser from reading a dead track.
- **Fix smoothing mismatch**: Align `useDeviceTest` smoothing constant (0.8 → 0.5) with live detection so the settings mic test shows levels consistent with actual voice calls.

Closes #175

## Test plan

- [ ] `docker compose run --rm frontend pnpm run test` — all 1006 tests pass including 7 new regression tests
- [ ] `docker compose run --rm frontend pnpm exec tsc --noEmit` — no type errors
- [ ] `docker compose run --rm frontend pnpm run lint` — 0 errors (11 pre-existing warnings)
- [ ] Manual: Join voice channel → speak → stop speaking for >300ms (gate closes) → speak again → indicator lights up and audio transmits
- [ ] Manual: Change mic device in settings while in a call → indicator restarts with new device
- [ ] Manual: In settings, test microphone with sensitivity slider → level meter response matches actual voice call behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)