### PR TITLE
fix: render attachment previews in pinned messages panel

### DIFF
--- a/frontend/src/__tests__/components/PinnedMessagesPanel.test.tsx
+++ b/frontend/src/__tests__/components/PinnedMessagesPanel.test.tsx
@@ -81,7 +81,7 @@ describe('PinnedMessagesPanel', () => {
 
   it('renders text-only pinned message', async () => {
     const msg = makePinnedMessage({
-      spans: [{ type: 'TEXT' as never, text: 'Hello world' }],
+      spans: [{ type: 'PLAINTEXT', text: 'Hello world', userId: null, specialKind: null, communityId: null, aliasId: null }],
     });
     setupPinnedEndpoint([msg]);
 
@@ -111,7 +111,7 @@ describe('PinnedMessagesPanel', () => {
 
   it('renders both text and attachment for message with caption', async () => {
     const msg = makePinnedMessage({
-      spans: [{ type: 'TEXT' as never, text: 'Check this out' }],
+      spans: [{ type: 'PLAINTEXT', text: 'Check this out', userId: null, specialKind: null, communityId: null, aliasId: null }],
       attachments: [
         { id: 'file-1', filename: 'screenshot.png', mimeType: 'image/png', fileType: 'IMAGE', size: 2048 },
       ],

--- a/frontend/src/components/Moderation/PinnedMessagesPanel.tsx
+++ b/frontend/src/components/Moderation/PinnedMessagesPanel.tsx
@@ -32,6 +32,7 @@ import { RBAC_ACTIONS } from "../../constants/rbacActions";
 import UserAvatar from "../Common/UserAvatar";
 import { AttachmentPreview } from "../Message/AttachmentPreview";
 import type { FileMetadata } from "../../types/message.type";
+import type { PinnedMessageAttachmentDto } from "../../api-client/types.gen";
 import { formatDistanceToNow } from "date-fns";
 import { logger } from "../../utils/logger";
 
@@ -93,6 +94,14 @@ const PinnedMessagesPanel: React.FC<PinnedMessagesPanelProps> = ({
       .map((span) => span.text)
       .join(" ");
   };
+
+  const toFileMetadata = (att: PinnedMessageAttachmentDto): FileMetadata => ({
+    id: att.id,
+    filename: att.filename,
+    mimeType: att.mimeType,
+    fileType: att.fileType,
+    size: att.size,
+  });
 
   if (error) {
     return (
@@ -183,7 +192,7 @@ const PinnedMessagesPanel: React.FC<PinnedMessagesPanelProps> = ({
                   }
                 >
                   <ListItemText
-                    secondaryTypographyProps={{ component: "div" } as object}
+                    secondaryTypographyProps={{ component: "div" }}
                     primary={
                       <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
                         {message.author && (
@@ -198,44 +207,51 @@ const PinnedMessagesPanel: React.FC<PinnedMessagesPanelProps> = ({
                       </Box>
                     }
                     secondary={
-                      <Box component="span" sx={{ display: "block" }}>
-                        {getMessageContent(message) && (
-                          <Typography
-                            variant="body2"
-                            color="text.primary"
-                            sx={{
-                              display: "-webkit-box",
-                              WebkitLineClamp: 3,
-                              WebkitBoxOrient: "vertical",
-                              overflow: "hidden",
-                              wordBreak: "break-word",
-                            }}
-                          >
-                            {getMessageContent(message)}
-                          </Typography>
-                        )}
-                        {message.attachments.length > 0 && (
-                          <Box
-                            sx={{
-                              mt: getMessageContent(message) ? 1 : 0,
-                              maxHeight: 150,
-                              overflow: "hidden",
-                              pointerEvents: "none",
-                              "& img": { maxHeight: 140 },
-                              "& video": { maxHeight: 140 },
-                            }}
-                          >
-                            <AttachmentPreview
-                              metadata={message.attachments[0] as FileMetadata}
-                            />
-                            {message.attachments.length > 1 && (
-                              <Typography variant="caption" color="text.secondary">
-                                +{message.attachments.length - 1} more
+                      (() => {
+                        const content = getMessageContent(message);
+                        return (
+                          <Box>
+                            {content && (
+                              <Typography
+                                variant="body2"
+                                color="text.primary"
+                                sx={{
+                                  display: "-webkit-box",
+                                  WebkitLineClamp: 3,
+                                  WebkitBoxOrient: "vertical",
+                                  overflow: "hidden",
+                                  wordBreak: "break-word",
+                                }}
+                              >
+                                {content}
                               </Typography>
                             )}
+                            {message.attachments.length > 0 && (
+                              <>
+                                <Box
+                                  sx={{
+                                    mt: content ? 1 : 0,
+                                    maxHeight: 150,
+                                    overflow: "hidden",
+                                    pointerEvents: "none",
+                                    "& img": { maxHeight: 140 },
+                                    "& video": { maxHeight: 140 },
+                                  }}
+                                >
+                                  <AttachmentPreview
+                                    metadata={toFileMetadata(message.attachments[0])}
+                                  />
+                                </Box>
+                                {message.attachments.length > 1 && (
+                                  <Typography variant="caption" color="text.secondary">
+                                    +{message.attachments.length - 1} more
+                                  </Typography>
+                                )}
+                              </>
+                            )}
                           </Box>
-                        )}
-                      </Box>
+                        );
+                      })()
                     }
                   />
                 </ListItem>


### PR DESCRIPTION
## Summary
- Pinned messages with attachments (images, videos, files) previously appeared blank in the pinned messages panel because only text spans were rendered
- Now renders the first attachment as a constrained preview (max 150px height, non-interactive) below the text content
- Shows a "+N more" badge when a message has multiple attachments
- Fixes `<p>` nesting hydration warning by using `secondaryTypographyProps={{ component: "div" }}`

Closes #290

## Test plan
- [x] Type check passes (`pnpm run type-check`)
- [x] New unit tests pass (5 tests covering text-only, image attachment, text+attachment, multiple attachments, empty state)
- [ ] Manual: Pin a message with an image → verify preview shows in pinned panel
- [ ] Manual: Pin a message with a video → verify thumbnail appears
- [ ] Manual: Pin a text-only message → verify text still renders normally
- [ ] Manual: Pin a message with multiple attachments → verify first preview + "+N more" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)