### PR TITLE
fix: stabilize voice connections during screen sharing

### DIFF
--- a/frontend/src/__tests__/features/voiceActions.test.ts
+++ b/frontend/src/__tests__/features/voiceActions.test.ts
@@ -29,9 +29,17 @@ vi.mock('livekit-client', () => {
     state = mockRoomInstance.state;
     localParticipant = mockRoomInstance.localParticipant;
     switchActiveDevice = mockRoomInstance.switchActiveDevice;
+    on = vi.fn().mockReturnThis();
   }
   return {
     Room: MockRoom,
+    RoomEvent: {
+      Reconnecting: 'reconnecting',
+      Reconnected: 'reconnected',
+      SignalConnected: 'signalConnected',
+      Disconnected: 'disconnected',
+    },
+    DisconnectReason: {},
     VideoCaptureOptions: {},
     AudioCaptureOptions: {},
   };

--- a/frontend/src/__tests__/hooks/useTrackSubscription.test.ts
+++ b/frontend/src/__tests__/hooks/useTrackSubscription.test.ts
@@ -160,10 +160,41 @@ describe('useTrackSubscription', () => {
       expect(micPub.setSubscribed).toHaveBeenCalledWith(true);
     });
 
-    it('unsubscribes newly published camera tracks', () => {
+    it('does not call setSubscribed(false) on never-subscribed camera tracks', () => {
       renderHook(() => useTrackSubscription());
 
       const camPub = createMockPublication('camera');
+      // camPub.isSubscribed is false by default (never subscribed)
+      const participant = createMockParticipant('user-1', [camPub]);
+
+      act(() => {
+        emitRoomEvent('trackPublished', camPub, participant);
+      });
+
+      // With the guard, setSubscribed(false) is NOT called on never-subscribed tracks
+      // to avoid sending redundant signals to the SFU
+      expect(camPub.setSubscribed).not.toHaveBeenCalled();
+    });
+
+    it('does not call setSubscribed(false) on never-subscribed screen share tracks', () => {
+      renderHook(() => useTrackSubscription());
+
+      const screenPub = createMockPublication('screen_share');
+      // screenPub.isSubscribed is false by default (never subscribed)
+      const participant = createMockParticipant('user-1', [screenPub]);
+
+      act(() => {
+        emitRoomEvent('trackPublished', screenPub, participant);
+      });
+
+      expect(screenPub.setSubscribed).not.toHaveBeenCalled();
+    });
+
+    it('unsubscribes previously-subscribed opt-in tracks on re-publish', () => {
+      renderHook(() => useTrackSubscription());
+
+      const camPub = createMockPublication('camera');
+      camPub.isSubscribed = true; // simulate a previously subscribed track
       const participant = createMockParticipant('user-1', [camPub]);
 
       act(() => {
@@ -171,19 +202,6 @@ describe('useTrackSubscription', () => {
       });
 
       expect(camPub.setSubscribed).toHaveBeenCalledWith(false);
-    });
-
-    it('unsubscribes newly published screen share tracks', () => {
-      renderHook(() => useTrackSubscription());
-
-      const screenPub = createMockPublication('screen_share');
-      const participant = createMockParticipant('user-1', [screenPub]);
-
-      act(() => {
-        emitRoomEvent('trackPublished', screenPub, participant);
-      });
-
-      expect(screenPub.setSubscribed).toHaveBeenCalledWith(false);
     });
   });
 

--- a/frontend/src/components/Voice/AudioRenderer.tsx
+++ b/frontend/src/components/Voice/AudioRenderer.tsx
@@ -61,6 +61,10 @@ const ParticipantAudio: React.FC<ParticipantAudioProps> = ({ participant, audioP
  * The deafen functionality is handled by the useDeafenEffect hook which sets
  * track volume to 0 when deafened.
  *
+ * IMPORTANT: This component uses a ref for watchingScreenShares to keep the
+ * updateAudioTracks callback and its event listener registrations stable.
+ * Mic audio management must never be disrupted by screen share watching state changes.
+ *
  * @example
  * // In Layout.tsx or MobileLayout.tsx, alongside VoiceBottomBar
  * <VoiceBottomBar />
@@ -71,6 +75,14 @@ export const AudioRenderer: React.FC = () => {
   const { watchingScreenShares } = useVoice();
   const [audioTracks, setAudioTracks] = useState<Map<string, { participant: RemoteParticipant; publication: RemoteTrackPublication }>>(new Map());
 
+  // Use a ref for watchingScreenShares so updateAudioTracks callback stays stable.
+  // This prevents event listener teardown/re-registration when watching state changes,
+  // which could cause missed events and audio drops.
+  const watchingScreenSharesRef = useRef(watchingScreenShares);
+  useEffect(() => {
+    watchingScreenSharesRef.current = watchingScreenShares;
+  }, [watchingScreenShares]);
+
   // Update audio tracks list when participants/tracks change
   const updateAudioTracks = useCallback(() => {
     if (!room) {
@@ -80,13 +92,14 @@ export const AudioRenderer: React.FC = () => {
     }
 
     const newTracks = new Map<string, { participant: RemoteParticipant; publication: RemoteTrackPublication }>();
+    const currentWatching = watchingScreenSharesRef.current;
 
     logger.debug('[AudioRenderer] Updating audio tracks, remote participants:', room.remoteParticipants.size);
     room.remoteParticipants.forEach((participant) => {
       participant.audioTrackPublications.forEach((publication) => {
         // Include microphone tracks always; screen share audio only when watching that participant's screen share
         const isMic = publication.source === Track.Source.Microphone;
-        const isScreenShareAudio = publication.source === Track.Source.ScreenShareAudio && watchingScreenShares.has(participant.identity);
+        const isScreenShareAudio = publication.source === Track.Source.ScreenShareAudio && currentWatching.has(participant.identity);
         if ((isMic || isScreenShareAudio) && publication.track) {
           const key = `${participant.identity}-${publication.trackSid}`;
           newTracks.set(key, { participant, publication });
@@ -97,8 +110,9 @@ export const AudioRenderer: React.FC = () => {
 
     logger.info('[AudioRenderer] Audio tracks updated, count:', newTracks.size);
     setAudioTracks(newTracks);
-  }, [room, watchingScreenShares]);
+  }, [room]);
 
+  // Register room event listeners — stable because updateAudioTracks only depends on room
   useEffect(() => {
     if (!room) return;
 
@@ -119,6 +133,12 @@ export const AudioRenderer: React.FC = () => {
       events.forEach((event) => room.off(event, updateAudioTracks));
     };
   }, [room, updateAudioTracks]);
+
+  // When watchingScreenShares changes, rebuild audio tracks to pick up
+  // screen share audio subscriptions without re-registering event listeners.
+  useEffect(() => {
+    updateAudioTracks();
+  }, [watchingScreenShares, updateAudioTracks]);
 
   // Don't render anything visible - just hidden audio elements
   if (!room || audioTracks.size === 0) {

--- a/frontend/src/contexts/RoomContext.tsx
+++ b/frontend/src/contexts/RoomContext.tsx
@@ -66,16 +66,16 @@ export const RoomProvider: React.FC<RoomProviderProps> = ({ children }) => {
     };
   }, [stateRef]);
 
-  // Clean up room when voice state transitions to disconnected
+  // Clean up room when voice state transitions to disconnected.
+  // Uses stateRef to check isConnected without subscribing to VoiceState context.
+  // Runs when the room state variable changes (setRoom triggers setRoomState).
   useEffect(() => {
-    // Poll isConnected via stateRef to avoid subscribing to VoiceState context.
-    // This effect only needs to run when the room state variable changes.
     if (!stateRef.current.isConnected && roomRef.current) {
       roomRef.current.disconnect();
       roomRef.current = null;
       setRoomState(null);
     }
-  });
+  }, [room, stateRef]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/frontend/src/contexts/RoomContext.tsx
+++ b/frontend/src/contexts/RoomContext.tsx
@@ -1,6 +1,6 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useCallback, useMemo, useState } from "react";
 import { Room } from "livekit-client";
-import { useVoice } from "./VoiceContext";
+import { useVoiceDispatch } from "./VoiceContext";
 import { RoomContext, RoomContextType } from "./RoomContextDef";
 import { getApiBaseUrl } from "../config/env";
 import { getAccessToken } from "../utils/tokenService";
@@ -11,33 +11,21 @@ interface RoomProviderProps {
 
 export const RoomProvider: React.FC<RoomProviderProps> = ({ children }) => {
   const roomRef = useRef<Room | null>(null);
-  const { isConnected, currentChannelId, currentDmGroupId } = useVoice();
-
-  // Use refs to access current values in beforeunload handler without re-registering
-  const channelIdRef = useRef(currentChannelId);
-  const dmGroupIdRef = useRef(currentDmGroupId);
-  const roomRefForUnload = useRef(roomRef.current);
-
-  // Keep refs in sync with state
-  useEffect(() => {
-    channelIdRef.current = currentChannelId;
-  }, [currentChannelId]);
-
-  useEffect(() => {
-    dmGroupIdRef.current = currentDmGroupId;
-  }, [currentDmGroupId]);
-
-  useEffect(() => {
-    roomRefForUnload.current = roomRef.current;
-  });
+  // Use stateRef from dispatch context (stable, no re-renders from voice state changes)
+  // instead of useVoice() which subscribes to ALL state changes and causes
+  // cascading re-renders through every useRoom() consumer (12+ hooks).
+  const { stateRef } = useVoiceDispatch();
+  // Track the room object in state so context consumers re-render when the room changes
+  const [room, setRoomState] = useState<Room | null>(null);
 
   // Handle page unload - notify backend before disconnect
   useEffect(() => {
     const handleBeforeUnload = () => {
       const token = getAccessToken();
       const baseUrl = getApiBaseUrl();
-      const channelId = channelIdRef.current;
-      const dmGroupId = dmGroupIdRef.current;
+      const state = stateRef.current;
+      const channelId = state.currentChannelId;
+      const dmGroupId = state.currentDmGroupId;
 
       // Use fetch with keepalive to ensure request completes during page unload
       if (channelId) {
@@ -67,8 +55,8 @@ export const RoomProvider: React.FC<RoomProviderProps> = ({ children }) => {
       }
 
       // Also disconnect LiveKit room immediately
-      if (roomRefForUnload.current) {
-        roomRefForUnload.current.disconnect();
+      if (roomRef.current) {
+        roomRef.current.disconnect();
       }
     };
 
@@ -76,15 +64,18 @@ export const RoomProvider: React.FC<RoomProviderProps> = ({ children }) => {
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
-  }, []);
+  }, [stateRef]);
 
-  // Clean up room when disconnected
+  // Clean up room when voice state transitions to disconnected
   useEffect(() => {
-    if (!isConnected && roomRef.current) {
+    // Poll isConnected via stateRef to avoid subscribing to VoiceState context.
+    // This effect only needs to run when the room state variable changes.
+    if (!stateRef.current.isConnected && roomRef.current) {
       roomRef.current.disconnect();
       roomRef.current = null;
+      setRoomState(null);
     }
-  }, [isConnected]);
+  });
 
   // Cleanup on unmount
   useEffect(() => {
@@ -96,20 +87,21 @@ export const RoomProvider: React.FC<RoomProviderProps> = ({ children }) => {
     };
   }, []);
 
-  const setRoom = (room: Room | null) => {
-    if (roomRef.current && roomRef.current !== room) {
+  const setRoom = useCallback((newRoom: Room | null) => {
+    if (roomRef.current && roomRef.current !== newRoom) {
       roomRef.current.disconnect();
     }
-    roomRef.current = room;
-  };
+    roomRef.current = newRoom;
+    setRoomState(newRoom);
+  }, []);
 
-  const getRoom = () => roomRef.current;
+  const getRoom = useCallback(() => roomRef.current, []);
 
-  const value: RoomContextType = {
-    room: roomRef.current,
+  const value = useMemo<RoomContextType>(() => ({
+    room,
     setRoom,
     getRoom,
-  };
+  }), [room, setRoom, getRoom]);
 
   return <RoomContext.Provider value={value}>{children}</RoomContext.Provider>;
 };

--- a/frontend/src/contexts/VoiceContext.tsx
+++ b/frontend/src/contexts/VoiceContext.tsx
@@ -166,31 +166,37 @@ function voiceReducer(state: VoiceState, action: VoiceAction): VoiceState {
     case VoiceActionType.SetServerMuted:
       return { ...state, isServerMuted: action.payload };
     case VoiceActionType.WatchCamera: {
+      if (state.watchingCameras.has(action.payload)) return state;
       const next = new Set(state.watchingCameras);
       next.add(action.payload);
       return { ...state, watchingCameras: next };
     }
     case VoiceActionType.StopWatchingCamera: {
+      if (!state.watchingCameras.has(action.payload)) return state;
       const next = new Set(state.watchingCameras);
       next.delete(action.payload);
       return { ...state, watchingCameras: next };
     }
     case VoiceActionType.WatchScreenShare: {
+      if (state.watchingScreenShares.has(action.payload)) return state;
       const next = new Set(state.watchingScreenShares);
       next.add(action.payload);
       return { ...state, watchingScreenShares: next };
     }
     case VoiceActionType.StopWatchingScreenShare: {
+      if (!state.watchingScreenShares.has(action.payload)) return state;
       const next = new Set(state.watchingScreenShares);
       next.delete(action.payload);
       return { ...state, watchingScreenShares: next };
     }
     case VoiceActionType.HideLocalTile: {
+      if (state.hiddenLocalTiles.has(action.payload)) return state;
       const next = new Set(state.hiddenLocalTiles);
       next.add(action.payload);
       return { ...state, hiddenLocalTiles: next };
     }
     case VoiceActionType.ShowLocalTile: {
+      if (!state.hiddenLocalTiles.has(action.payload)) return state;
       const next = new Set(state.hiddenLocalTiles);
       next.delete(action.payload);
       return { ...state, hiddenLocalTiles: next };

--- a/frontend/src/contexts/VoiceContext.tsx
+++ b/frontend/src/contexts/VoiceContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useReducer, useRef, useEffect } from "react";
+import React, { createContext, useContext, useReducer, useRef, useEffect, useMemo } from "react";
 
 export enum VoiceSessionType {
   Channel = 'channel',
@@ -221,8 +221,12 @@ export const VoiceProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     stateRef.current = state;
   }, [state]);
 
+  // Memoize dispatch context value so consumers (like RoomProvider) that only
+  // need dispatch/stateRef don't re-render on every VoiceState change.
+  const dispatchValue = useMemo(() => ({ dispatch, stateRef }), [dispatch, stateRef]);
+
   return (
-    <VoiceDispatchContext.Provider value={{ dispatch, stateRef }}>
+    <VoiceDispatchContext.Provider value={dispatchValue}>
       <VoiceStateContext.Provider value={state}>
         {children}
       </VoiceStateContext.Provider>

--- a/frontend/src/features/voice/voiceActions.ts
+++ b/frontend/src/features/voice/voiceActions.ts
@@ -1,4 +1,4 @@
-import { Room, VideoCaptureOptions, AudioCaptureOptions } from "livekit-client";
+import { Room, RoomEvent, DisconnectReason, VideoCaptureOptions, AudioCaptureOptions } from "livekit-client";
 import { VoiceSessionType, VoiceActionType, type VoiceAction, type VoiceState } from "../../contexts/VoiceContext";
 import { livekitControllerGenerateToken, livekitControllerGenerateDmToken, voicePresenceControllerJoinPresence, voicePresenceControllerLeavePresence, voicePresenceControllerUpdateDeafenState } from "../../api-client/sdk.gen";
 import { queryClient } from "../../queryClient";
@@ -108,6 +108,21 @@ async function connectToLiveKitRoom(
   logger.info('[Voice] Creating new LiveKit room instance');
   const room = new Room({
     autoSubscribe: false,
+  });
+
+  // Register connection state monitoring before connecting so we catch
+  // any events that fire during the connection handshake.
+  room.on(RoomEvent.Reconnecting, () => {
+    logger.warn('[Voice] LiveKit reconnecting...');
+  });
+  room.on(RoomEvent.Reconnected, () => {
+    logger.info('[Voice] LiveKit reconnected');
+  });
+  room.on(RoomEvent.SignalConnected, () => {
+    logger.info('[Voice] LiveKit signal reconnected');
+  });
+  room.on(RoomEvent.Disconnected, (reason?: DisconnectReason) => {
+    logger.error('[Voice] LiveKit disconnected, reason:', reason);
   });
 
   try {

--- a/frontend/src/features/voice/voiceActions.ts
+++ b/frontend/src/features/voice/voiceActions.ts
@@ -119,10 +119,14 @@ async function connectToLiveKitRoom(
     logger.info('[Voice] LiveKit reconnected');
   });
   room.on(RoomEvent.SignalConnected, () => {
-    logger.info('[Voice] LiveKit signal reconnected');
+    logger.info('[Voice] LiveKit signal connected');
   });
   room.on(RoomEvent.Disconnected, (reason?: DisconnectReason) => {
-    logger.error('[Voice] LiveKit disconnected, reason:', reason);
+    if (reason === DisconnectReason.CLIENT_INITIATED) {
+      logger.info('[Voice] LiveKit disconnected by client');
+      return;
+    }
+    logger.error('[Voice] LiveKit disconnected unexpectedly, reason:', reason);
   });
 
   try {

--- a/frontend/src/hooks/useTrackSubscription.ts
+++ b/frontend/src/hooks/useTrackSubscription.ts
@@ -96,6 +96,7 @@ export function useTrackSubscription(): TrackSubscriptionActions {
       participant: RemoteParticipant,
     ) => {
       if (!(publication instanceof RemoteTrackPublication)) return;
+      logger.info('[TrackSubscription] TrackPublished', participant.identity, publication.source, publication.trackSid);
       if (publication.source === Track.Source.Microphone) {
         subscribePublication(publication, `published-mic:${participant.identity}`);
       } else if (isOptInSource(publication.source)) {
@@ -107,6 +108,7 @@ export function useTrackSubscription(): TrackSubscriptionActions {
       publication: RemoteTrackPublication,
       participant: RemoteParticipant,
     ) => {
+      logger.info('[TrackSubscription] TrackUnpublished', participant.identity, publication.source, publication.trackSid);
       // Clean up watching state when a participant stops sharing
       if (publication.source === Track.Source.Camera) {
         dispatch({ type: VoiceActionType.StopWatchingCamera, payload: participant.identity });
@@ -116,11 +118,13 @@ export function useTrackSubscription(): TrackSubscriptionActions {
     };
 
     const handleParticipantConnected = (participant: RemoteParticipant) => {
+      logger.info('[TrackSubscription] ParticipantConnected', participant.identity, 'tracks:', participant.trackPublications.size);
       // Participant may already have published tracks by the time we get this event
       applySubscriptionPolicy(participant);
     };
 
     // Apply subscription policy to existing participants on mount
+    logger.info('[TrackSubscription] Applying initial subscription policy to', room.remoteParticipants.size, 'participants');
     for (const [, participant] of room.remoteParticipants) {
       applySubscriptionPolicy(participant);
     }

--- a/frontend/src/hooks/useTrackSubscription.ts
+++ b/frontend/src/hooks/useTrackSubscription.ts
@@ -11,10 +11,13 @@ import { logger } from '../utils/logger';
 
 /**
  * Unsubscribes a remote track publication from the SFU (saves bandwidth).
- * Always calls setSubscribed(false) to ensure the SFU knows we don't want this track,
- * regardless of current subscription state (important with autoSubscribe: false).
+ * Only sends the signal if the track is actually subscribed to avoid redundant
+ * WebSocket messages. With autoSubscribe: false, tracks start unsubscribed so
+ * calling setSubscribed(false) on them would send a no-op signal to the SFU
+ * that still consumes signaling bandwidth.
  */
 function unsubscribePublication(publication: RemoteTrackPublication, reason: string) {
+  if (!publication.isSubscribed) return;
   logger.info('[TrackSubscription] Unsubscribing', reason, publication.trackSid, publication.source);
   publication.setSubscribed(false);
 }


### PR DESCRIPTION
## Summary

Fixes random audio disconnects/drops that occurred when screen shares were active. The root cause was cascading React re-renders triggered by the selective track subscription system (shipped in 0.2.0), which could block the main thread long enough to disrupt LiveKit's real-time audio processing.

### Changes

- **RoomProvider render cascade** — `RoomProvider` subscribed to ALL `VoiceState` changes via `useVoice()` and recreated its context value on every render, cascading re-renders to all 12 `useRoom()` consumers. Switched to `useVoiceDispatch().stateRef` (stable, no re-renders) and memoized the context value with `useMemo`/`useCallback`.

- **VoiceContext no-op Set creation** — `StopWatchingScreenShare`/`StopWatchingCamera` reducer cases always created new `Set` references even when `delete()` was a no-op (identity not in set). This fired on every screen share unpublish regardless of whether the user was watching. Now returns same state reference when nothing changed, preventing unnecessary downstream re-renders.

- **AudioRenderer mic/screen-share coupling** — `updateAudioTracks` callback depended on `watchingScreenShares`, causing event listener teardown and re-registration on every watching state change. Now uses a ref for `watchingScreenShares` so mic audio event listeners remain stable. Screen share audio changes trigger a separate lightweight `updateAudioTracks()` call without re-registering listeners.

- **Redundant subscription signals** — `unsubscribePublication` called `setSubscribed(false)` on tracks that were never subscribed (with `autoSubscribe: false`). LiveKit's client SDK has no guard, so each call sent an `UpdateSubscription` WebSocket signal. Verified via LiveKit server source that these are no-ops on the SFU, but they add unnecessary signaling traffic. Now guarded with `isSubscribed` check.

- **Connection state monitoring** — Added handlers for `RoomEvent.Reconnecting`, `Reconnected`, `Disconnected`, and `SignalConnected` for observability into LiveKit connection state changes.

## Test plan

- [x] All 1183 frontend tests pass
- [x] TypeScript type check passes
- [ ] Manual test: join voice channel with multiple participants, start/stop screen shares, verify audio stays stable
- [ ] Manual test: watch/unwatch screen shares while in voice, verify no audio drops
- [ ] Monitor browser console for `[Voice] LiveKit reconnecting/disconnected` logs during screen share activity


🤖 Generated with [Claude Code](https://claude.com/claude-code)