### PR TITLE
fix: voice indicator, audio gating, sensitivity, screen share audio, device switching

### DIFF
--- a/frontend/src/__tests__/components/AudioRenderer.test.tsx
+++ b/frontend/src/__tests__/components/AudioRenderer.test.tsx
@@ -76,10 +76,18 @@ vi.mock('../../hooks/useRoom', () => ({
   useRoom: vi.fn(() => ({ room: mockRoom })),
 }));
 
+// --- Mock useVoice hook ---
+let mockShowVideoTiles = false;
+
+vi.mock('../../contexts/VoiceContext', () => ({
+  useVoice: vi.fn(() => ({ showVideoTiles: mockShowVideoTiles })),
+}));
+
 describe('AudioRenderer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     buildMockRoom();
+    mockShowVideoTiles = false;
   });
 
   it('renders nothing when there is no room', () => {
@@ -98,7 +106,8 @@ describe('AudioRenderer', () => {
     expect(audioElements.length).toBe(1);
   });
 
-  it('renders audio elements for screen share audio tracks', () => {
+  it('renders audio elements for screen share audio tracks when video tiles are open', () => {
+    mockShowVideoTiles = true;
     const screenAudioPub = createMockPublication('screen_share_audio');
     const participant = createMockRemoteParticipant('user-1', [screenAudioPub]);
     mockRoom!.remoteParticipants.set('user-1', participant);
@@ -108,7 +117,19 @@ describe('AudioRenderer', () => {
     expect(audioElements.length).toBe(1);
   });
 
-  it('renders audio elements for both microphone and screen share audio from the same participant', () => {
+  it('does NOT render screen share audio when video tiles are closed', () => {
+    mockShowVideoTiles = false;
+    const screenAudioPub = createMockPublication('screen_share_audio');
+    const participant = createMockRemoteParticipant('user-1', [screenAudioPub]);
+    mockRoom!.remoteParticipants.set('user-1', participant);
+
+    const { container } = render(<AudioRenderer />);
+    const audioElements = container.querySelectorAll('audio');
+    expect(audioElements.length).toBe(0);
+  });
+
+  it('renders both mic and screen share audio when video tiles are open', () => {
+    mockShowVideoTiles = true;
     const micPub = createMockPublication('microphone');
     const screenAudioPub = createMockPublication('screen_share_audio');
     const participant = createMockRemoteParticipant('user-1', [micPub, screenAudioPub]);
@@ -117,6 +138,18 @@ describe('AudioRenderer', () => {
     const { container } = render(<AudioRenderer />);
     const audioElements = container.querySelectorAll('audio');
     expect(audioElements.length).toBe(2);
+  });
+
+  it('renders only mic audio when video tiles are closed and both tracks exist', () => {
+    mockShowVideoTiles = false;
+    const micPub = createMockPublication('microphone');
+    const screenAudioPub = createMockPublication('screen_share_audio');
+    const participant = createMockRemoteParticipant('user-1', [micPub, screenAudioPub]);
+    mockRoom!.remoteParticipants.set('user-1', participant);
+
+    const { container } = render(<AudioRenderer />);
+    const audioElements = container.querySelectorAll('audio');
+    expect(audioElements.length).toBe(1);
   });
 
   it('does not render audio for tracks without a track object', () => {

--- a/frontend/src/__tests__/hooks/useSpeakingDetection.test.ts
+++ b/frontend/src/__tests__/hooks/useSpeakingDetection.test.ts
@@ -7,12 +7,18 @@ let audioLevel = 0;
 const mockAudioContextClose = vi.fn();
 
 const mockAnalyser = {
-  fftSize: 0,
+  fftSize: 256,
   smoothingTimeConstant: 0,
-  frequencyBinCount: 4,
+  frequencyBinCount: 128,
+  context: { sampleRate: 48000 },
   getByteFrequencyData(arr: Uint8Array) {
     const byteVal = Math.round((audioLevel / 100) * 255);
-    for (let i = 0; i < arr.length; i++) arr[i] = byteVal;
+    // Fill voice-frequency bins (0-21 at 48kHz/256 fftSize) with the test level;
+    // higher bins get near-zero to mimic real speech spectrum.
+    const voiceBins = Math.ceil(4000 / (48000 / 256)); // ~22
+    for (let i = 0; i < arr.length; i++) {
+      arr[i] = i < voiceBins ? byteVal : 0;
+    }
   },
   connect: vi.fn(),
 };

--- a/frontend/src/__tests__/utils/audioLevel.test.ts
+++ b/frontend/src/__tests__/utils/audioLevel.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { computeVoiceLevel } from '../../utils/audioLevel';
+
+function createMockAnalyser(
+  sampleRate: number,
+  fftSize: number,
+  fillFn: (arr: Uint8Array) => void,
+): AnalyserNode {
+  const binCount = fftSize / 2;
+  return {
+    fftSize,
+    frequencyBinCount: binCount,
+    context: { sampleRate } as AudioContext,
+    getByteFrequencyData: fillFn,
+  } as unknown as AnalyserNode;
+}
+
+describe('computeVoiceLevel', () => {
+  it('returns level based only on voice-frequency bins (80-4000Hz)', () => {
+    const fftSize = 256;
+    const sampleRate = 48000;
+    const binHz = sampleRate / fftSize; // 187.5
+    const voiceEnd = Math.ceil(4000 / binHz); // 22
+
+    const analyser = createMockAnalyser(sampleRate, fftSize, (arr: Uint8Array) => {
+      // Voice bins at 200, rest at 0
+      for (let i = 0; i < arr.length; i++) {
+        arr[i] = i < voiceEnd ? 200 : 0;
+      }
+    });
+
+    const dataArray = new Uint8Array(fftSize / 2);
+    const level = computeVoiceLevel(analyser, dataArray);
+
+    // Should be ~78.4 (200/255*100), not diluted by zero-filled high bins
+    expect(level).toBeGreaterThan(70);
+    expect(level).toBeLessThan(85);
+  });
+
+  it('returns near-zero for silence', () => {
+    const analyser = createMockAnalyser(48000, 256, (arr: Uint8Array) => {
+      arr.fill(0);
+    });
+
+    const dataArray = new Uint8Array(128);
+    const level = computeVoiceLevel(analyser, dataArray);
+    expect(level).toBe(0);
+  });
+
+  it('returns 100 for max amplitude in voice range', () => {
+    const analyser = createMockAnalyser(48000, 256, (arr: Uint8Array) => {
+      arr.fill(255);
+    });
+
+    const dataArray = new Uint8Array(128);
+    const level = computeVoiceLevel(analyser, dataArray);
+    expect(level).toBeCloseTo(100, 0);
+  });
+
+  it('ignores high-frequency noise outside voice range', () => {
+    const fftSize = 256;
+    const sampleRate = 48000;
+    const binHz = sampleRate / fftSize;
+    const voiceEnd = Math.ceil(4000 / binHz);
+
+    const analyser = createMockAnalyser(sampleRate, fftSize, (arr: Uint8Array) => {
+      // Voice bins silent, high-frequency bins loud
+      for (let i = 0; i < arr.length; i++) {
+        arr[i] = i >= voiceEnd ? 255 : 0;
+      }
+    });
+
+    const dataArray = new Uint8Array(128);
+    const level = computeVoiceLevel(analyser, dataArray);
+    expect(level).toBe(0);
+  });
+});

--- a/frontend/src/components/Settings/AudioVideoSettingsPanel.tsx
+++ b/frontend/src/components/Settings/AudioVideoSettingsPanel.tsx
@@ -37,7 +37,7 @@ import { useVoiceSettings, VoiceInputMode } from '../../hooks/useVoiceSettings';
 
 interface AudioVideoSettingsPanelProps {
   /** Callback when user changes device selection (for live-switching during calls) */
-  onDeviceChange?: (type: 'audio' | 'video', deviceId: string) => void;
+  onDeviceChange?: (type: 'audio' | 'video' | 'audioOutput', deviceId: string) => void;
   /** When false, stops active device tests. Dialog passes `open` here. Default: true */
   active?: boolean;
   /** Whether to show the "Voice & Video" title row with refresh icon. Default: true */
@@ -420,7 +420,10 @@ const AudioVideoSettingsPanel: React.FC<AudioVideoSettingsPanelProps> = ({
           <Select
             value={selectedAudioOutputId}
             label="Speakers"
-            onChange={(e) => setSelectedAudioOutput(e.target.value)}
+            onChange={(e) => {
+              setSelectedAudioOutput(e.target.value);
+              onDeviceChange?.('audioOutput', e.target.value);
+            }}
             disabled={audioOutputDevices.length === 0}
           >
             {renderDeviceMenuItems(audioOutputDevices, selectedAudioOutputId)}

--- a/frontend/src/components/Voice/AudioRenderer.tsx
+++ b/frontend/src/components/Voice/AudioRenderer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { RemoteParticipant, RemoteTrackPublication, Track, AudioTrack, RoomEvent } from 'livekit-client';
 import { useRoom } from '../../hooks/useRoom';
+import { useVoice } from '../../contexts/VoiceContext';
 import { logger } from '../../utils/logger';
 
 /**
@@ -67,6 +68,7 @@ const ParticipantAudio: React.FC<ParticipantAudioProps> = ({ participant, audioP
  */
 export const AudioRenderer: React.FC = () => {
   const { room } = useRoom();
+  const { showVideoTiles } = useVoice();
   const [audioTracks, setAudioTracks] = useState<Map<string, { participant: RemoteParticipant; publication: RemoteTrackPublication }>>(new Map());
 
   // Update audio tracks list when participants/tracks change
@@ -82,8 +84,10 @@ export const AudioRenderer: React.FC = () => {
     logger.debug('[AudioRenderer] Updating audio tracks, remote participants:', room.remoteParticipants.size);
     room.remoteParticipants.forEach((participant) => {
       participant.audioTrackPublications.forEach((publication) => {
-        // Include microphone and screen share audio tracks
-        if ((publication.source === Track.Source.Microphone || publication.source === Track.Source.ScreenShareAudio) && publication.track) {
+        // Include microphone tracks always; screen share audio only when video tiles are open
+        const isMic = publication.source === Track.Source.Microphone;
+        const isScreenShareAudio = publication.source === Track.Source.ScreenShareAudio && showVideoTiles;
+        if ((isMic || isScreenShareAudio) && publication.track) {
           const key = `${participant.identity}-${publication.trackSid}`;
           newTracks.set(key, { participant, publication });
           logger.debug('[AudioRenderer] Found audio track for:', participant.identity);
@@ -93,7 +97,7 @@ export const AudioRenderer: React.FC = () => {
 
     logger.info('[AudioRenderer] Audio tracks updated, count:', newTracks.size);
     setAudioTracks(newTracks);
-  }, [room]);
+  }, [room, showVideoTiles]);
 
   useEffect(() => {
     if (!room) return;

--- a/frontend/src/components/Voice/DeviceSettingsDialog.tsx
+++ b/frontend/src/components/Voice/DeviceSettingsDialog.tsx
@@ -11,7 +11,7 @@ import AudioVideoSettingsPanel from '../Settings/AudioVideoSettingsPanel';
 interface DeviceSettingsDialogProps {
   open: boolean;
   onClose: () => void;
-  onDeviceChange?: (type: 'audio' | 'video', deviceId: string) => void;
+  onDeviceChange?: (type: 'audio' | 'video' | 'audioOutput', deviceId: string) => void;
 }
 
 export const DeviceSettingsDialog: React.FC<DeviceSettingsDialogProps> = ({

--- a/frontend/src/components/Voice/VoiceBottomBar.tsx
+++ b/frontend/src/components/Voice/VoiceBottomBar.tsx
@@ -123,10 +123,12 @@ export const VoiceBottomBar: React.FC = () => {
     setShowDeviceSettings(false);
   }, []);
 
-  const handleDeviceChange = useCallback(async (type: 'audio' | 'video', deviceId: string) => {
+  const handleDeviceChange = useCallback(async (type: 'audio' | 'video' | 'audioOutput', deviceId: string) => {
     try {
       if (type === 'audio') {
         await actions.switchAudioInputDevice(deviceId);
+      } else if (type === 'audioOutput') {
+        await actions.switchAudioOutputDevice(deviceId);
       } else if (type === 'video') {
         await actions.switchVideoInputDevice(deviceId);
       }

--- a/frontend/src/components/Voice/components/CompactUserItem.tsx
+++ b/frontend/src/components/Voice/components/CompactUserItem.tsx
@@ -41,9 +41,9 @@ const CompactUserItem: React.FC<CompactUserItemProps> = React.memo(({
   onShowVideoTiles,
 }) => {
   const theme = useTheme();
-  const speaking = isSpeaking(user.id);
   const livekitState = useParticipantTracks(user.id);
   const userState = deriveUserState(livekitState, user);
+  const speaking = isSpeaking(user.id) && !userState.isMuted && !userState.isServerMuted && !userState.isDeafened;
 
   // Check if locally muted (volume = 0 in localStorage)
   const isLocalUser = localParticipantIdentity === user.id;

--- a/frontend/src/features/voice/voiceActions.ts
+++ b/frontend/src/features/voice/voiceActions.ts
@@ -685,6 +685,9 @@ export async function switchAudioInputDevice(
   try {
     await room.switchActiveDevice('audioinput', deviceId);
     dispatch({ type: VoiceActionType.SetSelectedAudioInputId, payload: deviceId });
+    // Persist so the preference survives page refresh
+    const saved = getCachedItem<DevicePreferences>(DEVICE_PREFERENCES_KEY);
+    setCachedItem(DEVICE_PREFERENCES_KEY, { ...saved, audioInputDeviceId: deviceId });
     logger.info('[Voice] Switched audio input device:', deviceId);
   } catch (error) {
     logger.error("Failed to switch audio input device:", error);
@@ -705,6 +708,8 @@ export async function switchAudioOutputDevice(
   try {
     await room.switchActiveDevice('audiooutput', deviceId);
     dispatch({ type: VoiceActionType.SetSelectedAudioOutputId, payload: deviceId });
+    const saved = getCachedItem<DevicePreferences>(DEVICE_PREFERENCES_KEY);
+    setCachedItem(DEVICE_PREFERENCES_KEY, { ...saved, audioOutputDeviceId: deviceId });
     logger.info('[Voice] Switched audio output device:', deviceId);
   } catch (error) {
     logger.error("Failed to switch audio output device:", error);
@@ -725,6 +730,8 @@ export async function switchVideoInputDevice(
   try {
     await room.switchActiveDevice('videoinput', deviceId);
     dispatch({ type: VoiceActionType.SetSelectedVideoInputId, payload: deviceId });
+    const saved = getCachedItem<DevicePreferences>(DEVICE_PREFERENCES_KEY);
+    setCachedItem(DEVICE_PREFERENCES_KEY, { ...saved, videoInputDeviceId: deviceId });
   } catch (error) {
     logger.error("Failed to switch video input device:", error);
     throw error;

--- a/frontend/src/hooks/useDeviceTest.ts
+++ b/frontend/src/hooks/useDeviceTest.ts
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { logger } from '../utils/logger';
+import { computeVoiceLevel } from '../utils/audioLevel';
 
 interface UseDeviceTestOptions {
   videoRef: React.RefObject<HTMLVideoElement | null>;
@@ -124,14 +125,7 @@ export function useDeviceTest({
       const updateLevel = (): void => {
         if (!analyserRef.current) return;
 
-        analyser.getByteFrequencyData(dataArray);
-
-        let sum = 0;
-        for (let i = 0; i < dataArray.length; i++) {
-          sum += dataArray[i];
-        }
-        const average = sum / dataArray.length;
-        const raw = (average / 255) * 100;
+        const raw = computeVoiceLevel(analyser, dataArray);
         const level = Math.min(100, raw * 2);
         setRawAudioLevel(raw);
         setAudioLevel(level);

--- a/frontend/src/hooks/useSpeakingDetection.ts
+++ b/frontend/src/hooks/useSpeakingDetection.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useRoom } from "./useRoom";
 import { Participant, Track } from "livekit-client";
 import { getCachedItem } from "../utils/storage";
+import { computeVoiceLevel } from "../utils/audioLevel";
 
 const VOICE_SETTINGS_KEY = 'semaphore_voice_settings';
 const HOLD_OPEN_MS = 300;
@@ -195,15 +196,7 @@ export const useSpeakingDetection = () => {
             cachedSettingsRef.current = readSettings();
           }
 
-          analyser.getByteFrequencyData(dataArray);
-
-          // Compute RMS-like level (0-100)
-          let sum = 0;
-          for (let i = 0; i < dataArray.length; i++) {
-            sum += dataArray[i];
-          }
-          const average = sum / dataArray.length;
-          const level = (average / 255) * 100;
+          const level = computeVoiceLevel(analyser, dataArray);
 
           const { threshold, isVoiceActivity } = cachedSettingsRef.current;
           const now = Date.now();
@@ -228,7 +221,9 @@ export const useSpeakingDetection = () => {
                   gateOpenRef.current = false;
                   gateDisabledTrackRef.current = true;
                   lastGateCloseRef.current = now;
-                  mediaStreamTrack.enabled = false;
+                  // Re-acquire track ref to avoid stale closure after LiveKit track replacement
+                  const currentTrackOff = local.getTrackPublication(Track.Source.Microphone)?.track?.mediaStreamTrack;
+                  if (currentTrackOff) currentTrackOff.enabled = false;
                   setSpeakingMap((prev) => {
                     if (prev.get(local.identity) === false) return prev;
                     const newMap = new Map(prev);
@@ -245,7 +240,9 @@ export const useSpeakingDetection = () => {
                   gateOpenRef.current = true;
                   gateDisabledTrackRef.current = false;
                   lastAboveThresholdRef.current = now;
-                  mediaStreamTrack.enabled = true;
+                  // Re-acquire track ref to avoid stale closure after LiveKit track replacement
+                  const currentTrackOn = local.getTrackPublication(Track.Source.Microphone)?.track?.mediaStreamTrack;
+                  if (currentTrackOn) currentTrackOn.enabled = true;
                   setSpeakingMap((prev) => {
                     if (prev.get(local.identity) === true) return prev;
                     const newMap = new Map(prev);
@@ -260,7 +257,8 @@ export const useSpeakingDetection = () => {
             // Only undo gate-caused disables; never touch track.enabled otherwise
             // (PTT/manual mute control it via LiveKit's publish/unpublish)
             if (gateDisabledTrackRef.current) {
-              mediaStreamTrack.enabled = true;
+              const currentTrackRestore = local.getTrackPublication(Track.Source.Microphone)?.track?.mediaStreamTrack;
+              if (currentTrackRestore) currentTrackRestore.enabled = true;
               gateDisabledTrackRef.current = false;
               gateOpenRef.current = true;
             }

--- a/frontend/src/utils/audioLevel.ts
+++ b/frontend/src/utils/audioLevel.ts
@@ -1,0 +1,36 @@
+/**
+ * Compute audio level using only voice-frequency bins (80Hz–4000Hz).
+ *
+ * The default approach of averaging ALL FFT bins dilutes voice energy
+ * because most high-frequency bins are near zero for speech. Restricting
+ * to the voice band produces levels of ~30-60 for normal speech instead
+ * of ~5-15, making the sensitivity slider usable across its full range.
+ */
+export function computeVoiceLevel(
+  analyser: AnalyserNode,
+  dataArray: Uint8Array,
+): number {
+  analyser.getByteFrequencyData(dataArray);
+
+  const sampleRate = analyser.context.sampleRate;
+  const binHz = sampleRate / (analyser.fftSize || 256);
+  const startBin = Math.max(1, Math.floor(80 / binHz));
+  const endBin = Math.min(dataArray.length, Math.ceil(4000 / binHz));
+  const binCount = endBin - startBin;
+
+  if (binCount <= 0) {
+    // Fallback: average all bins if sample rate / fftSize don't give valid range
+    let sum = 0;
+    for (let i = 0; i < dataArray.length; i++) {
+      sum += dataArray[i];
+    }
+    return (sum / dataArray.length / 255) * 100;
+  }
+
+  let sum = 0;
+  for (let i = startBin; i < endBin; i++) {
+    sum += dataArray[i];
+  }
+
+  return (sum / binCount / 255) * 100;
+}


### PR DESCRIPTION
## Summary
- **Muted speaking indicator**: Check mute/deafen/server-mute state before showing green speaking border in `CompactUserItem` — fixes LiveKit VAD not clearing `isSpeaking` after track mute
- **Voice gate stale track ref**: Re-acquire `MediaStreamTrack` from LiveKit publication on each gate toggle instead of using closure-captured reference that goes stale after track replacement
- **Unusable sensitivity slider**: New `computeVoiceLevel()` utility restricts FFT analysis to voice-frequency bins (80–4000Hz) — normal speech now produces levels ~30-60 instead of ~5-15, making the full slider range usable
- **Screen share audio leak**: Gate `ScreenShareAudio` tracks in `AudioRenderer` on `showVideoTiles` state — users must click "View screen share" to hear screen share audio (matches Discord's Watch Stream UX)
- **Device switching during calls**: Persist device changes to localStorage after LiveKit switch (was only updating React state), and wire up audio output switching via `onDeviceChange` callback

## Test plan
- [x] All 1118 frontend tests pass
- [x] TypeScript type-check passes
- [ ] Manual: join voice channel, mute → verify no green speaking border on muted users
- [ ] Manual: adjust sensitivity slider → verify gate works at ~50% sensitivity (not just 98%+)
- [ ] Manual: another user starts screen share → verify no audio until "View screen share" clicked
- [ ] Manual: switch microphone/speaker during active call → verify it works and persists after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)