### PR TITLE
fix: sort DM list by last message + fix voice join timestamps

### DIFF
--- a/backend/src/direct-messages/direct-messages.service.spec.ts
+++ b/backend/src/direct-messages/direct-messages.service.spec.ts
@@ -131,6 +131,45 @@ describe('DirectMessagesService', () => {
       expect(result[0].lastMessage).toBeNull();
     });
 
+    it('should sort groups by most recent message first, falling back to createdAt', async () => {
+      const user = UserFactory.build();
+
+      const jan1 = new Date('2025-01-01T00:00:00Z');
+      const feb1 = new Date('2025-02-01T00:00:00Z');
+      const feb15 = new Date('2025-02-15T00:00:00Z');
+      const mar1 = new Date('2025-03-01T00:00:00Z');
+      const mar15 = new Date('2025-03-15T00:00:00Z');
+
+      const msgA = MessageFactory.buildDirectMessage({
+        directMessageGroupId: 'dm-A',
+        sentAt: mar1,
+      });
+      const msgB = MessageFactory.buildDirectMessage({
+        directMessageGroupId: 'dm-B',
+        sentAt: feb15,
+      });
+
+      mockDatabase.directMessageGroupMember.findMany
+        .mockResolvedValueOnce([
+          { groupId: 'dm-A' },
+          { groupId: 'dm-B' },
+          { groupId: 'dm-C' },
+        ])
+        .mockResolvedValueOnce([]);
+
+      mockDatabase.directMessageGroup.findMany.mockResolvedValue([
+        { id: 'dm-C', name: null, isGroup: false, createdAt: mar15 },
+        { id: 'dm-B', name: null, isGroup: false, createdAt: feb1 },
+        { id: 'dm-A', name: null, isGroup: false, createdAt: jan1 },
+      ]);
+
+      mockDatabase.message.findMany.mockResolvedValue([msgA, msgB]);
+
+      const result = await service.findUserDmGroups(user.id);
+
+      expect(result.map((g) => g.id)).toEqual(['dm-C', 'dm-A', 'dm-B']);
+    });
+
     it('should rethrow errors', async () => {
       const user = UserFactory.build();
       mockDatabase.directMessageGroupMember.findMany.mockRejectedValue(

--- a/backend/src/direct-messages/direct-messages.service.ts
+++ b/backend/src/direct-messages/direct-messages.service.ts
@@ -92,8 +92,8 @@ export class DirectMessagesService {
       }
     }
 
-    // Step 4: Assemble response
-    return groups.map((group) => ({
+    // Step 4: Assemble and sort by most recent activity
+    const result = groups.map((group) => ({
       id: group.id,
       name: group.name,
       isGroup: group.isGroup,
@@ -101,6 +101,18 @@ export class DirectMessagesService {
       members: membersByGroupId.get(group.id) || [],
       lastMessage: lastMessageByGroupId.get(group.id) || null,
     }));
+
+    result.sort((a, b) => {
+      const aTime = a.lastMessage
+        ? new Date(a.lastMessage.sentAt).getTime()
+        : a.createdAt.getTime();
+      const bTime = b.lastMessage
+        ? new Date(b.lastMessage.sentAt).getTime()
+        : b.createdAt.getTime();
+      return bTime - aTime;
+    });
+
+    return result;
   }
 
   async createDmGroup(

--- a/backend/src/direct-messages/direct-messages.service.ts
+++ b/backend/src/direct-messages/direct-messages.service.ts
@@ -93,24 +93,31 @@ export class DirectMessagesService {
     }
 
     // Step 4: Assemble and sort by most recent activity
-    const result = groups.map((group) => ({
-      id: group.id,
-      name: group.name,
-      isGroup: group.isGroup,
-      createdAt: group.createdAt,
-      members: membersByGroupId.get(group.id) || [],
-      lastMessage: lastMessageByGroupId.get(group.id) || null,
-    }));
-
-    result.sort((a, b) => {
-      const aTime = a.lastMessage
-        ? new Date(a.lastMessage.sentAt).getTime()
-        : a.createdAt.getTime();
-      const bTime = b.lastMessage
-        ? new Date(b.lastMessage.sentAt).getTime()
-        : b.createdAt.getTime();
-      return bTime - aTime;
+    const result = groups.map((group) => {
+      const lastMessage = lastMessageByGroupId.get(group.id) || null;
+      return {
+        id: group.id,
+        name: group.name,
+        isGroup: group.isGroup,
+        createdAt: group.createdAt,
+        members: membersByGroupId.get(group.id) || [],
+        lastMessage,
+      };
     });
+
+    const activityTime = new Map<string, number>();
+    for (const group of result) {
+      activityTime.set(
+        group.id,
+        group.lastMessage
+          ? new Date(group.lastMessage.sentAt).getTime()
+          : group.createdAt.getTime(),
+      );
+    }
+
+    result.sort(
+      (a, b) => (activityTime.get(b.id) ?? 0) - (activityTime.get(a.id) ?? 0),
+    );
 
     return result;
   }

--- a/backend/src/link-previews/link-preview.utils.spec.ts
+++ b/backend/src/link-previews/link-preview.utils.spec.ts
@@ -15,7 +15,6 @@ jest.mock('dns', () => ({
   },
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockLookup = dns.lookup as jest.Mock<any>;
 
 describe('link-preview.utils', () => {
@@ -362,8 +361,12 @@ describe('link-preview.utils', () => {
 
   describe('findOEmbedProvider', () => {
     it('should match YouTube watch URLs', () => {
-      expect(findOEmbedProvider('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).not.toBeNull();
-      expect(findOEmbedProvider('https://youtube.com/watch?v=abc')).not.toBeNull();
+      expect(
+        findOEmbedProvider('https://www.youtube.com/watch?v=dQw4w9WgXcQ'),
+      ).not.toBeNull();
+      expect(
+        findOEmbedProvider('https://youtube.com/watch?v=abc'),
+      ).not.toBeNull();
     });
 
     it('should match YouTube short URLs', () => {
@@ -371,11 +374,15 @@ describe('link-preview.utils', () => {
     });
 
     it('should match YouTube Shorts', () => {
-      expect(findOEmbedProvider('https://www.youtube.com/shorts/abc123')).not.toBeNull();
+      expect(
+        findOEmbedProvider('https://www.youtube.com/shorts/abc123'),
+      ).not.toBeNull();
     });
 
     it('should match Spotify URLs', () => {
-      expect(findOEmbedProvider('https://open.spotify.com/track/abc')).not.toBeNull();
+      expect(
+        findOEmbedProvider('https://open.spotify.com/track/abc'),
+      ).not.toBeNull();
     });
 
     it('should match Vimeo URLs', () => {
@@ -383,7 +390,9 @@ describe('link-preview.utils', () => {
     });
 
     it('should match TikTok URLs', () => {
-      expect(findOEmbedProvider('https://www.tiktok.com/@user/video/123')).not.toBeNull();
+      expect(
+        findOEmbedProvider('https://www.tiktok.com/@user/video/123'),
+      ).not.toBeNull();
     });
 
     it('should return null for non-matching URLs', () => {

--- a/frontend/src/__tests__/components/VoiceChannelUserList.test.tsx
+++ b/frontend/src/__tests__/components/VoiceChannelUserList.test.tsx
@@ -276,19 +276,25 @@ describe('VoiceChannelUserList - Clickable Icons', () => {
       expect(mockSetShowVideoTiles).toHaveBeenCalledWith(true);
     });
 
-    it('seeds joinedAt timestamps from the backend REST API', async () => {
+    it('seeds joinedAt timestamps from the backend REST API and applies them', async () => {
       renderWithProviders(
-        <VoiceChannelUserList channel={voiceChannel} showCompact />,
+        <VoiceChannelUserList channel={voiceChannel} />,
       );
 
-      await screen.findByTestId('VideocamIcon');
-
+      // Wait for the seed effect to call the REST API and update participants
       await waitFor(() => {
         expect(mockGetChannelPresence).toHaveBeenCalledWith(
           expect.objectContaining({
             path: { channelId: 'voice-ch-1' },
           }),
         );
+      });
+
+      // The seeded timestamp (2025-06-15) should be applied to the rendered participant,
+      // showing a time much older than "less than a minute ago"
+      await waitFor(() => {
+        const joinedText = screen.getByText(/Joined/);
+        expect(joinedText.textContent).not.toContain('less than a minute');
       });
     });
   });

--- a/frontend/src/__tests__/components/VoiceChannelUserList.test.tsx
+++ b/frontend/src/__tests__/components/VoiceChannelUserList.test.tsx
@@ -37,6 +37,29 @@ vi.mock('livekit-client', () => ({
   },
 }));
 
+// Mock SDK for voice presence seed
+const mockGetChannelPresence = vi.fn().mockResolvedValue({
+  data: {
+    channelId: 'voice-ch-1',
+    users: [
+      {
+        id: 'user-1',
+        username: 'alice',
+        displayName: 'Alice',
+        avatarUrl: null,
+        joinedAt: '2025-06-15T10:00:00Z',
+        isDeafened: false,
+        isServerMuted: false,
+      },
+    ],
+    count: 1,
+  },
+});
+
+vi.mock('../../api-client/sdk.gen', () => ({
+  voicePresenceControllerGetChannelPresence: (...args: unknown[]) => mockGetChannelPresence(...args),
+}));
+
 // Mock getUserInfo
 vi.mock('../../features/users/userApiHelpers', () => ({
   getUserInfo: vi.fn().mockResolvedValue({ avatarUrl: null }),
@@ -251,6 +274,22 @@ describe('VoiceChannelUserList - Clickable Icons', () => {
 
       expect(mockWatchScreenShare).toHaveBeenCalledWith('user-1');
       expect(mockSetShowVideoTiles).toHaveBeenCalledWith(true);
+    });
+
+    it('seeds joinedAt timestamps from the backend REST API', async () => {
+      renderWithProviders(
+        <VoiceChannelUserList channel={voiceChannel} showCompact />,
+      );
+
+      await screen.findByTestId('VideocamIcon');
+
+      await waitFor(() => {
+        expect(mockGetChannelPresence).toHaveBeenCalledWith(
+          expect.objectContaining({
+            path: { channelId: 'voice-ch-1' },
+          }),
+        );
+      });
     });
   });
 

--- a/frontend/src/components/Voice/VoiceChannelUserList.tsx
+++ b/frontend/src/components/Voice/VoiceChannelUserList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   Box,
   Typography,
@@ -9,6 +9,7 @@ import {
 import { useTheme } from "@mui/material/styles";
 import { useQuery } from "@tanstack/react-query";
 import { voicePresenceControllerGetChannelPresenceOptions } from "../../api-client/@tanstack/react-query.gen";
+import { voicePresenceControllerGetChannelPresence } from "../../api-client/sdk.gen";
 import type { VoicePresenceUserDto } from "../../api-client/types.gen";
 import { ChannelType, type Channel } from "../../types/channel.type";
 import { useVoiceConnection } from "../../hooks/useVoiceConnection";
@@ -42,6 +43,7 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
   const { watchingCameras, watchingScreenShares } = useVoice();
   const trackActions = useTrackSubscriptionActions();
   const [livekitParticipants, setLivekitParticipants] = useState<VoicePresenceUserDto[]>([]);
+  const joinedAtCacheRef = useRef<Map<string, string>>(new Map());
   const { openProfile } = useUserProfile();
   const [contextMenu, setContextMenu] = useState<{
     position: { top: number; left: number } | null;
@@ -59,6 +61,32 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
 
   // Check if we're connected to this specific channel
   const isConnectedToThisChannel = voiceState.currentChannelId === channel.id && voiceState.isConnected;
+
+  // Seed joinedAt cache from backend when first connecting
+  useEffect(() => {
+    if (!isConnectedToThisChannel) {
+      joinedAtCacheRef.current.clear();
+      return;
+    }
+
+    const abortController = new AbortController();
+    voicePresenceControllerGetChannelPresence({
+      path: { channelId: channel.id },
+      signal: abortController.signal,
+    }).then((response) => {
+      if (abortController.signal.aborted) return;
+      const data = response.data;
+      if (data?.users) {
+        for (const user of data.users) {
+          if (!joinedAtCacheRef.current.has(user.id)) {
+            joinedAtCacheRef.current.set(user.id, user.joinedAt);
+          }
+        }
+      }
+    }).catch(() => { /* ignore — fallback to new Date() is acceptable */ });
+
+    return () => abortController.abort();
+  }, [isConnectedToThisChannel, channel.id]);
 
   // Use backend presence query only when NOT connected to this channel
   // (for viewing other voice channels we're not in)
@@ -122,7 +150,7 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
         username: p.name || p.identity,
         displayName: p.name || undefined,
         avatarUrl: userInfos[i]?.avatarUrl ?? undefined,
-        joinedAt: new Date().toISOString(),
+        joinedAt: joinedAtCacheRef.current.get(p.identity) || new Date().toISOString(),
         isDeafened: p.isDeafened,
       }));
 
@@ -167,6 +195,22 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
           : p,
       ),
     );
+  });
+
+  // Keep joinedAt cache in sync with new joins/leaves
+  useServerEvent(ServerEvents.VOICE_CHANNEL_USER_JOINED, (payload) => {
+    if (!isConnectedToThisChannel || payload.channelId !== channel.id) return;
+    if (payload.user?.joinedAt) {
+      const ts = typeof payload.user.joinedAt === 'string'
+        ? payload.user.joinedAt
+        : new Date(payload.user.joinedAt).toISOString();
+      joinedAtCacheRef.current.set(payload.user.id, ts);
+    }
+  });
+
+  useServerEvent(ServerEvents.VOICE_CHANNEL_USER_LEFT, (payload) => {
+    if (payload.channelId !== channel.id) return;
+    joinedAtCacheRef.current.delete(payload.userId);
   });
 
   // Determine which data source to use

--- a/frontend/src/components/Voice/VoiceChannelUserList.tsx
+++ b/frontend/src/components/Voice/VoiceChannelUserList.tsx
@@ -77,10 +77,27 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
       if (abortController.signal.aborted) return;
       const data = response.data;
       if (data?.users) {
+        let cacheUpdated = false;
         for (const user of data.users) {
           if (!joinedAtCacheRef.current.has(user.id)) {
             joinedAtCacheRef.current.set(user.id, user.joinedAt);
+            cacheUpdated = true;
           }
+        }
+
+        if (cacheUpdated) {
+          setLivekitParticipants((prev) => {
+            let changed = false;
+            const next = prev.map((p) => {
+              const joinedAt = joinedAtCacheRef.current.get(p.id);
+              if (joinedAt && p.joinedAt !== joinedAt) {
+                changed = true;
+                return { ...p, joinedAt };
+              }
+              return p;
+            });
+            return changed ? next : prev;
+          });
         }
       }
     }).catch(() => { /* ignore — fallback to new Date() is acceptable */ });


### PR DESCRIPTION
## Summary
- **#343**: Sort DM conversations by most recent message date (descending), falling back to `createdAt` for groups with no messages. Previously sorted by group creation date only.
- **#345**: Fix voice channel participants all showing "joined 1 minute ago" by caching real `joinedAt` timestamps from the REST API and WebSocket events instead of using `new Date()` on every LiveKit re-render.

## Changes
- **Backend**: In-memory sort of assembled DM response array by `lastMessage.sentAt` 
- **Frontend**: Added `joinedAt` cache ref seeded from `GET /channels/:id/voice-presence` on connect, kept in sync via `VOICE_CHANNEL_USER_JOINED`/`LEFT` WebSocket events

## Test plan
- [x] Backend unit test: DM groups sorted by most recent message first, falling back to createdAt
- [x] Frontend unit test: Voice presence REST API called to seed joinedAt cache when connected
- [x] Full backend test suite passes (32 DM tests, all suites green)
- [x] Full frontend test suite passes (1184 tests across 115 files)
- [x] Lint clean (0 errors) for both backend and frontend
- [x] E2E: Verified DM list reorders after sending a message in an older conversation

Closes #343, closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)