### PR TITLE
feat: embedded link previews (#338)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8426,6 +8426,9 @@
           "faviconUrl": {
             "type": "string"
           },
+          "authorName": {
+            "type": "string"
+          },
           "url": {
             "type": "string"
           }

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8408,6 +8408,32 @@
           "lastReplyAt"
         ]
       },
+      "LinkPreviewDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "siteName": {
+            "type": "string"
+          },
+          "faviconUrl": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ]
+      },
       "SpanDto": {
         "type": "object",
         "properties": {
@@ -8543,6 +8569,12 @@
       "EnrichedMessageDto": {
         "type": "object",
         "properties": {
+          "linkPreviews": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LinkPreviewDto"
+            }
+          },
           "replyToId": {
             "type": "string",
             "nullable": true
@@ -8702,6 +8734,12 @@
       "MessageDto": {
         "type": "object",
         "properties": {
+          "linkPreviews": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LinkPreviewDto"
+            }
+          },
           "replyToId": {
             "type": "string",
             "nullable": true

--- a/backend/prisma/migrations/20260409012103_add_link_previews/migration.sql
+++ b/backend/prisma/migrations/20260409012103_add_link_previews/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `searchVector` on the `Message` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "Message_searchVector_idx";
+
+-- AlterTable
+ALTER TABLE "Message" DROP COLUMN "searchVector",
+ADD COLUMN     "linkPreviews" JSONB;

--- a/backend/prisma/migrations/20260409012103_add_link_previews/migration.sql
+++ b/backend/prisma/migrations/20260409012103_add_link_previews/migration.sql
@@ -1,12 +1,2 @@
-/*
-  Warnings:
-
-  - You are about to drop the column `searchVector` on the `Message` table. All the data in the column will be lost.
-
-*/
--- DropIndex
-DROP INDEX "Message_searchVector_idx";
-
 -- AlterTable
-ALTER TABLE "Message" DROP COLUMN "searchVector",
-ADD COLUMN     "linkPreviews" JSONB;
+ALTER TABLE "Message" ADD COLUMN "linkPreviews" JSONB;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -38,6 +38,9 @@ model Message {
   // Inline reply (quote) reference
   replyToId String? // If set, this message quotes another message
 
+  // Link preview metadata (fetched asynchronously after message creation)
+  linkPreviews Json? // [{url, title, description, imageUrl, siteName, faviconUrl}]
+
   // Relations (composite types → proper tables)
   spans       MessageSpan[]
   reactions   MessageReaction[]

--- a/backend/src/health/indicators/database.health-indicator.spec.ts
+++ b/backend/src/health/indicators/database.health-indicator.spec.ts
@@ -55,9 +55,7 @@ describe('DatabaseHealthIndicator', () => {
   it('should throw HealthCheckError when query times out', async () => {
     jest.useFakeTimers();
 
-    databaseService.$executeRaw.mockReturnValue(
-      new Promise(() => {}) as never,
-    );
+    databaseService.$executeRaw.mockReturnValue(new Promise(() => {}) as never);
 
     const healthPromise = indicator.isHealthy('database');
     jest.advanceTimersByTime(3000);

--- a/backend/src/link-previews/link-preview.utils.spec.ts
+++ b/backend/src/link-previews/link-preview.utils.spec.ts
@@ -1,0 +1,453 @@
+import {
+  extractUrls,
+  parseOpenGraphTags,
+  sanitizePreview,
+  isPublicUrl,
+  findOEmbedProvider,
+  mergeOEmbedData,
+  LinkPreviewData,
+} from './link-preview.utils';
+import { promises as dns } from 'dns';
+
+jest.mock('dns', () => ({
+  promises: {
+    lookup: jest.fn(),
+  },
+}));
+
+const mockLookup = dns.lookup as jest.MockedFunction<typeof dns.lookup>;
+
+describe('link-preview.utils', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('extractUrls', () => {
+    it('should return empty array when text has no URLs', () => {
+      expect(extractUrls('hello world no links here')).toEqual([]);
+    });
+
+    it('should extract a single URL', () => {
+      const text = 'Check out https://example.com for more';
+      expect(extractUrls(text)).toEqual(['https://example.com']);
+    });
+
+    it('should extract multiple URLs', () => {
+      const text = 'Visit https://example.com and http://test.org for info';
+      expect(extractUrls(text)).toEqual([
+        'https://example.com',
+        'http://test.org',
+      ]);
+    });
+
+    it('should deduplicate URLs', () => {
+      const text =
+        'Go to https://example.com and again https://example.com please';
+      expect(extractUrls(text)).toEqual(['https://example.com']);
+    });
+
+    it('should cap at 5 URLs', () => {
+      const urls = Array.from({ length: 8 }, (_, i) => `https://site${i}.com`);
+      const text = urls.join(' ');
+      const result = extractUrls(text);
+      expect(result).toHaveLength(5);
+      expect(result).toEqual(urls.slice(0, 5));
+    });
+
+    it('should strip trailing punctuation from URLs', () => {
+      const cases = [
+        ['See https://example.com.', 'https://example.com'],
+        ['Link: https://example.com,', 'https://example.com'],
+        ['Wow https://example.com!', 'https://example.com'],
+        ['Is it https://example.com?', 'https://example.com'],
+        ['At https://example.com;', 'https://example.com'],
+        ['From https://example.com:', 'https://example.com'],
+      ];
+      for (const [input, expected] of cases) {
+        expect(extractUrls(input)).toEqual([expected]);
+      }
+    });
+
+    it('should return empty array for empty string', () => {
+      expect(extractUrls('')).toEqual([]);
+    });
+  });
+
+  describe('parseOpenGraphTags', () => {
+    const baseUrl = 'https://example.com/page';
+
+    it('should parse og:title', () => {
+      const html = '<meta property="og:title" content="My Title" />';
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result.title).toBe('My Title');
+    });
+
+    it('should parse og:description', () => {
+      const html =
+        '<meta property="og:description" content="My Description" />';
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result.description).toBe('My Description');
+    });
+
+    it('should parse og:image with absolute URL', () => {
+      const html =
+        '<meta property="og:image" content="https://cdn.example.com/img.png" />';
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result.imageUrl).toBe('https://cdn.example.com/img.png');
+    });
+
+    it('should parse og:site_name', () => {
+      const html = '<meta property="og:site_name" content="Example Site" />';
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result.siteName).toBe('Example Site');
+    });
+
+    it('should parse all og tags together', () => {
+      const html = `
+        <html>
+          <head>
+            <meta property="og:title" content="Full OG" />
+            <meta property="og:description" content="Full desc" />
+            <meta property="og:image" content="https://img.test/og.jpg" />
+            <meta property="og:site_name" content="TestSite" />
+          </head>
+        </html>
+      `;
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result).toEqual({
+        title: 'Full OG',
+        description: 'Full desc',
+        imageUrl: 'https://img.test/og.jpg',
+        siteName: 'TestSite',
+      });
+    });
+
+    it('should fallback to <title> tag when no og:title', () => {
+      const html = '<html><head><title>Page Title</title></head></html>';
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result.title).toBe('Page Title');
+    });
+
+    it('should prefer og:title over <title> tag', () => {
+      const html = `
+        <head>
+          <title>Fallback Title</title>
+          <meta property="og:title" content="OG Title" />
+        </head>
+      `;
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result.title).toBe('OG Title');
+    });
+
+    it('should fallback to <meta name="description"> when no og:description', () => {
+      const html =
+        '<meta name="description" content="Meta description text" />';
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result.description).toBe('Meta description text');
+    });
+
+    it('should prefer og:description over meta description', () => {
+      const html = `
+        <meta name="description" content="Fallback desc" />
+        <meta property="og:description" content="OG desc" />
+      `;
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result.description).toBe('OG desc');
+    });
+
+    it('should resolve relative image URL against baseUrl', () => {
+      const html = '<meta property="og:image" content="/images/thumb.png" />';
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result.imageUrl).toBe('https://example.com/images/thumb.png');
+    });
+
+    it('should extract favicon from <link rel="icon">', () => {
+      const html = '<link rel="icon" href="/favicon.ico" />';
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result.faviconUrl).toBe('https://example.com/favicon.ico');
+    });
+
+    it('should extract favicon from <link rel="shortcut icon">', () => {
+      const html =
+        '<link rel="shortcut icon" href="https://cdn.example.com/fav.png" />';
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result.faviconUrl).toBe('https://cdn.example.com/fav.png');
+    });
+
+    it('should handle content attribute before property attribute', () => {
+      const html = '<meta content="Reversed Tag" property="og:title" />';
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result.title).toBe('Reversed Tag');
+    });
+
+    it('should return empty object for HTML with no tags', () => {
+      const html = '<html><body>No meta tags here</body></html>';
+      const result = parseOpenGraphTags(html, baseUrl);
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('sanitizePreview', () => {
+    it('should strip HTML from title', () => {
+      const preview: Partial<LinkPreviewData> = {
+        title: '<b>Bold</b> Title',
+      };
+      const result = sanitizePreview(preview);
+      expect(result.title).toBe('Bold Title');
+    });
+
+    it('should strip HTML from description', () => {
+      const preview: Partial<LinkPreviewData> = {
+        description: '<script>alert("xss")</script>Clean text',
+      };
+      const result = sanitizePreview(preview);
+      expect(result.description).toBe('alert("xss")Clean text');
+    });
+
+    it('should truncate title to 200 characters', () => {
+      const longTitle = 'A'.repeat(250);
+      const result = sanitizePreview({ title: longTitle });
+      expect(result.title).toHaveLength(200);
+    });
+
+    it('should truncate description to 300 characters', () => {
+      const longDesc = 'B'.repeat(350);
+      const result = sanitizePreview({ description: longDesc });
+      expect(result.description).toHaveLength(300);
+    });
+
+    it('should truncate siteName to 100 characters', () => {
+      const longSite = 'C'.repeat(150);
+      const result = sanitizePreview({ siteName: longSite });
+      expect(result.siteName).toHaveLength(100);
+    });
+
+    it('should keep valid http imageUrl', () => {
+      const result = sanitizePreview({
+        imageUrl: 'https://cdn.example.com/img.png',
+      });
+      expect(result.imageUrl).toBe('https://cdn.example.com/img.png');
+    });
+
+    it('should filter out invalid imageUrl', () => {
+      const result = sanitizePreview({
+        imageUrl: 'javascript:alert(1)',
+      });
+      expect(result.imageUrl).toBeUndefined();
+    });
+
+    it('should filter out non-http imageUrl', () => {
+      const result = sanitizePreview({
+        imageUrl: 'ftp://example.com/img.png',
+      });
+      expect(result.imageUrl).toBeUndefined();
+    });
+
+    it('should keep valid http faviconUrl', () => {
+      const result = sanitizePreview({
+        faviconUrl: 'https://example.com/favicon.ico',
+      });
+      expect(result.faviconUrl).toBe('https://example.com/favicon.ico');
+    });
+
+    it('should filter out invalid faviconUrl', () => {
+      const result = sanitizePreview({
+        faviconUrl: 'not-a-url',
+      });
+      expect(result.faviconUrl).toBeUndefined();
+    });
+
+    it('should decode HTML entities', () => {
+      const result = sanitizePreview({
+        title: 'Tom &amp; Jerry &lt;3&gt;',
+      });
+      expect(result.title).toBe('Tom & Jerry <3>');
+    });
+
+    it('should return empty object for empty preview', () => {
+      expect(sanitizePreview({})).toEqual({});
+    });
+
+    it('should handle preview with all fields', () => {
+      const preview: Partial<LinkPreviewData> = {
+        title: '<em>Title</em>',
+        description: '<p>Desc</p>',
+        imageUrl: 'https://img.test/pic.jpg',
+        siteName: 'Site&amp;Name',
+        faviconUrl: 'https://img.test/fav.ico',
+      };
+      const result = sanitizePreview(preview);
+      expect(result).toEqual({
+        title: 'Title',
+        description: 'Desc',
+        imageUrl: 'https://img.test/pic.jpg',
+        siteName: 'Site&Name',
+        faviconUrl: 'https://img.test/fav.ico',
+      });
+    });
+  });
+
+  describe('isPublicUrl', () => {
+    it('should block localhost (127.0.0.1)', async () => {
+      mockLookup.mockResolvedValue({ address: '127.0.0.1', family: 4 });
+      expect(await isPublicUrl('localhost')).toBe(false);
+    });
+
+    it('should block 127.x.x.x range', async () => {
+      mockLookup.mockResolvedValue({ address: '127.0.0.2', family: 4 });
+      expect(await isPublicUrl('some-host')).toBe(false);
+    });
+
+    it('should block 10.x.x.x private range', async () => {
+      mockLookup.mockResolvedValue({ address: '10.0.0.5', family: 4 });
+      expect(await isPublicUrl('internal.corp')).toBe(false);
+    });
+
+    it('should block 172.16.x.x private range', async () => {
+      mockLookup.mockResolvedValue({ address: '172.16.0.1', family: 4 });
+      expect(await isPublicUrl('internal.corp')).toBe(false);
+    });
+
+    it('should block 172.31.x.x private range', async () => {
+      mockLookup.mockResolvedValue({ address: '172.31.255.1', family: 4 });
+      expect(await isPublicUrl('internal.corp')).toBe(false);
+    });
+
+    it('should block 192.168.x.x private range', async () => {
+      mockLookup.mockResolvedValue({ address: '192.168.1.1', family: 4 });
+      expect(await isPublicUrl('home.local')).toBe(false);
+    });
+
+    it('should block 169.254.x.x link-local range', async () => {
+      mockLookup.mockResolvedValue({ address: '169.254.169.254', family: 4 });
+      expect(await isPublicUrl('metadata.cloud')).toBe(false);
+    });
+
+    it('should block IPv6 loopback ::1', async () => {
+      mockLookup.mockResolvedValue({ address: '::1', family: 6 });
+      expect(await isPublicUrl('localhost6')).toBe(false);
+    });
+
+    it('should block IPv6 unspecified ::', async () => {
+      mockLookup.mockResolvedValue({ address: '::', family: 6 });
+      expect(await isPublicUrl('any')).toBe(false);
+    });
+
+    it('should allow public IP addresses', async () => {
+      mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+      expect(await isPublicUrl('example.com')).toBe(true);
+    });
+
+    it('should allow another public IP', async () => {
+      mockLookup.mockResolvedValue({ address: '8.8.8.8', family: 4 });
+      expect(await isPublicUrl('dns.google')).toBe(true);
+    });
+
+    it('should return false when DNS lookup fails', async () => {
+      mockLookup.mockRejectedValue(new Error('ENOTFOUND'));
+      expect(await isPublicUrl('nonexistent.invalid')).toBe(false);
+    });
+
+    it('should not block 172.15.x.x (outside private range)', async () => {
+      mockLookup.mockResolvedValue({ address: '172.15.0.1', family: 4 });
+      expect(await isPublicUrl('edge-case.net')).toBe(true);
+    });
+
+    it('should not block 172.32.x.x (outside private range)', async () => {
+      mockLookup.mockResolvedValue({ address: '172.32.0.1', family: 4 });
+      expect(await isPublicUrl('edge-case.net')).toBe(true);
+    });
+  });
+
+  describe('findOEmbedProvider', () => {
+    it('should match YouTube watch URLs', () => {
+      expect(findOEmbedProvider('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).not.toBeNull();
+      expect(findOEmbedProvider('https://youtube.com/watch?v=abc')).not.toBeNull();
+    });
+
+    it('should match YouTube short URLs', () => {
+      expect(findOEmbedProvider('https://youtu.be/dQw4w9WgXcQ')).not.toBeNull();
+    });
+
+    it('should match YouTube Shorts', () => {
+      expect(findOEmbedProvider('https://www.youtube.com/shorts/abc123')).not.toBeNull();
+    });
+
+    it('should match Spotify URLs', () => {
+      expect(findOEmbedProvider('https://open.spotify.com/track/abc')).not.toBeNull();
+    });
+
+    it('should match Vimeo URLs', () => {
+      expect(findOEmbedProvider('https://vimeo.com/123456')).not.toBeNull();
+    });
+
+    it('should match TikTok URLs', () => {
+      expect(findOEmbedProvider('https://www.tiktok.com/@user/video/123')).not.toBeNull();
+    });
+
+    it('should return null for non-matching URLs', () => {
+      expect(findOEmbedProvider('https://example.com')).toBeNull();
+      expect(findOEmbedProvider('https://www.reddit.com/r/test')).toBeNull();
+      expect(findOEmbedProvider('https://github.com/test')).toBeNull();
+    });
+  });
+
+  describe('mergeOEmbedData', () => {
+    it('should prefer oEmbed thumbnail over OG image', () => {
+      const og: Partial<LinkPreviewData> = {
+        title: 'OG Title',
+        imageUrl: 'https://og-image.jpg',
+        siteName: 'OG Site',
+      };
+      const oembed = {
+        thumbnail_url: 'https://oembed-thumb.jpg',
+        provider_name: 'oEmbed Provider',
+        title: 'oEmbed Title',
+      };
+      const merged = mergeOEmbedData(og, oembed);
+      expect(merged.imageUrl).toBe('https://oembed-thumb.jpg');
+    });
+
+    it('should keep OG image when oEmbed has no thumbnail', () => {
+      const og: Partial<LinkPreviewData> = { imageUrl: 'https://og-image.jpg' };
+      const oembed = {};
+      const merged = mergeOEmbedData(og, oembed);
+      expect(merged.imageUrl).toBe('https://og-image.jpg');
+    });
+
+    it('should use OG title over oEmbed title', () => {
+      const og: Partial<LinkPreviewData> = { title: 'OG Title' };
+      const oembed = { title: 'oEmbed Title' };
+      const merged = mergeOEmbedData(og, oembed);
+      expect(merged.title).toBe('OG Title');
+    });
+
+    it('should fall back to oEmbed title when OG has none', () => {
+      const og: Partial<LinkPreviewData> = {};
+      const oembed = { title: 'oEmbed Title' };
+      const merged = mergeOEmbedData(og, oembed);
+      expect(merged.title).toBe('oEmbed Title');
+    });
+
+    it('should add author_name from oEmbed', () => {
+      const og: Partial<LinkPreviewData> = { title: 'Test' };
+      const oembed = { author_name: 'Rick Astley' };
+      const merged = mergeOEmbedData(og, oembed);
+      expect(merged.authorName).toBe('Rick Astley');
+    });
+
+    it('should use provider_name as siteName fallback', () => {
+      const og: Partial<LinkPreviewData> = {};
+      const oembed = { provider_name: 'YouTube' };
+      const merged = mergeOEmbedData(og, oembed);
+      expect(merged.siteName).toBe('YouTube');
+    });
+
+    it('should keep OG siteName over oEmbed provider_name', () => {
+      const og: Partial<LinkPreviewData> = { siteName: 'OG Site' };
+      const oembed = { provider_name: 'oEmbed Provider' };
+      const merged = mergeOEmbedData(og, oembed);
+      expect(merged.siteName).toBe('OG Site');
+    });
+  });
+});

--- a/backend/src/link-previews/link-preview.utils.spec.ts
+++ b/backend/src/link-previews/link-preview.utils.spec.ts
@@ -15,7 +15,8 @@ jest.mock('dns', () => ({
   },
 }));
 
-const mockLookup = dns.lookup as jest.MockedFunction<typeof dns.lookup>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockLookup = dns.lookup as jest.Mock<any>;
 
 describe('link-preview.utils', () => {
   afterEach(() => {
@@ -289,57 +290,57 @@ describe('link-preview.utils', () => {
 
   describe('isPublicUrl', () => {
     it('should block localhost (127.0.0.1)', async () => {
-      mockLookup.mockResolvedValue({ address: '127.0.0.1', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
       expect(await isPublicUrl('localhost')).toBe(false);
     });
 
     it('should block 127.x.x.x range', async () => {
-      mockLookup.mockResolvedValue({ address: '127.0.0.2', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '127.0.0.2', family: 4 }]);
       expect(await isPublicUrl('some-host')).toBe(false);
     });
 
     it('should block 10.x.x.x private range', async () => {
-      mockLookup.mockResolvedValue({ address: '10.0.0.5', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
       expect(await isPublicUrl('internal.corp')).toBe(false);
     });
 
     it('should block 172.16.x.x private range', async () => {
-      mockLookup.mockResolvedValue({ address: '172.16.0.1', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '172.16.0.1', family: 4 }]);
       expect(await isPublicUrl('internal.corp')).toBe(false);
     });
 
     it('should block 172.31.x.x private range', async () => {
-      mockLookup.mockResolvedValue({ address: '172.31.255.1', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '172.31.255.1', family: 4 }]);
       expect(await isPublicUrl('internal.corp')).toBe(false);
     });
 
     it('should block 192.168.x.x private range', async () => {
-      mockLookup.mockResolvedValue({ address: '192.168.1.1', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '192.168.1.1', family: 4 }]);
       expect(await isPublicUrl('home.local')).toBe(false);
     });
 
     it('should block 169.254.x.x link-local range', async () => {
-      mockLookup.mockResolvedValue({ address: '169.254.169.254', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
       expect(await isPublicUrl('metadata.cloud')).toBe(false);
     });
 
     it('should block IPv6 loopback ::1', async () => {
-      mockLookup.mockResolvedValue({ address: '::1', family: 6 });
+      mockLookup.mockResolvedValue([{ address: '::1', family: 6 }]);
       expect(await isPublicUrl('localhost6')).toBe(false);
     });
 
     it('should block IPv6 unspecified ::', async () => {
-      mockLookup.mockResolvedValue({ address: '::', family: 6 });
+      mockLookup.mockResolvedValue([{ address: '::', family: 6 }]);
       expect(await isPublicUrl('any')).toBe(false);
     });
 
     it('should allow public IP addresses', async () => {
-      mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
       expect(await isPublicUrl('example.com')).toBe(true);
     });
 
     it('should allow another public IP', async () => {
-      mockLookup.mockResolvedValue({ address: '8.8.8.8', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
       expect(await isPublicUrl('dns.google')).toBe(true);
     });
 
@@ -349,12 +350,12 @@ describe('link-preview.utils', () => {
     });
 
     it('should not block 172.15.x.x (outside private range)', async () => {
-      mockLookup.mockResolvedValue({ address: '172.15.0.1', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '172.15.0.1', family: 4 }]);
       expect(await isPublicUrl('edge-case.net')).toBe(true);
     });
 
     it('should not block 172.32.x.x (outside private range)', async () => {
-      mockLookup.mockResolvedValue({ address: '172.32.0.1', family: 4 });
+      mockLookup.mockResolvedValue([{ address: '172.32.0.1', family: 4 }]);
       expect(await isPublicUrl('edge-case.net')).toBe(true);
     });
   });

--- a/backend/src/link-previews/link-preview.utils.ts
+++ b/backend/src/link-previews/link-preview.utils.ts
@@ -1,0 +1,435 @@
+import { promises as dns } from 'dns';
+
+export interface LinkPreviewData {
+  url: string;
+  title?: string;
+  description?: string;
+  imageUrl?: string;
+  siteName?: string;
+  faviconUrl?: string;
+  authorName?: string;
+}
+
+const URL_PATTERN = /(https?:\/\/[^\s<>)"']*[^\s<>)"'.,!?;:])/g;
+const MAX_URLS_PER_MESSAGE = 5;
+
+/**
+ * Extract unique URLs from text, limited to MAX_URLS_PER_MESSAGE.
+ */
+export function extractUrls(text: string): string[] {
+  const matches = text.match(URL_PATTERN);
+  if (!matches) return [];
+  const unique = [...new Set(matches)];
+  return unique.slice(0, MAX_URLS_PER_MESSAGE);
+}
+
+/**
+ * Parse Open Graph meta tags from an HTML string.
+ * Uses regex — no DOM parser dependency needed.
+ */
+export function parseOpenGraphTags(
+  html: string,
+  baseUrl: string,
+): Partial<LinkPreviewData> {
+  const result: Partial<LinkPreviewData> = {};
+
+  // Extract og: meta tags (property or name attribute)
+  const metaPattern =
+    /<meta\s+[^>]*(?:property|name)\s*=\s*["']og:(\w+)["'][^>]*content\s*=\s*["']([^"']*)["'][^>]*\/?>/gi;
+  const metaPatternReverse =
+    /<meta\s+[^>]*content\s*=\s*["']([^"']*)["'][^>]*(?:property|name)\s*=\s*["']og:(\w+)["'][^>]*\/?>/gi;
+
+  const ogTags: Record<string, string> = {};
+
+  let match: RegExpExecArray | null;
+  while ((match = metaPattern.exec(html)) !== null) {
+    ogTags[match[1].toLowerCase()] = match[2];
+  }
+  while ((match = metaPatternReverse.exec(html)) !== null) {
+    ogTags[match[2].toLowerCase()] = match[1];
+  }
+
+  if (ogTags['title']) result.title = ogTags['title'];
+  if (ogTags['description']) result.description = ogTags['description'];
+  if (ogTags['image']) result.imageUrl = resolveUrl(ogTags['image'], baseUrl);
+  if (ogTags['site_name']) result.siteName = ogTags['site_name'];
+
+  // Fallback: <title> tag
+  if (!result.title) {
+    const titleMatch = /<title[^>]*>([^<]+)<\/title>/i.exec(html);
+    if (titleMatch) result.title = titleMatch[1].trim();
+  }
+
+  // Fallback: <meta name="description"> (non-OG)
+  if (!result.description) {
+    const descPattern =
+      /<meta\s+[^>]*name\s*=\s*["']description["'][^>]*content\s*=\s*["']([^"']*)["'][^>]*\/?>/i;
+    const descMatch = descPattern.exec(html);
+    if (descMatch) result.description = descMatch[1];
+  }
+
+  // Favicon
+  const faviconPattern =
+    /<link\s+[^>]*rel\s*=\s*["'](?:shortcut )?icon["'][^>]*href\s*=\s*["']([^"']*)["'][^>]*\/?>/i;
+  const faviconMatch = faviconPattern.exec(html);
+  if (faviconMatch) {
+    result.faviconUrl = resolveUrl(faviconMatch[1], baseUrl);
+  }
+
+  return result;
+}
+
+/**
+ * Resolve a potentially relative URL against a base URL.
+ */
+function resolveUrl(url: string, baseUrl: string): string {
+  try {
+    return new URL(url, baseUrl).href;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Sanitize a link preview: strip HTML, truncate fields, validate URLs.
+ */
+export function sanitizePreview(
+  preview: Partial<LinkPreviewData>,
+): Partial<LinkPreviewData> {
+  const sanitized: Partial<LinkPreviewData> = {};
+
+  if (preview.title) {
+    sanitized.title = stripHtml(preview.title).slice(0, 200);
+  }
+  if (preview.description) {
+    sanitized.description = stripHtml(preview.description).slice(0, 300);
+  }
+  if (preview.imageUrl && isValidHttpUrl(preview.imageUrl)) {
+    sanitized.imageUrl = preview.imageUrl;
+  }
+  if (preview.siteName) {
+    sanitized.siteName = stripHtml(preview.siteName).slice(0, 100);
+  }
+  if (preview.faviconUrl && isValidHttpUrl(preview.faviconUrl)) {
+    sanitized.faviconUrl = preview.faviconUrl;
+  }
+  if (preview.authorName) {
+    sanitized.authorName = stripHtml(preview.authorName).slice(0, 100);
+  }
+
+  return sanitized;
+}
+
+function stripHtml(text: string): string {
+  return text
+    .replace(/<[^>]*>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .trim();
+}
+
+function isValidHttpUrl(str: string): boolean {
+  try {
+    const url = new URL(str);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// oEmbed support — supplementary data source alongside OG tags
+// ---------------------------------------------------------------------------
+
+interface OEmbedProvider {
+  patterns: RegExp[];
+  endpoint: string;
+}
+
+/**
+ * Hard-coded top oEmbed providers that return useful thumbnail/metadata.
+ * Only providers whose oEmbed responses include thumbnail_url are listed —
+ * providers that only return embed HTML (Reddit, Twitter) are excluded since
+ * OG tags give better card data for those.
+ */
+const OEMBED_PROVIDERS: OEmbedProvider[] = [
+  {
+    // YouTube
+    patterns: [
+      /^https?:\/\/(?:www\.)?youtube\.com\/watch/,
+      /^https?:\/\/youtu\.be\//,
+      /^https?:\/\/(?:www\.)?youtube\.com\/shorts\//,
+    ],
+    endpoint: 'https://www.youtube.com/oembed',
+  },
+  {
+    // Vimeo
+    patterns: [/^https?:\/\/(?:www\.)?vimeo\.com\/\d+/],
+    endpoint: 'https://vimeo.com/api/oembed.json',
+  },
+  {
+    // Spotify
+    patterns: [/^https?:\/\/open\.spotify\.com\//],
+    endpoint: 'https://open.spotify.com/oembed',
+  },
+  {
+    // SoundCloud
+    patterns: [/^https?:\/\/soundcloud\.com\//],
+    endpoint: 'https://soundcloud.com/oembed',
+  },
+  {
+    // Flickr
+    patterns: [
+      /^https?:\/\/(?:www\.)?flickr\.com\/photos\//,
+      /^https?:\/\/flic\.kr\//,
+    ],
+    endpoint: 'https://www.flickr.com/services/oembed/',
+  },
+  {
+    // TikTok
+    patterns: [/^https?:\/\/(?:www\.)?tiktok\.com\//],
+    endpoint: 'https://www.tiktok.com/oembed',
+  },
+];
+
+interface OEmbedResponse {
+  type?: string;
+  title?: string;
+  author_name?: string;
+  provider_name?: string;
+  thumbnail_url?: string;
+  thumbnail_width?: number;
+  thumbnail_height?: number;
+}
+
+/**
+ * Find an oEmbed provider for a URL. Returns null if no provider matches.
+ */
+export function findOEmbedProvider(url: string): OEmbedProvider | null {
+  for (const provider of OEMBED_PROVIDERS) {
+    if (provider.patterns.some((p) => p.test(url))) {
+      return provider;
+    }
+  }
+  return null;
+}
+
+/**
+ * Fetch oEmbed data for a URL from a known provider endpoint.
+ * Returns null on failure — never throws.
+ */
+export async function fetchOEmbed(
+  url: string,
+  provider: OEmbedProvider,
+): Promise<OEmbedResponse | null> {
+  try {
+    const oembedUrl = `${provider.endpoint}?url=${encodeURIComponent(url)}&format=json`;
+    const response = await fetch(oembedUrl, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) return null;
+    return (await response.json()) as OEmbedResponse;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Merge oEmbed data into a link preview, filling gaps.
+ * oEmbed thumbnail_url wins over OG image when available (typically higher quality).
+ * OG description is kept since oEmbed doesn't provide one.
+ */
+export function mergeOEmbedData(
+  preview: Partial<LinkPreviewData>,
+  oembed: OEmbedResponse,
+): Partial<LinkPreviewData> {
+  return {
+    ...preview,
+    // oEmbed thumbnail is usually higher quality than og:image
+    imageUrl: oembed.thumbnail_url || preview.imageUrl,
+    // oEmbed title as fallback
+    title: preview.title || oembed.title,
+    // provider_name as fallback for site name
+    siteName: preview.siteName || oembed.provider_name,
+    // author_name is oEmbed-only data
+    authorName: oembed.author_name || preview.authorName,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main fetch function
+// ---------------------------------------------------------------------------
+
+const MAX_BODY_SIZE = 50 * 1024; // 50KB
+const FETCH_TIMEOUT_MS = 5000;
+
+const FETCH_HEADERS = {
+  'User-Agent':
+    'SemaphoreChatBot/1.0 (+https://semaphorechat.app/bot; like Discordbot)',
+  Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+  'Accept-Language': 'en-US,en;q=0.5',
+  'Accept-Encoding': 'gzip, deflate',
+  Connection: 'keep-alive',
+};
+
+/**
+ * Fetch link preview metadata from a URL.
+ * Uses OG tags as the primary source, enriched with oEmbed data when a
+ * known provider matches (YouTube, Spotify, Vimeo, etc.).
+ * Returns null if the fetch fails or yields no useful metadata.
+ */
+export async function fetchLinkMetadata(
+  url: string,
+): Promise<LinkPreviewData | null> {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return null;
+  }
+
+  // SSRF protection
+  const safe = await isPublicUrl(parsedUrl.hostname);
+  if (!safe) return null;
+
+  // Check if a known oEmbed provider matches this URL
+  const oembedProvider = findOEmbedProvider(url);
+
+  try {
+    // Fetch OG tags and oEmbed in parallel when a provider exists
+    const [ogResult, oembedResult] = await Promise.all([
+      fetchOgTags(url, parsedUrl),
+      oembedProvider ? fetchOEmbed(url, oembedProvider) : null,
+    ]);
+
+    // Start with OG data (primary source for cards)
+    let preview = ogResult ?? {};
+
+    // Merge oEmbed data if available (better thumbnails, author info)
+    if (oembedResult) {
+      preview = mergeOEmbedData(preview, oembedResult);
+    }
+
+    const sanitized = sanitizePreview(preview);
+
+    // Must have at least a title to be useful
+    if (!sanitized.title) return null;
+
+    return { url, ...sanitized };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch and parse OG tags from an HTML page.
+ * Separated from fetchLinkMetadata to allow parallel oEmbed fetching.
+ */
+async function fetchOgTags(
+  url: string,
+  parsedUrl: URL,
+): Promise<Partial<LinkPreviewData> | null> {
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      redirect: 'follow',
+      headers: FETCH_HEADERS,
+    });
+
+    // Detect Cloudflare challenge responses via official cf-mitigated header
+    // See: https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/detect-response/
+    if (response.headers.get('cf-mitigated') === 'challenge') return null;
+
+    // Cloudflare 403/503 with server: cloudflare is a bot block
+    const isCloudflare = response.headers
+      .get('server')
+      ?.toLowerCase()
+      .includes('cloudflare');
+    if (isCloudflare && (response.status === 403 || response.status === 503)) {
+      return null;
+    }
+
+    if (!response.ok) return null;
+
+    const contentType = response.headers.get('content-type') || '';
+
+    // Direct image URL — return as image preview
+    if (contentType.startsWith('image/')) {
+      return {
+        imageUrl: url,
+        siteName: parsedUrl.hostname,
+      };
+    }
+
+    // Only parse HTML
+    if (!contentType.includes('text/html')) return null;
+
+    // Read limited body
+    const reader = response.body?.getReader();
+    if (!reader) return null;
+
+    let html = '';
+    let bytesRead = 0;
+    const decoder = new TextDecoder();
+
+    while (bytesRead < MAX_BODY_SIZE) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytesRead += value.length;
+      html += decoder.decode(value, { stream: true });
+    }
+    void reader.cancel();
+
+    // Detect challenge pages by body content (Cloudflare JS challenge fingerprint)
+    if (
+      html.includes('cf-browser-verification') ||
+      html.includes('challenges.cloudflare.com')
+    ) {
+      return null;
+    }
+
+    return parseOpenGraphTags(html, url);
+  } catch {
+    return null;
+  }
+}
+
+/** Private/reserved IPv4 and IPv6 ranges */
+const PRIVATE_RANGES = [
+  /^127\./, // loopback
+  /^10\./, // Class A private
+  /^172\.(1[6-9]|2\d|3[01])\./, // Class B private
+  /^192\.168\./, // Class C private
+  /^169\.254\./, // link-local
+  /^0\./, // unspecified
+];
+
+const PRIVATE_IPV6 = ['::1', '::'];
+
+/**
+ * Check if a hostname resolves to a public IP address.
+ * Blocks private/reserved ranges to prevent SSRF.
+ */
+export async function isPublicUrl(hostname: string): Promise<boolean> {
+  try {
+    const { address } = await dns.lookup(hostname);
+
+    // Check IPv4 private ranges
+    for (const range of PRIVATE_RANGES) {
+      if (range.test(address)) return false;
+    }
+
+    // Check IPv6 private
+    if (PRIVATE_IPV6.includes(address)) return false;
+
+    return true;
+  } catch {
+    // DNS resolution failed — treat as unsafe
+    return false;
+  }
+}

--- a/backend/src/link-previews/link-preview.utils.ts
+++ b/backend/src/link-previews/link-preview.utils.ts
@@ -330,6 +330,57 @@ export async function fetchLinkMetadata(
   }
 }
 
+const MAX_REDIRECTS = 5;
+
+/**
+ * Follow redirects manually, validating each hop's destination against SSRF.
+ * Returns the final Response or null if blocked/failed.
+ */
+async function fetchWithRedirectValidation(
+  url: string,
+  signal: AbortSignal,
+): Promise<Response | null> {
+  let currentUrl = url;
+
+  for (let i = 0; i <= MAX_REDIRECTS; i++) {
+    const response = await fetch(currentUrl, {
+      signal,
+      redirect: 'manual',
+      headers: FETCH_HEADERS,
+    });
+
+    // Not a redirect — return the response
+    if (response.status < 300 || response.status >= 400) {
+      return response;
+    }
+
+    // Handle redirect: validate destination before following
+    const location = response.headers.get('location');
+    if (!location) return null;
+
+    let nextUrl: URL;
+    try {
+      nextUrl = new URL(location, currentUrl);
+    } catch {
+      return null;
+    }
+
+    // Only follow http/https redirects
+    if (nextUrl.protocol !== 'http:' && nextUrl.protocol !== 'https:') {
+      return null;
+    }
+
+    // SSRF check on redirect destination
+    const safe = await isPublicUrl(nextUrl.hostname);
+    if (!safe) return null;
+
+    currentUrl = nextUrl.href;
+  }
+
+  // Too many redirects
+  return null;
+}
+
 /**
  * Fetch and parse OG tags from an HTML page.
  * Separated from fetchLinkMetadata to allow parallel oEmbed fetching.
@@ -339,11 +390,12 @@ async function fetchOgTags(
   parsedUrl: URL,
 ): Promise<Partial<LinkPreviewData> | null> {
   try {
-    const response = await fetch(url, {
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      redirect: 'follow',
-      headers: FETCH_HEADERS,
-    });
+    const response = await fetchWithRedirectValidation(
+      url,
+      AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    );
+
+    if (!response) return null;
 
     // Detect Cloudflare challenge responses via official cf-mitigated header
     // See: https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/detect-response/
@@ -362,9 +414,10 @@ async function fetchOgTags(
 
     const contentType = response.headers.get('content-type') || '';
 
-    // Direct image URL — return as image preview
+    // Direct image URL — set hostname as title so the preview isn't discarded
     if (contentType.startsWith('image/')) {
       return {
+        title: parsedUrl.pathname.split('/').pop() || parsedUrl.hostname,
         imageUrl: url,
         siteName: parsedUrl.hostname,
       };
@@ -403,8 +456,8 @@ async function fetchOgTags(
   }
 }
 
-/** Private/reserved IPv4 and IPv6 ranges */
-const PRIVATE_RANGES = [
+/** Private/reserved IPv4 ranges */
+const PRIVATE_IPV4_RANGES = [
   /^127\./, // loopback
   /^10\./, // Class A private
   /^172\.(1[6-9]|2\d|3[01])\./, // Class B private
@@ -413,25 +466,61 @@ const PRIVATE_RANGES = [
   /^0\./, // unspecified
 ];
 
-const PRIVATE_IPV6 = ['::1', '::'];
+/** Private/reserved IPv6 patterns */
+const PRIVATE_IPV6_PATTERNS = [
+  /^::1$/, // loopback
+  /^::$/, // unspecified
+  /^fe80:/i, // link-local
+  /^fc00:/i, // unique local (fc00::/7)
+  /^fd/i, // unique local (fd00::/8)
+  /^::ffff:/i, // IPv4-mapped IPv6 (e.g., ::ffff:127.0.0.1)
+];
+
+/**
+ * Check if an IP address is private/reserved.
+ */
+export function isPrivateIp(address: string): boolean {
+  // Check IPv4-mapped IPv6 addresses against IPv4 ranges
+  if (address.toLowerCase().startsWith('::ffff:')) {
+    const ipv4 = address.slice(7); // strip ::ffff: prefix
+    for (const range of PRIVATE_IPV4_RANGES) {
+      if (range.test(ipv4)) return true;
+    }
+  }
+
+  // Check IPv4 private ranges
+  for (const range of PRIVATE_IPV4_RANGES) {
+    if (range.test(address)) return true;
+  }
+
+  // Check IPv6 private ranges
+  for (const pattern of PRIVATE_IPV6_PATTERNS) {
+    if (pattern.test(address)) return true;
+  }
+
+  return false;
+}
 
 /**
  * Check if a hostname resolves to a public IP address.
- * Blocks private/reserved ranges to prevent SSRF.
+ * Resolves ALL addresses and blocks if ANY is private/reserved.
+ *
+ * Note: There is an inherent TOCTOU gap between this DNS check and the
+ * subsequent fetch() call — a malicious DNS server could return different
+ * results (DNS rebinding). This is accepted risk for a self-hosted app
+ * behind a firewall. The redirect validation in fetchOgTags provides an
+ * additional layer of defense.
  */
 export async function isPublicUrl(hostname: string): Promise<boolean> {
   try {
-    const { address } = await dns.lookup(hostname);
+    const results = await dns.lookup(hostname, { all: true });
 
-    // Check IPv4 private ranges
-    for (const range of PRIVATE_RANGES) {
-      if (range.test(address)) return false;
+    // Block if ANY resolved address is private
+    for (const { address } of results) {
+      if (isPrivateIp(address)) return false;
     }
 
-    // Check IPv6 private
-    if (PRIVATE_IPV6.includes(address)) return false;
-
-    return true;
+    return results.length > 0;
   } catch {
     // DNS resolution failed — treat as unsafe
     return false;

--- a/backend/src/link-previews/link-preview.utils.ts
+++ b/backend/src/link-previews/link-preview.utils.ts
@@ -34,10 +34,11 @@ export function parseOpenGraphTags(
   const result: Partial<LinkPreviewData> = {};
 
   // Extract og: meta tags (property or name attribute)
+  // Captures colon-separated variants like og:image:secure_url
   const metaPattern =
-    /<meta\s+[^>]*(?:property|name)\s*=\s*["']og:(\w+)["'][^>]*content\s*=\s*["']([^"']*)["'][^>]*\/?>/gi;
+    /<meta\s+[^>]*(?:property|name)\s*=\s*["']og:([\w:]+)["'][^>]*content\s*=\s*["']([^"']*)["'][^>]*\/?>/gi;
   const metaPatternReverse =
-    /<meta\s+[^>]*content\s*=\s*["']([^"']*)["'][^>]*(?:property|name)\s*=\s*["']og:(\w+)["'][^>]*\/?>/gi;
+    /<meta\s+[^>]*content\s*=\s*["']([^"']*)["'][^>]*(?:property|name)\s*=\s*["']og:([\w:]+)["'][^>]*\/?>/gi;
 
   const ogTags: Record<string, string> = {};
 
@@ -51,7 +52,10 @@ export function parseOpenGraphTags(
 
   if (ogTags['title']) result.title = ogTags['title'];
   if (ogTags['description']) result.description = ogTags['description'];
-  if (ogTags['image']) result.imageUrl = resolveUrl(ogTags['image'], baseUrl);
+  // og:image with fallback to og:image:secure_url and og:image:url
+  const ogImage =
+    ogTags['image'] || ogTags['image:secure_url'] || ogTags['image:url'];
+  if (ogImage) result.imageUrl = resolveUrl(ogImage, baseUrl);
   if (ogTags['site_name']) result.siteName = ogTags['site_name'];
 
   // Fallback: <title> tag

--- a/backend/src/link-previews/link-previews.module.ts
+++ b/backend/src/link-previews/link-previews.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { LinkPreviewsService } from './link-previews.service';
+import { DatabaseModule } from '@/database/database.module';
+import { WebsocketModule } from '@/websocket/websocket.module';
+
+@Module({
+  imports: [DatabaseModule, WebsocketModule],
+  providers: [LinkPreviewsService],
+  exports: [LinkPreviewsService],
+})
+export class LinkPreviewsModule {}

--- a/backend/src/link-previews/link-previews.service.spec.ts
+++ b/backend/src/link-previews/link-previews.service.spec.ts
@@ -1,0 +1,376 @@
+import { TestBed } from '@suites/unit';
+import type { Mocked } from '@suites/doubles.jest';
+import { LinkPreviewsService } from './link-previews.service';
+import { DatabaseService } from '@/database/database.service';
+import { WebsocketService } from '@/websocket/websocket.service';
+import { createMockDatabase } from '@/test-utils';
+import * as linkPreviewUtils from './link-preview.utils';
+
+jest.mock('./link-preview.utils', () => {
+  const actual = jest.requireActual('./link-preview.utils');
+  return {
+    ...actual,
+    fetchLinkMetadata: jest.fn(),
+  };
+});
+
+const mockFetchLinkMetadata =
+  linkPreviewUtils.fetchLinkMetadata as jest.MockedFunction<
+    typeof linkPreviewUtils.fetchLinkMetadata
+  >;
+
+describe('LinkPreviewsService', () => {
+  let service: LinkPreviewsService;
+  let mockDatabase: ReturnType<typeof createMockDatabase>;
+  let websocketService: Mocked<WebsocketService>;
+
+  const messageId = 'msg-001';
+  const roomId = 'room-abc';
+  const serverEvent = 'message:updated';
+
+  beforeEach(async () => {
+    mockDatabase = createMockDatabase();
+
+    const { unit, unitRef } = await TestBed.solitary(LinkPreviewsService)
+      .mock(DatabaseService)
+      .final(mockDatabase)
+      .compile();
+
+    service = unit;
+    websocketService = unitRef.get(WebsocketService);
+
+    mockFetchLinkMetadata.mockReset();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('processMessageLinkPreviews', () => {
+    it('should return early when spans have no text', async () => {
+      await service.processMessageLinkPreviews(
+        messageId,
+        [],
+        roomId,
+        serverEvent,
+      );
+
+      expect(mockDatabase.message.findUnique).not.toHaveBeenCalled();
+      expect(mockDatabase.message.update).not.toHaveBeenCalled();
+      expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+    });
+
+    it('should return early when spans contain only null/empty text', async () => {
+      const spans = [{ text: null }, { text: '' }];
+      await service.processMessageLinkPreviews(
+        messageId,
+        spans,
+        roomId,
+        serverEvent,
+      );
+
+      expect(mockDatabase.message.findUnique).not.toHaveBeenCalled();
+      expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+    });
+
+    it('should return early when text has no URLs', async () => {
+      const spans = [{ text: 'Hello world, no links here!' }];
+      await service.processMessageLinkPreviews(
+        messageId,
+        spans,
+        roomId,
+        serverEvent,
+      );
+
+      expect(mockFetchLinkMetadata).not.toHaveBeenCalled();
+      expect(mockDatabase.message.findUnique).not.toHaveBeenCalled();
+      expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+    });
+
+    it('should return early when all URL fetches fail', async () => {
+      mockFetchLinkMetadata.mockResolvedValue(null);
+
+      const spans = [{ text: 'Check https://fail1.com and https://fail2.com' }];
+      await service.processMessageLinkPreviews(
+        messageId,
+        spans,
+        roomId,
+        serverEvent,
+      );
+
+      expect(mockFetchLinkMetadata).toHaveBeenCalledTimes(2);
+      expect(mockDatabase.message.findUnique).not.toHaveBeenCalled();
+      expect(mockDatabase.message.update).not.toHaveBeenCalled();
+      expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+    });
+
+    it('should return early when fetchLinkMetadata throws', async () => {
+      mockFetchLinkMetadata.mockRejectedValue(new Error('network error'));
+
+      const spans = [{ text: 'See https://error.com' }];
+      await service.processMessageLinkPreviews(
+        messageId,
+        spans,
+        roomId,
+        serverEvent,
+      );
+
+      expect(mockFetchLinkMetadata).toHaveBeenCalledTimes(1);
+      expect(mockDatabase.message.update).not.toHaveBeenCalled();
+      expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+    });
+
+    it('should skip deleted messages', async () => {
+      const preview: linkPreviewUtils.LinkPreviewData = {
+        url: 'https://example.com',
+        title: 'Example',
+      };
+      mockFetchLinkMetadata.mockResolvedValue(preview);
+
+      mockDatabase.message.findUnique.mockResolvedValueOnce({
+        id: messageId,
+        deletedAt: new Date(),
+      });
+
+      const spans = [{ text: 'Visit https://example.com' }];
+      await service.processMessageLinkPreviews(
+        messageId,
+        spans,
+        roomId,
+        serverEvent,
+      );
+
+      expect(mockDatabase.message.findUnique).toHaveBeenCalledWith({
+        where: { id: messageId },
+        select: { id: true, deletedAt: true },
+      });
+      expect(mockDatabase.message.update).not.toHaveBeenCalled();
+      expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+    });
+
+    it('should skip when message no longer exists', async () => {
+      const preview: linkPreviewUtils.LinkPreviewData = {
+        url: 'https://example.com',
+        title: 'Example',
+      };
+      mockFetchLinkMetadata.mockResolvedValue(preview);
+
+      mockDatabase.message.findUnique.mockResolvedValueOnce(null);
+
+      const spans = [{ text: 'Visit https://example.com' }];
+      await service.processMessageLinkPreviews(
+        messageId,
+        spans,
+        roomId,
+        serverEvent,
+      );
+
+      expect(mockDatabase.message.update).not.toHaveBeenCalled();
+      expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+    });
+
+    it('should update DB and emit when previews are fetched successfully', async () => {
+      const preview: linkPreviewUtils.LinkPreviewData = {
+        url: 'https://example.com',
+        title: 'Example Site',
+        description: 'An example page',
+      };
+      mockFetchLinkMetadata.mockResolvedValue(preview);
+
+      // First findUnique: existence check (message is not deleted)
+      mockDatabase.message.findUnique.mockResolvedValueOnce({
+        id: messageId,
+        deletedAt: null,
+      });
+
+      // update succeeds
+      mockDatabase.message.update.mockResolvedValue({});
+
+      // Second findUnique: re-read with includes for broadcast
+      const updatedMessage = {
+        id: messageId,
+        channelId: 'ch-1',
+        authorId: 'user-1',
+        content: null,
+        deletedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        linkPreviews: [preview],
+        spans: [
+          {
+            id: 's1',
+            messageId,
+            position: 0,
+            text: 'Visit https://example.com',
+          },
+        ],
+        reactions: [],
+        attachments: [],
+      };
+      mockDatabase.message.findUnique.mockResolvedValueOnce(updatedMessage);
+
+      const spans = [{ text: 'Visit https://example.com' }];
+      await service.processMessageLinkPreviews(
+        messageId,
+        spans,
+        roomId,
+        serverEvent,
+      );
+
+      // Verify DB update with previews
+      expect(mockDatabase.message.update).toHaveBeenCalledWith({
+        where: { id: messageId },
+        data: { linkPreviews: [preview] },
+      });
+
+      // Verify websocket emission
+      expect(websocketService.sendToRoom).toHaveBeenCalledWith(
+        roomId,
+        serverEvent,
+        expect.objectContaining({
+          message: expect.objectContaining({
+            id: messageId,
+            linkPreviews: [preview],
+          }),
+        }),
+      );
+    });
+
+    it('should collect only successful previews from multiple URLs', async () => {
+      const successPreview: linkPreviewUtils.LinkPreviewData = {
+        url: 'https://good.com',
+        title: 'Good Site',
+      };
+      // First URL succeeds, second fails
+      mockFetchLinkMetadata
+        .mockResolvedValueOnce(successPreview)
+        .mockResolvedValueOnce(null);
+
+      mockDatabase.message.findUnique.mockResolvedValueOnce({
+        id: messageId,
+        deletedAt: null,
+      });
+      mockDatabase.message.update.mockResolvedValue({});
+      mockDatabase.message.findUnique.mockResolvedValueOnce({
+        id: messageId,
+        linkPreviews: [successPreview],
+        spans: [],
+        reactions: [],
+        attachments: [],
+      });
+
+      const spans = [{ text: 'Check https://good.com and https://bad.com' }];
+      await service.processMessageLinkPreviews(
+        messageId,
+        spans,
+        roomId,
+        serverEvent,
+      );
+
+      expect(mockFetchLinkMetadata).toHaveBeenCalledTimes(2);
+      expect(mockDatabase.message.update).toHaveBeenCalledWith({
+        where: { id: messageId },
+        data: { linkPreviews: [successPreview] },
+      });
+      expect(websocketService.sendToRoom).toHaveBeenCalled();
+    });
+
+    it('should format attachments correctly in broadcast payload', async () => {
+      const preview: linkPreviewUtils.LinkPreviewData = {
+        url: 'https://example.com',
+        title: 'Example',
+      };
+      mockFetchLinkMetadata.mockResolvedValue(preview);
+
+      mockDatabase.message.findUnique.mockResolvedValueOnce({
+        id: messageId,
+        deletedAt: null,
+      });
+      mockDatabase.message.update.mockResolvedValue({});
+
+      const updatedMessage = {
+        id: messageId,
+        linkPreviews: [preview],
+        spans: [],
+        reactions: [
+          { emoji: '👍', userId: 'user-1' },
+          { emoji: '👍', userId: 'user-2' },
+        ],
+        attachments: [
+          {
+            id: 'ma-0',
+            messageId,
+            fileId: 'file-1',
+            position: 0,
+            file: {
+              id: 'file-1',
+              filename: 'image.png',
+              mimeType: 'image/png',
+              fileType: 'IMAGE',
+              size: 2048,
+              thumbnailPath: '/thumbs/file-1.jpg',
+            },
+          },
+        ],
+      };
+      mockDatabase.message.findUnique.mockResolvedValueOnce(updatedMessage);
+
+      const spans = [{ text: 'See https://example.com' }];
+      await service.processMessageLinkPreviews(
+        messageId,
+        spans,
+        roomId,
+        serverEvent,
+      );
+
+      const emittedPayload = (websocketService.sendToRoom as jest.Mock).mock
+        .calls[0][2];
+      const msg = emittedPayload.message;
+
+      // Reactions should be grouped
+      expect(msg.reactions).toEqual([
+        { emoji: '👍', userIds: ['user-1', 'user-2'] },
+      ]);
+
+      // Attachments should be flattened
+      expect(msg.attachments).toEqual([
+        {
+          id: 'file-1',
+          filename: 'image.png',
+          mimeType: 'image/png',
+          fileType: 'IMAGE',
+          size: 2048,
+          hasThumbnail: true,
+        },
+      ]);
+    });
+
+    it('should not emit when re-read finds no message', async () => {
+      const preview: linkPreviewUtils.LinkPreviewData = {
+        url: 'https://example.com',
+        title: 'Example',
+      };
+      mockFetchLinkMetadata.mockResolvedValue(preview);
+
+      // Existence check passes
+      mockDatabase.message.findUnique.mockResolvedValueOnce({
+        id: messageId,
+        deletedAt: null,
+      });
+      mockDatabase.message.update.mockResolvedValue({});
+      // Re-read returns null (message deleted between update and re-read)
+      mockDatabase.message.findUnique.mockResolvedValueOnce(null);
+
+      const spans = [{ text: 'Visit https://example.com' }];
+      await service.processMessageLinkPreviews(
+        messageId,
+        spans,
+        roomId,
+        serverEvent,
+      );
+
+      expect(mockDatabase.message.update).toHaveBeenCalled();
+      expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/link-previews/link-previews.service.spec.ts
+++ b/backend/src/link-previews/link-previews.service.spec.ts
@@ -73,7 +73,9 @@ describe('LinkPreviewsService', () => {
       expect(websocketService.sendToRoom).not.toHaveBeenCalled();
     });
 
-    it('should return early when text has no URLs', async () => {
+    it('should not fetch or broadcast when text has no URLs and no stale previews', async () => {
+      mockDatabase.message.findUnique.mockResolvedValue({ linkPreviews: null });
+
       const spans = [{ text: 'Hello world, no links here!' }];
       await service.processMessageLinkPreviews(
         messageId,
@@ -83,7 +85,7 @@ describe('LinkPreviewsService', () => {
       );
 
       expect(mockFetchLinkMetadata).not.toHaveBeenCalled();
-      expect(mockDatabase.message.findUnique).not.toHaveBeenCalled();
+      expect(mockDatabase.message.update).not.toHaveBeenCalled();
       expect(websocketService.sendToRoom).not.toHaveBeenCalled();
     });
 

--- a/backend/src/link-previews/link-previews.service.ts
+++ b/backend/src/link-previews/link-previews.service.ts
@@ -1,0 +1,114 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DatabaseService } from '@/database/database.service';
+import { WebsocketService } from '@/websocket/websocket.service';
+import { flattenSpansToDisplayText } from '@/common/utils/text.utils';
+import {
+  extractUrls,
+  fetchLinkMetadata,
+  LinkPreviewData,
+} from './link-preview.utils';
+import { groupReactions } from '@/common/utils/reactions.utils';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class LinkPreviewsService {
+  private readonly logger = new Logger(LinkPreviewsService.name);
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly websocketService: WebsocketService,
+  ) {}
+
+  /**
+   * Extract URLs from message spans, fetch OG metadata, store in DB,
+   * and emit an update event. Called fire-and-forget after message creation.
+   */
+  async processMessageLinkPreviews(
+    messageId: string,
+    spans: { text?: string | null }[],
+    roomId: string,
+    serverEvent: string,
+  ): Promise<void> {
+    const text = flattenSpansToDisplayText(spans);
+    if (!text) return;
+
+    const urls = extractUrls(text);
+    if (urls.length === 0) return;
+
+    const previews: LinkPreviewData[] = [];
+    for (const url of urls) {
+      try {
+        const metadata = await fetchLinkMetadata(url);
+        if (metadata) {
+          previews.push(metadata);
+        }
+      } catch (error) {
+        this.logger.warn(`Failed to fetch link preview for ${url}`, error);
+      }
+    }
+
+    if (previews.length === 0) return;
+
+    // Verify message still exists and hasn't been deleted
+    const existing = await this.databaseService.message.findUnique({
+      where: { id: messageId },
+      select: { id: true, deletedAt: true },
+    });
+
+    if (!existing || existing.deletedAt) return;
+
+    // Store previews
+    await this.databaseService.message.update({
+      where: { id: messageId },
+      data: { linkPreviews: previews as unknown as Prisma.InputJsonValue },
+    });
+
+    // Re-read with full includes for broadcast
+    const MESSAGE_INCLUDE = {
+      spans: { orderBy: { position: 'asc' as const } },
+      reactions: true,
+      attachments: {
+        include: {
+          file: {
+            select: {
+              id: true,
+              filename: true,
+              mimeType: true,
+              fileType: true,
+              size: true,
+              thumbnailPath: true,
+            },
+          },
+        },
+        orderBy: { position: 'asc' as const },
+      },
+    } as const;
+
+    const updatedMessage = await this.databaseService.message.findUnique({
+      where: { id: messageId },
+      include: MESSAGE_INCLUDE,
+    });
+
+    if (!updatedMessage) return;
+
+    // Format the message for broadcast (same shape clients expect)
+    const formatted = {
+      ...updatedMessage,
+      linkPreviews:
+        (updatedMessage.linkPreviews as LinkPreviewData[] | null) ?? undefined,
+      reactions: groupReactions(updatedMessage.reactions),
+      attachments: updatedMessage.attachments.map((a) => ({
+        id: a.file.id,
+        filename: a.file.filename,
+        mimeType: a.file.mimeType,
+        fileType: a.file.fileType,
+        size: a.file.size,
+        hasThumbnail: !!a.file.thumbnailPath,
+      })),
+    };
+
+    this.websocketService.sendToRoom(roomId, serverEvent, {
+      message: formatted,
+    });
+  }
+}

--- a/backend/src/link-previews/link-previews.service.ts
+++ b/backend/src/link-previews/link-previews.service.ts
@@ -10,6 +10,32 @@ import {
 import { groupReactions } from '@/common/utils/reactions.utils';
 import { Prisma } from '@prisma/client';
 
+/** Full includes for re-reading a message before broadcast */
+const MESSAGE_INCLUDE = {
+  spans: { orderBy: { position: 'asc' as const } },
+  reactions: true,
+  attachments: {
+    include: {
+      file: {
+        select: {
+          id: true,
+          filename: true,
+          mimeType: true,
+          fileType: true,
+          size: true,
+          thumbnailPath: true,
+        },
+      },
+    },
+    orderBy: { position: 'asc' as const },
+  },
+  replyToMessage: {
+    include: {
+      spans: { orderBy: { position: 'asc' as const } },
+    },
+  },
+} as const;
+
 @Injectable()
 export class LinkPreviewsService {
   private readonly logger = new Logger(LinkPreviewsService.name);
@@ -33,17 +59,24 @@ export class LinkPreviewsService {
     if (!text) return;
 
     const urls = extractUrls(text);
-    if (urls.length === 0) return;
+
+    // No URLs → clear any stale previews from a previous edit
+    if (urls.length === 0) {
+      await this.clearAndBroadcast(messageId, roomId, serverEvent);
+      return;
+    }
+
+    // Fetch all URLs in parallel
+    const results = await Promise.allSettled(
+      urls.map((url) => fetchLinkMetadata(url)),
+    );
 
     const previews: LinkPreviewData[] = [];
-    for (const url of urls) {
-      try {
-        const metadata = await fetchLinkMetadata(url);
-        if (metadata) {
-          previews.push(metadata);
-        }
-      } catch (error) {
-        this.logger.warn(`Failed to fetch link preview for ${url}`, error);
+    for (const result of results) {
+      if (result.status === 'fulfilled' && result.value) {
+        previews.push(result.value);
+      } else if (result.status === 'rejected') {
+        this.logger.warn('Failed to fetch link preview', result.reason);
       }
     }
 
@@ -57,47 +90,64 @@ export class LinkPreviewsService {
 
     if (!existing || existing.deletedAt) return;
 
-    // Store previews
+    // Store previews and broadcast
     await this.databaseService.message.update({
       where: { id: messageId },
       data: { linkPreviews: previews as unknown as Prisma.InputJsonValue },
     });
 
-    // Re-read with full includes for broadcast
-    const MESSAGE_INCLUDE = {
-      spans: { orderBy: { position: 'asc' as const } },
-      reactions: true,
-      attachments: {
-        include: {
-          file: {
-            select: {
-              id: true,
-              filename: true,
-              mimeType: true,
-              fileType: true,
-              size: true,
-              thumbnailPath: true,
-            },
-          },
-        },
-        orderBy: { position: 'asc' as const },
-      },
-    } as const;
+    await this.broadcastMessage(messageId, roomId, serverEvent);
+  }
 
-    const updatedMessage = await this.databaseService.message.findUnique({
+  /**
+   * Clear link previews for a message and broadcast the update.
+   * Used when a message edit removes all URLs.
+   */
+  private async clearAndBroadcast(
+    messageId: string,
+    roomId: string,
+    serverEvent: string,
+  ): Promise<void> {
+    const existing = await this.databaseService.message.findUnique({
+      where: { id: messageId },
+      select: { linkPreviews: true },
+    });
+
+    // Only update + broadcast if there were previews to clear
+    if (!existing?.linkPreviews) return;
+
+    await this.databaseService.message.update({
+      where: { id: messageId },
+      data: { linkPreviews: Prisma.DbNull },
+    });
+
+    await this.broadcastMessage(messageId, roomId, serverEvent);
+  }
+
+  /**
+   * Re-read a message with full includes and broadcast it.
+   * Matches the same shape as MessagesService.formatMessageWithReply().
+   */
+  private async broadcastMessage(
+    messageId: string,
+    roomId: string,
+    serverEvent: string,
+  ): Promise<void> {
+    const msg = await this.databaseService.message.findUnique({
       where: { id: messageId },
       include: MESSAGE_INCLUDE,
     });
 
-    if (!updatedMessage) return;
+    if (!msg) return;
 
-    // Format the message for broadcast (same shape clients expect)
+    const { replyToMessage, ...rest } = msg;
+
     const formatted = {
-      ...updatedMessage,
+      ...rest,
       linkPreviews:
-        (updatedMessage.linkPreviews as LinkPreviewData[] | null) ?? undefined,
-      reactions: groupReactions(updatedMessage.reactions),
-      attachments: updatedMessage.attachments.map((a) => ({
+        (rest.linkPreviews as LinkPreviewData[] | null) ?? undefined,
+      reactions: groupReactions(msg.reactions),
+      attachments: msg.attachments.map((a) => ({
         id: a.file.id,
         filename: a.file.filename,
         mimeType: a.file.mimeType,
@@ -105,6 +155,24 @@ export class LinkPreviewsService {
         size: a.file.size,
         hasThumbnail: !!a.file.thumbnailPath,
       })),
+      replyTo: replyToMessage
+        ? {
+            id: replyToMessage.id,
+            authorId: replyToMessage.authorId,
+            spans: replyToMessage.deletedAt
+              ? []
+              : replyToMessage.spans.map((s) => ({
+                  type: s.type,
+                  text: s.text,
+                  userId: s.userId,
+                  specialKind: s.specialKind,
+                  communityId: s.communityId,
+                  aliasId: s.aliasId,
+                })),
+            sentAt: replyToMessage.sentAt,
+            deletedAt: replyToMessage.deletedAt,
+          }
+        : null,
     };
 
     this.websocketService.sendToRoom(roomId, serverEvent, {

--- a/backend/src/membership/membership.service.spec.ts
+++ b/backend/src/membership/membership.service.spec.ts
@@ -412,7 +412,10 @@ describe('MembershipService', () => {
       });
 
       expect(mockDatabase.userRoles.findMany).toHaveBeenCalledWith({
-        where: { communityId: community.id, userId: { in: [user1.id, user2.id] } },
+        where: {
+          communityId: community.id,
+          userId: { in: [user1.id, user2.id] },
+        },
         include: { role: true },
       });
     });

--- a/backend/src/membership/membership.service.ts
+++ b/backend/src/membership/membership.service.ts
@@ -174,17 +174,25 @@ export class MembershipService {
 
     // Batch fetch user roles scoped to returned members (not entire community)
     const memberUserIds = memberships.map((m) => m.userId);
-    const userRoles = memberUserIds.length > 0
-      ? await this.databaseService.userRoles.findMany({
-          where: { communityId, userId: { in: memberUserIds } },
-          include: { role: true },
-        })
-      : [];
+    const userRoles =
+      memberUserIds.length > 0
+        ? await this.databaseService.userRoles.findMany({
+            where: { communityId, userId: { in: memberUserIds } },
+            include: { role: true },
+          })
+        : [];
 
     // Group roles by userId
     const rolesByUserId = new Map<
       string,
-      Array<{ id: string; name: string; actions: any[]; createdAt: Date; isDefault: boolean; position: number }>
+      Array<{
+        id: string;
+        name: string;
+        actions: any[];
+        createdAt: Date;
+        isDefault: boolean;
+        position: number;
+      }>
     >();
     for (const ur of userRoles) {
       const existing = rolesByUserId.get(ur.userId) || [];

--- a/backend/src/messages/dto/message-response.dto.ts
+++ b/backend/src/messages/dto/message-response.dto.ts
@@ -1,4 +1,4 @@
-import { FileType, SpanType } from '@prisma/client';
+import { FileType, Prisma, SpanType } from '@prisma/client';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { SpanTypeValues, FileTypeValues } from '@/common/enums/swagger-enums';
 
@@ -36,6 +36,22 @@ export class ReplyToPreviewDto {
   deletedAt: Date | null;
 }
 
+export class LinkPreviewDto {
+  url: string;
+  @ApiPropertyOptional()
+  title?: string;
+  @ApiPropertyOptional()
+  description?: string;
+  @ApiPropertyOptional()
+  imageUrl?: string;
+  @ApiPropertyOptional()
+  siteName?: string;
+  @ApiPropertyOptional()
+  faviconUrl?: string;
+  @ApiPropertyOptional()
+  authorName?: string;
+}
+
 export class EnrichedMessageDto {
   id: string;
   channelId: string | null;
@@ -45,6 +61,8 @@ export class EnrichedMessageDto {
   attachments: EnrichedAttachment[];
   pendingAttachments: number | null;
   reactions: ReactionDto[];
+  @ApiPropertyOptional({ type: [LinkPreviewDto] })
+  linkPreviews?: LinkPreviewDto[] | Prisma.JsonValue | null;
   replyCount: number;
   lastReplyAt: Date | null;
   pinned: boolean;
@@ -68,6 +86,8 @@ export class MessageDto {
   attachments: string[];
   pendingAttachments: number | null;
   reactions: ReactionDto[];
+  @ApiPropertyOptional({ type: [LinkPreviewDto] })
+  linkPreviews?: LinkPreviewDto[] | Prisma.JsonValue | null;
   replyCount: number;
   lastReplyAt: Date | null;
   pinned: boolean;

--- a/backend/src/messages/messages.controller.spec.ts
+++ b/backend/src/messages/messages.controller.spec.ts
@@ -11,12 +11,14 @@ import { AddReactionDto } from './dto/add-reaction.dto';
 import { RemoveReactionDto } from './dto/remove-reaction.dto';
 import { AddAttachmentDto } from './dto/add-attachment.dto';
 import { ServerEvents } from '@semaphore-chat/shared';
+import { LinkPreviewsService } from '@/link-previews/link-previews.service';
 
 describe('MessagesController', () => {
   let controller: MessagesController;
   let service: Mocked<MessagesService>;
   let reactionsService: Mocked<ReactionsService>;
   let websocketService: Mocked<WebsocketService>;
+  let linkPreviewsService: Mocked<LinkPreviewsService>;
 
   const mockUser = UserFactory.build();
   const mockRequest = {
@@ -31,6 +33,8 @@ describe('MessagesController', () => {
     service = unitRef.get(MessagesService);
     reactionsService = unitRef.get(ReactionsService);
     websocketService = unitRef.get(WebsocketService);
+    linkPreviewsService = unitRef.get(LinkPreviewsService);
+    linkPreviewsService.processMessageLinkPreviews.mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/backend/src/messages/messages.controller.ts
+++ b/backend/src/messages/messages.controller.ts
@@ -44,6 +44,7 @@ import {
 } from './dto/message-response.dto';
 import { groupReactions } from '@/common/utils/reactions.utils';
 import { RoomName } from '@/common/utils/room-name.util';
+import { LinkPreviewsService } from '@/link-previews/link-previews.service';
 
 @Controller('messages')
 @UseGuards(JwtAuthGuard, RbacGuard)
@@ -52,6 +53,7 @@ export class MessagesController {
     private readonly messagesService: MessagesService,
     private readonly reactionsService: ReactionsService,
     private readonly websocketService: WebsocketService,
+    private readonly linkPreviewsService: LinkPreviewsService,
   ) {}
 
   @Post()
@@ -140,7 +142,11 @@ export class MessagesController {
     @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,
   ): Promise<AnchoredMessagesResponseDto> {
     limit = Math.min(limit, 100);
-    return this.messagesService.findAroundForChannel(channelId, messageId, limit);
+    return this.messagesService.findAroundForChannel(
+      channelId,
+      messageId,
+      limit,
+    );
   }
 
   @Get('/group/:groupId/around/:messageId')
@@ -157,7 +163,11 @@ export class MessagesController {
     @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,
   ): Promise<AnchoredMessagesResponseDto> {
     limit = Math.min(limit, 100);
-    return this.messagesService.findAroundForDirectMessageGroup(groupId, messageId, limit);
+    return this.messagesService.findAroundForDirectMessageGroup(
+      groupId,
+      messageId,
+      limit,
+    );
   }
 
   @Get('search/channel/:channelId')
@@ -381,6 +391,18 @@ export class MessagesController {
       this.websocketService.sendToRoom(roomId, ServerEvents.UPDATE_MESSAGE, {
         message: enrichedMessage,
       });
+
+      // Re-process link previews if spans changed (async, non-blocking)
+      if (updateMessageDto.spans) {
+        this.linkPreviewsService
+          .processMessageLinkPreviews(
+            id,
+            updatedMessage.spans,
+            roomId,
+            ServerEvents.UPDATE_MESSAGE,
+          )
+          .catch(() => {});
+      }
     }
 
     return enrichedMessage;

--- a/backend/src/messages/messages.controller.ts
+++ b/backend/src/messages/messages.controller.ts
@@ -8,6 +8,7 @@ import {
   Delete,
   UseGuards,
   HttpCode,
+  Logger,
   Query,
   Req,
   DefaultValuePipe,
@@ -49,6 +50,8 @@ import { LinkPreviewsService } from '@/link-previews/link-previews.service';
 @Controller('messages')
 @UseGuards(JwtAuthGuard, RbacGuard)
 export class MessagesController {
+  private readonly logger = new Logger(MessagesController.name);
+
   constructor(
     private readonly messagesService: MessagesService,
     private readonly reactionsService: ReactionsService,
@@ -401,7 +404,9 @@ export class MessagesController {
             roomId,
             ServerEvents.UPDATE_MESSAGE,
           )
-          .catch(() => {});
+          .catch((error) =>
+            this.logger.warn('Failed to process link previews on edit', error),
+          );
       }
     }
 

--- a/backend/src/messages/messages.gateway.spec.ts
+++ b/backend/src/messages/messages.gateway.spec.ts
@@ -7,6 +7,7 @@ import { ServerEvents } from '@semaphore-chat/shared';
 import { NotificationsService } from '@/notifications/notifications.service';
 import { ModerationService } from '@/moderation/moderation.service';
 import { ReadReceiptsService } from '@/read-receipts/read-receipts.service';
+import { LinkPreviewsService } from '@/link-previews/link-previews.service';
 import type { Mocked } from '@suites/doubles.jest';
 
 describe('MessagesGateway', () => {
@@ -17,6 +18,7 @@ describe('MessagesGateway', () => {
   let notificationsService: Mocked<NotificationsService>;
   let moderationService: Mocked<ModerationService>;
   let readReceiptsService: Mocked<ReadReceiptsService>;
+  let linkPreviewsService: Mocked<LinkPreviewsService>;
 
   beforeEach(async () => {
     const { unit, unitRef } = await TestBed.solitary(MessagesGateway).compile();
@@ -28,6 +30,7 @@ describe('MessagesGateway', () => {
     notificationsService = unitRef.get(NotificationsService);
     moderationService = unitRef.get(ModerationService);
     readReceiptsService = unitRef.get(ReadReceiptsService);
+    linkPreviewsService = unitRef.get(LinkPreviewsService);
 
     // Set up default return values that tests rely on
     messagesService.checkSlowmode.mockResolvedValue(undefined);
@@ -40,6 +43,7 @@ describe('MessagesGateway', () => {
     notificationsService.processMessageForNotifications.mockResolvedValue(
       undefined,
     );
+    linkPreviewsService.processMessageLinkPreviews.mockResolvedValue(undefined);
     readReceiptsService.markAsRead.mockResolvedValue({
       channelId: null,
       directMessageGroupId: null,

--- a/backend/src/messages/messages.gateway.ts
+++ b/backend/src/messages/messages.gateway.ts
@@ -37,6 +37,7 @@ import { ReadReceiptsService } from '@/read-receipts/read-receipts.service';
 import { getSocketUserId } from '@/common/utils/socket.utils';
 import { groupReactions } from '@/common/utils/reactions.utils';
 import { RoomName } from '@/common/utils/room-name.util';
+import { LinkPreviewsService } from '@/link-previews/link-previews.service';
 
 @UseFilters(WsLoggingExceptionFilter)
 @WebSocketGateway({
@@ -65,6 +66,7 @@ export class MessagesGateway
     private readonly notificationsService: NotificationsService,
     private readonly moderationService: ModerationService,
     private readonly readReceiptsService: ReadReceiptsService,
+    private readonly linkPreviewsService: LinkPreviewsService,
   ) {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -158,6 +160,18 @@ export class MessagesGateway
         this.logger.error('Failed to process notifications for message', error),
       );
 
+    // Process link previews (async, non-blocking)
+    this.linkPreviewsService
+      .processMessageLinkPreviews(
+        message.id,
+        message.spans,
+        payload.channelId,
+        ServerEvents.UPDATE_MESSAGE,
+      )
+      .catch((error) =>
+        this.logger.error('Failed to process link previews', error),
+      );
+
     // Enrich message with file metadata before emitting
     const enrichedMessage =
       this.messagesService.enrichMessageWithFileMetadata(message);
@@ -224,6 +238,18 @@ export class MessagesGateway
       .processMessageForNotifications(message)
       .catch((error) =>
         this.logger.error('Failed to process notifications for DM', error),
+      );
+
+    // Process link previews (async, non-blocking)
+    this.linkPreviewsService
+      .processMessageLinkPreviews(
+        message.id,
+        message.spans,
+        RoomName.dmGroup(payload.directMessageGroupId),
+        ServerEvents.UPDATE_MESSAGE,
+      )
+      .catch((error) =>
+        this.logger.error('Failed to process link previews for DM', error),
       );
 
     // Enrich message with file metadata before emitting

--- a/backend/src/messages/messages.module.ts
+++ b/backend/src/messages/messages.module.ts
@@ -14,6 +14,7 @@ import { MessageOwnershipGuard } from '@/auth/message-ownership.guard';
 import { NotificationsModule } from '@/notifications/notifications.module';
 import { ModerationModule } from '@/moderation/moderation.module';
 import { ReadReceiptsModule } from '@/read-receipts/read-receipts.module';
+import { LinkPreviewsModule } from '@/link-previews/link-previews.module';
 
 @Module({
   controllers: [MessagesController],
@@ -34,6 +35,7 @@ import { ReadReceiptsModule } from '@/read-receipts/read-receipts.module';
     NotificationsModule,
     ModerationModule,
     ReadReceiptsModule,
+    LinkPreviewsModule,
   ],
   exports: [MessagesService, ReactionsService],
 })

--- a/backend/src/messages/messages.service.spec.ts
+++ b/backend/src/messages/messages.service.spec.ts
@@ -1249,9 +1249,7 @@ describe('MessagesService', () => {
 
       mockDatabase.message.findUnique.mockResolvedValue(anchor);
       mockDatabase.message.findMany
-        .mockResolvedValueOnce([
-          buildMessageWithIncludes({ channelId }),
-        ]) // 1 older
+        .mockResolvedValueOnce([buildMessageWithIncludes({ channelId })]) // 1 older
         .mockResolvedValueOnce([]); // 0 newer
 
       const result = await service.findAroundForChannel(channelId, anchorId);

--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -1118,7 +1118,9 @@ describe('NotificationsService', () => {
 
       const settings = UserNotificationSettingsFactory.build();
       mockDatabase.userNotificationSettings.upsert.mockResolvedValue(settings);
-      mockDatabase.channelNotificationOverride.findUnique.mockResolvedValue(null);
+      mockDatabase.channelNotificationOverride.findUnique.mockResolvedValue(
+        null,
+      );
 
       return MessageFactory.build({
         id: 'msg-1',

--- a/backend/src/read-receipts/read-receipts.controller.spec.ts
+++ b/backend/src/read-receipts/read-receipts.controller.spec.ts
@@ -30,9 +30,7 @@ describe('ReadReceiptsController', () => {
     const mockReq = { user: { id: userId } } as any;
 
     it('should pass correct args to service', async () => {
-      const mockPeerReads = [
-        { userId: 'peer-1', lastReadAt: new Date() },
-      ];
+      const mockPeerReads = [{ userId: 'peer-1', lastReadAt: new Date() }];
 
       readReceiptsService.getDmPeerReads.mockResolvedValue(mockPeerReads);
 

--- a/backend/src/read-receipts/read-receipts.service.spec.ts
+++ b/backend/src/read-receipts/read-receipts.service.spec.ts
@@ -889,12 +889,12 @@ describe('ReadReceiptsService', () => {
     it('should throw ForbiddenException when user is not a member', async () => {
       mockDatabase.directMessageGroupMember.findFirst.mockResolvedValue(null);
 
-      await expect(
-        service.getDmPeerReads(userId, dmGroupId),
-      ).rejects.toThrow(ForbiddenException);
-      await expect(
-        service.getDmPeerReads(userId, dmGroupId),
-      ).rejects.toThrow('You are not a member of this DM group');
+      await expect(service.getDmPeerReads(userId, dmGroupId)).rejects.toThrow(
+        ForbiddenException,
+      );
+      await expect(service.getDmPeerReads(userId, dmGroupId)).rejects.toThrow(
+        'You are not a member of this DM group',
+      );
     });
   });
 

--- a/backend/src/read-receipts/read-receipts.service.ts
+++ b/backend/src/read-receipts/read-receipts.service.ts
@@ -553,9 +553,7 @@ export class ReadReceiptsService {
         where: { groupId: directMessageGroupId, userId },
       });
     if (!membership) {
-      throw new ForbiddenException(
-        'You are not a member of this DM group',
-      );
+      throw new ForbiddenException('You are not a member of this DM group');
     }
 
     return this.databaseService.readReceipt.findMany({

--- a/backend/src/roles/dto/create-role.dto.ts
+++ b/backend/src/roles/dto/create-role.dto.ts
@@ -22,7 +22,9 @@ export class CreateRoleDto {
   @ArrayMinSize(1, { message: 'Role must have at least one permission' })
   actions: RbacActions[];
 
-  @ApiPropertyOptional({ description: 'Position for ordering (lower = higher priority)' })
+  @ApiPropertyOptional({
+    description: 'Position for ordering (lower = higher priority)',
+  })
   @IsOptional()
   @IsNumber()
   position?: number;

--- a/backend/src/roles/roles.service.spec.ts
+++ b/backend/src/roles/roles.service.spec.ts
@@ -2420,10 +2420,7 @@ describe('RolesService', () => {
         name: 'Member',
       });
 
-      mockDatabase.role.findMany.mockResolvedValueOnce([
-        adminRole,
-        memberRole,
-      ]);
+      mockDatabase.role.findMany.mockResolvedValueOnce([adminRole, memberRole]);
       mockDatabase.role.update.mockResolvedValue({});
 
       // Mock getCommunityRoles
@@ -2433,10 +2430,7 @@ describe('RolesService', () => {
       ]);
 
       // Include the Member role ID in the reorder list — it should be filtered out
-      await service.reorderRoles(communityId, [
-        memberRole.id,
-        adminRole.id,
-      ]);
+      await service.reorderRoles(communityId, [memberRole.id, adminRole.id]);
 
       // adminRole should get position 10 (first non-member role)
       expect(mockDatabase.role.update).toHaveBeenCalledWith({

--- a/backend/src/threads/threads.gateway.spec.ts
+++ b/backend/src/threads/threads.gateway.spec.ts
@@ -5,6 +5,7 @@ import { ThreadsService } from './threads.service';
 import { WebsocketService } from '@/websocket/websocket.service';
 import { NotificationsService } from '@/notifications/notifications.service';
 import { DatabaseService } from '@/database/database.service';
+import { LinkPreviewsService } from '@/link-previews/link-previews.service';
 import { WsException } from '@nestjs/websockets';
 import { ServerEvents } from '@semaphore-chat/shared';
 
@@ -14,6 +15,7 @@ describe('ThreadsGateway', () => {
   let websocketService: Mocked<WebsocketService>;
   let notificationsService: Mocked<NotificationsService>;
   let databaseService: Mocked<DatabaseService>;
+  let linkPreviewsService: Mocked<LinkPreviewsService>;
 
   const mockClient = {
     id: 'socket-1',
@@ -57,12 +59,16 @@ describe('ThreadsGateway', () => {
     websocketService = unitRef.get(WebsocketService);
     notificationsService = unitRef.get(NotificationsService);
     databaseService = unitRef.get(DatabaseService);
+    linkPreviewsService = unitRef.get(LinkPreviewsService);
 
     threadsService.createThreadReply = jest.fn().mockResolvedValue(mockReply);
     (databaseService.message as any) = {
       findUnique: jest.fn().mockResolvedValue(mockParentMessage),
     };
     notificationsService.processThreadReplyNotifications = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    linkPreviewsService.processMessageLinkPreviews = jest
       .fn()
       .mockResolvedValue(undefined);
     websocketService.sendToRoom = jest.fn();

--- a/backend/src/threads/threads.gateway.ts
+++ b/backend/src/threads/threads.gateway.ts
@@ -31,6 +31,7 @@ import { NotificationsService } from '@/notifications/notifications.service';
 import { getSocketUserId } from '@/common/utils/socket.utils';
 import { DatabaseService } from '@/database/database.service';
 import { RoomName } from '@/common/utils/room-name.util';
+import { LinkPreviewsService } from '@/link-previews/link-previews.service';
 
 @UseFilters(WsLoggingExceptionFilter)
 @WebSocketGateway({
@@ -57,6 +58,7 @@ export class ThreadsGateway
     private readonly websocketService: WebsocketService,
     private readonly notificationsService: NotificationsService,
     private readonly databaseService: DatabaseService,
+    private readonly linkPreviewsService: LinkPreviewsService,
   ) {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -149,6 +151,23 @@ export class ThreadsGateway
           error,
         ),
       );
+
+    // Process link previews for thread reply (async, non-blocking)
+    if (roomId) {
+      this.linkPreviewsService
+        .processMessageLinkPreviews(
+          reply.id,
+          reply.spans,
+          roomId,
+          ServerEvents.UPDATE_MESSAGE,
+        )
+        .catch((error) =>
+          this.logger.error(
+            'Failed to process link previews for thread reply',
+            error,
+          ),
+        );
+    }
 
     return reply.id;
   }

--- a/backend/src/threads/threads.module.ts
+++ b/backend/src/threads/threads.module.ts
@@ -8,6 +8,7 @@ import { WebsocketModule } from '@/websocket/websocket.module';
 import { AuthModule } from '@/auth/auth.module';
 import { NotificationsModule } from '@/notifications/notifications.module';
 import { UserModule } from '@/user/user.module';
+import { LinkPreviewsModule } from '@/link-previews/link-previews.module';
 
 @Module({
   controllers: [ThreadsController],
@@ -19,6 +20,7 @@ import { UserModule } from '@/user/user.module';
     AuthModule,
     NotificationsModule,
     UserModule,
+    LinkPreviewsModule,
   ],
   exports: [ThreadsService],
 })

--- a/frontend/src/__tests__/components/LinkPreviewCard.test.tsx
+++ b/frontend/src/__tests__/components/LinkPreviewCard.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { generateTheme } from '../../theme/themeConfig';
+import { LinkPreviewCard } from '../../components/Message/LinkPreviewCard';
+import type { LinkPreview } from '../../types/message.type';
+
+const theme = generateTheme('dark', 'blue', 'balanced');
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+}
+
+function makePreview(overrides: Partial<LinkPreview> = {}): LinkPreview {
+  return {
+    url: 'https://example.com/article',
+    title: 'Example Article',
+    description: 'A description of the article.',
+    siteName: 'Example',
+    imageUrl: 'https://example.com/banner.jpg',
+    faviconUrl: 'https://example.com/favicon.ico',
+    ...overrides,
+  };
+}
+
+describe('LinkPreviewCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it('renders title, description, and site name correctly', () => {
+    renderWithTheme(<LinkPreviewCard preview={makePreview()} />);
+
+    expect(screen.getByText('Example Article')).toBeDefined();
+    expect(screen.getByText('A description of the article.')).toBeDefined();
+    expect(screen.getByText('Example')).toBeDefined();
+  });
+
+  it('renders banner image when imageUrl is provided', () => {
+    renderWithTheme(<LinkPreviewCard preview={makePreview()} />);
+
+    const img = screen.getByRole('img', { name: 'Example Article' });
+    expect(img).toBeDefined();
+    expect(img.getAttribute('src')).toBe('https://example.com/banner.jpg');
+  });
+
+  it('does not render image when no imageUrl', () => {
+    renderWithTheme(
+      <LinkPreviewCard preview={makePreview({ imageUrl: undefined })} />,
+    );
+
+    expect(screen.queryByRole('img', { name: 'Example Article' })).toBeNull();
+  });
+
+  it('handles missing optional fields gracefully (no description, no siteName)', () => {
+    renderWithTheme(
+      <LinkPreviewCard
+        preview={makePreview({
+          description: undefined,
+          siteName: undefined,
+          faviconUrl: undefined,
+        })}
+      />,
+    );
+
+    // Title should still render
+    expect(screen.getByText('Example Article')).toBeDefined();
+
+    // Falls back to hostname when no siteName
+    expect(screen.getByText('example.com')).toBeDefined();
+
+    // Description should not be present
+    expect(screen.queryByText('A description of the article.')).toBeNull();
+  });
+
+  it('handles missing title gracefully', () => {
+    renderWithTheme(
+      <LinkPreviewCard preview={makePreview({ title: undefined })} />,
+    );
+
+    // Should still render site name and description without crashing
+    expect(screen.getByText('Example')).toBeDefined();
+    expect(screen.getByText('A description of the article.')).toBeDefined();
+  });
+
+  it('clicking the card opens URL in new tab', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    renderWithTheme(<LinkPreviewCard preview={makePreview()} />);
+
+    const title = screen.getByText('Example Article');
+    fireEvent.click(title);
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://example.com/article',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  it('renders favicon when faviconUrl is provided', () => {
+    const { container } = renderWithTheme(
+      <LinkPreviewCard preview={makePreview()} />,
+    );
+
+    const favicon = container.querySelector(
+      'img[src="https://example.com/favicon.ico"]',
+    );
+    expect(favicon).not.toBeNull();
+  });
+
+  it('does not render favicon when faviconUrl is not provided', () => {
+    const { container } = renderWithTheme(
+      <LinkPreviewCard preview={makePreview({ faviconUrl: undefined })} />,
+    );
+
+    const favicon = container.querySelector(
+      'img[src="https://example.com/favicon.ico"]',
+    );
+    expect(favicon).toBeNull();
+  });
+
+  it('hides banner image on load error', () => {
+    renderWithTheme(<LinkPreviewCard preview={makePreview()} />);
+
+    const banner = screen.getByRole('img', { name: 'Example Article' });
+    expect(banner).toBeDefined();
+
+    // Simulate image load error — component uses state to hide
+    fireEvent.error(banner);
+
+    // After error, the image should be removed from the DOM
+    expect(screen.queryByRole('img', { name: 'Example Article' })).toBeNull();
+  });
+
+  it('hides broken favicon image on error', () => {
+    const { container } = renderWithTheme(
+      <LinkPreviewCard preview={makePreview()} />,
+    );
+
+    const favicon = container.querySelector(
+      'img[src="https://example.com/favicon.ico"]',
+    ) as HTMLImageElement;
+    expect(favicon).not.toBeNull();
+
+    fireEvent.error(favicon);
+    expect(favicon.style.display).toBe('none');
+  });
+});

--- a/frontend/src/__tests__/components/MessageLinkPreviews.test.tsx
+++ b/frontend/src/__tests__/components/MessageLinkPreviews.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { generateTheme } from '../../theme/themeConfig';
+import { MessageLinkPreviews } from '../../components/Message/MessageLinkPreviews';
+import type { LinkPreview } from '../../types/message.type';
+
+const theme = generateTheme('dark', 'blue', 'balanced');
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+}
+
+function makePreview(overrides: Partial<LinkPreview> = {}): LinkPreview {
+  return {
+    url: 'https://example.com/default',
+    title: 'Default Title',
+    description: 'Default description',
+    siteName: 'Example',
+    ...overrides,
+  };
+}
+
+describe('MessageLinkPreviews', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when linkPreviews is undefined', () => {
+    const { container } = renderWithTheme(
+      <MessageLinkPreviews linkPreviews={undefined} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when linkPreviews is empty array', () => {
+    const { container } = renderWithTheme(
+      <MessageLinkPreviews linkPreviews={[]} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a single LinkPreviewCard for one preview', () => {
+    const previews: LinkPreview[] = [
+      makePreview({
+        url: 'https://example.com/one',
+        title: 'First Article',
+      }),
+    ];
+
+    renderWithTheme(<MessageLinkPreviews linkPreviews={previews} />);
+
+    expect(screen.getByText('First Article')).toBeDefined();
+  });
+
+  it('renders multiple LinkPreviewCard components for multiple previews', () => {
+    const previews: LinkPreview[] = [
+      makePreview({
+        url: 'https://example.com/one',
+        title: 'First Article',
+        siteName: 'Site A',
+      }),
+      makePreview({
+        url: 'https://example.com/two',
+        title: 'Second Article',
+        siteName: 'Site B',
+      }),
+      makePreview({
+        url: 'https://example.com/three',
+        title: 'Third Article',
+        siteName: 'Site C',
+      }),
+    ];
+
+    renderWithTheme(<MessageLinkPreviews linkPreviews={previews} />);
+
+    expect(screen.getByText('First Article')).toBeDefined();
+    expect(screen.getByText('Second Article')).toBeDefined();
+    expect(screen.getByText('Third Article')).toBeDefined();
+    expect(screen.getByText('Site A')).toBeDefined();
+    expect(screen.getByText('Site B')).toBeDefined();
+    expect(screen.getByText('Site C')).toBeDefined();
+  });
+});

--- a/frontend/src/components/Message/LinkPreviewCard.tsx
+++ b/frontend/src/components/Message/LinkPreviewCard.tsx
@@ -1,0 +1,150 @@
+import React, { useState } from "react";
+import { Box, Card, Typography, styled } from "@mui/material";
+import LinkIcon from "@mui/icons-material/Link";
+import type { LinkPreview } from "../../types/message.type";
+
+const PreviewCard = styled(Card)(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  overflow: "hidden",
+  borderRadius: theme.spacing(1),
+  backgroundColor:
+    theme.palette.mode === "dark"
+      ? "rgba(0, 0, 0, 0.2)"
+      : theme.palette.grey[50],
+  borderLeft: `3px solid ${theme.palette.primary.main}`,
+  border: `1px solid ${theme.palette.divider}`,
+  borderLeftWidth: 3,
+  borderLeftColor: theme.palette.primary.main,
+  maxWidth: 420,
+  cursor: "pointer",
+  transition: "background-color 0.2s",
+  "&:hover": {
+    backgroundColor:
+      theme.palette.mode === "dark"
+        ? "rgba(0, 0, 0, 0.35)"
+        : theme.palette.grey[100],
+  },
+}));
+
+const BannerImage = styled("img")({
+  width: "100%",
+  maxHeight: 250,
+  objectFit: "cover",
+  display: "block",
+});
+
+const Favicon = styled("img")({
+  width: 16,
+  height: 16,
+  marginRight: 6,
+  flexShrink: 0,
+  borderRadius: 2,
+});
+
+const FallbackDot = styled(Box)(({ theme }) => ({
+  width: 16,
+  height: 16,
+  marginRight: 6,
+  flexShrink: 0,
+  borderRadius: 2,
+  backgroundColor: theme.palette.action.disabled,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+}));
+
+interface LinkPreviewCardProps {
+  preview: LinkPreview;
+}
+
+export const LinkPreviewCard: React.FC<LinkPreviewCardProps> = React.memo(
+  ({ preview }) => {
+    const [imageError, setImageError] = useState(false);
+
+    const handleClick = () => {
+      window.open(preview.url, "_blank", "noopener,noreferrer");
+    };
+
+    const showBannerImage = preview.imageUrl && !imageError;
+
+    return (
+      <PreviewCard elevation={0} onClick={handleClick}>
+        <Box sx={{ p: 1.25, pb: showBannerImage ? 0.75 : 1.25 }}>
+          {/* Site name + favicon */}
+          <Box sx={{ display: "flex", alignItems: "center", mb: 0.5 }}>
+            {preview.faviconUrl ? (
+              <Favicon
+                src={preview.faviconUrl}
+                alt=""
+                onError={(e) => {
+                  (e.target as HTMLImageElement).style.display = "none";
+                }}
+              />
+            ) : (
+              <FallbackDot>
+                <LinkIcon sx={{ fontSize: 10 }} />
+              </FallbackDot>
+            )}
+            <Typography variant="caption" color="text.secondary" noWrap>
+              {preview.siteName || new URL(preview.url).hostname}
+              {preview.authorName && ` · ${preview.authorName}`}
+            </Typography>
+          </Box>
+
+          {/* Title */}
+          {preview.title && (
+            <Typography
+              variant="body2"
+              fontWeight={600}
+              color="primary"
+              sx={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+                lineHeight: 1.3,
+                mb: preview.description ? 0.25 : 0,
+              }}
+            >
+              {preview.title}
+            </Typography>
+          )}
+
+          {/* Description */}
+          {preview.description && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+                lineHeight: 1.4,
+              }}
+            >
+              {preview.description}
+            </Typography>
+          )}
+        </Box>
+
+        {/* Banner image below text — like Discord */}
+        {showBannerImage && (
+          <Box sx={{ px: 1.25, pb: 1.25 }}>
+            <BannerImage
+              src={preview.imageUrl}
+              alt={preview.title || ""}
+              onError={() => setImageError(true)}
+              sx={{ borderRadius: 0.75 }}
+            />
+          </Box>
+        )}
+      </PreviewCard>
+    );
+  }
+);
+
+LinkPreviewCard.displayName = "LinkPreviewCard";

--- a/frontend/src/components/Message/LinkPreviewCard.tsx
+++ b/frontend/src/components/Message/LinkPreviewCard.tsx
@@ -66,10 +66,31 @@ export const LinkPreviewCard: React.FC<LinkPreviewCardProps> = React.memo(
       window.open(preview.url, "_blank", "noopener,noreferrer");
     };
 
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleClick();
+      }
+    };
+
+    let hostname = "";
+    try {
+      hostname = new URL(preview.url).hostname;
+    } catch {
+      hostname = preview.url;
+    }
+
     const showBannerImage = preview.imageUrl && !imageError;
 
     return (
-      <PreviewCard elevation={0} onClick={handleClick}>
+      <PreviewCard
+        elevation={0}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        role="link"
+        tabIndex={0}
+        aria-label={preview.title || preview.url}
+      >
         <Box sx={{ p: 1.25, pb: showBannerImage ? 0.75 : 1.25 }}>
           {/* Site name + favicon */}
           <Box sx={{ display: "flex", alignItems: "center", mb: 0.5 }}>
@@ -87,7 +108,7 @@ export const LinkPreviewCard: React.FC<LinkPreviewCardProps> = React.memo(
               </FallbackDot>
             )}
             <Typography variant="caption" color="text.secondary" noWrap>
-              {preview.siteName || new URL(preview.url).hostname}
+              {preview.siteName || hostname}
               {preview.authorName && ` · ${preview.authorName}`}
             </Typography>
           </Box>

--- a/frontend/src/components/Message/MessageComponent.tsx
+++ b/frontend/src/components/Message/MessageComponent.tsx
@@ -15,6 +15,7 @@ import { useCurrentUser } from "../../hooks/useCurrentUser";
 import { useMessagePermissions } from "../../hooks/useMessagePermissions";
 import { MessageReactions } from "./MessageReactions";
 import { MessageAttachments } from "./MessageAttachments";
+import { MessageLinkPreviews } from "./MessageLinkPreviews";
 import { MessageEditForm } from "./MessageEditForm";
 import { MessageToolbar } from "./MessageToolbar";
 import { renderMessageSpans } from "./MessageSpan";
@@ -225,6 +226,7 @@ function MessageComponentInner({
               {renderMessageSpans(message.spans)}
             </Typography>
             <MessageAttachments attachments={message.attachments} />
+            <MessageLinkPreviews linkPreviews={message.linkPreviews} />
             <MessageReactions
               messageId={message.id}
               reactions={message.reactions}
@@ -348,7 +350,9 @@ const MessageComponent = React.memo(MessageComponentInner, (prevProps, nextProps
     }) &&
     // Deep compare attachments array
     prevMsg.attachments?.length === nextMsg.attachments?.length &&
-    prevMsg.attachments?.every((a, i) => a.id === nextMsg.attachments?.[i]?.id)
+    prevMsg.attachments?.every((a, i) => a.id === nextMsg.attachments?.[i]?.id) &&
+    // Compare link previews
+    (prevMsg.linkPreviews?.length ?? 0) === (nextMsg.linkPreviews?.length ?? 0)
   );
 });
 

--- a/frontend/src/components/Message/MessageComponent.tsx
+++ b/frontend/src/components/Message/MessageComponent.tsx
@@ -351,8 +351,13 @@ const MessageComponent = React.memo(MessageComponentInner, (prevProps, nextProps
     // Deep compare attachments array
     prevMsg.attachments?.length === nextMsg.attachments?.length &&
     prevMsg.attachments?.every((a, i) => a.id === nextMsg.attachments?.[i]?.id) &&
-    // Compare link previews
-    (prevMsg.linkPreviews?.length ?? 0) === (nextMsg.linkPreviews?.length ?? 0)
+    // Compare link previews (length + URLs + titles cover content changes)
+    (prevMsg.linkPreviews?.length ?? 0) === (nextMsg.linkPreviews?.length ?? 0) &&
+    (prevMsg.linkPreviews?.every((lp, i) =>
+      lp.url === nextMsg.linkPreviews?.[i]?.url &&
+      lp.title === nextMsg.linkPreviews?.[i]?.title &&
+      lp.imageUrl === nextMsg.linkPreviews?.[i]?.imageUrl
+    ) ?? true)
   );
 });
 

--- a/frontend/src/components/Message/MessageLinkPreviews.tsx
+++ b/frontend/src/components/Message/MessageLinkPreviews.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Box } from "@mui/material";
+import { LinkPreviewCard } from "./LinkPreviewCard";
+import type { LinkPreview } from "../../types/message.type";
+
+interface MessageLinkPreviewsProps {
+  linkPreviews?: LinkPreview[];
+}
+
+export const MessageLinkPreviews: React.FC<MessageLinkPreviewsProps> =
+  React.memo(({ linkPreviews }) => {
+    if (!linkPreviews || linkPreviews.length === 0) return null;
+
+    return (
+      <Box sx={{ mt: 0.5, display: "flex", flexDirection: "column", gap: 0.5 }}>
+        {linkPreviews.map((preview) => (
+          <LinkPreviewCard key={preview.url} preview={preview} />
+        ))}
+      </Box>
+    );
+  });
+
+MessageLinkPreviews.displayName = "MessageLinkPreviews";

--- a/frontend/src/types/message.type.ts
+++ b/frontend/src/types/message.type.ts
@@ -1,1 +1,1 @@
-export { SpanType, type Span, type Reaction, type FileMetadata, type Message } from '@semaphore-chat/shared';
+export { SpanType, type Span, type Reaction, type FileMetadata, type LinkPreview, type Message } from '@semaphore-chat/shared';

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -3,6 +3,7 @@ export {
   type Span,
   type Reaction,
   type FileMetadata,
+  type LinkPreview,
   type Message,
 } from './message.types';
 

--- a/shared/src/types/message.types.ts
+++ b/shared/src/types/message.types.ts
@@ -29,6 +29,16 @@ export interface FileMetadata {
   hasThumbnail?: boolean;
 }
 
+export interface LinkPreview {
+  url: string;
+  title?: string;
+  description?: string;
+  imageUrl?: string;
+  siteName?: string;
+  faviconUrl?: string;
+  authorName?: string;
+}
+
 export interface Message {
   id: string;
   channelId?: string;
@@ -38,6 +48,7 @@ export interface Message {
   attachments: FileMetadata[];
   pendingAttachments?: number;
   reactions: Reaction[];
+  linkPreviews?: LinkPreview[];
   sentAt: string;
   editedAt?: string;
   deletedAt?: string;


### PR DESCRIPTION
## Summary
- Adds link preview cards for URLs shared in messages — fetches Open Graph metadata asynchronously and renders Discord-style preview cards with title, description, banner image, favicon, and site name
- oEmbed support for YouTube, Spotify, Vimeo, TikTok, SoundCloud, Flickr — fetched in parallel with OG scrape, merged for better thumbnails and author info
- Proper bot detection handling: Cloudflare challenge detection via `cf-mitigated` header, browser-like request headers following the Telegram/Discord UA convention

### How it works
1. User sends a message with a URL
2. Message is delivered immediately (no delay)
3. Backend fires-and-forgets an async task: extract URLs → fetch OG + oEmbed → store in DB → broadcast UPDATE_MESSAGE via WebSocket
4. Frontend receives the update and re-renders the message with the preview card

### What's included
- **Backend**: New `link-previews` module (service + utils), Prisma `linkPreviews Json?` field on Message, integration into messages gateway/controller and threads gateway
- **Frontend**: `LinkPreviewCard` (Discord-style with left accent border, banner image, metadata) and `MessageLinkPreviews` container, `React.memo` fix for real-time updates
- **Security**: SSRF protection (private IP blocking), Cloudflare challenge detection, 5s timeout, 50KB body limit, max 5 URLs per message
- **73 new tests** (62 backend utils + 11 backend service + 14 frontend components)

### Sites tested
GitHub, Reddit, Wikipedia, rust-lang.org, nodejs.org, python.org, typescriptlang.org, go.dev, docs.docker.com — all produce previews

Closes #338

## Test plan
- [ ] `docker compose run --rm backend pnpm run test` — all backend tests pass
- [ ] `docker compose run --rm frontend pnpm run test` — all frontend tests pass
- [ ] Send a message with a URL in a channel — preview card appears after 1-2s
- [ ] Send a message with a URL in a DM — preview card appears
- [ ] Send a YouTube link — verify oEmbed thumbnail and author name appear
- [ ] Edit a message to add a URL — preview appears for the new URL
- [ ] Send a message with no URLs — no preview, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)