### PR TITLE
fix: live audio device switching + sensitivity UX (#346, #347)

### DIFF
--- a/frontend/src/__tests__/components/AudioVideoSettingsPanel.test.tsx
+++ b/frontend/src/__tests__/components/AudioVideoSettingsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import { renderWithProviders } from '../test-utils';
 
 // --- Mock hooks ---
@@ -50,6 +50,7 @@ let mockNoiseSuppression = true;
 let mockAutoGainControl = true;
 let mockVoiceIsolation = false;
 const mockSetAudioProcessing = vi.fn();
+const mockSetVoiceActivityThreshold = vi.fn();
 
 vi.mock('../../hooks/useVoiceSettings', () => ({
   useVoiceSettings: () => ({
@@ -62,7 +63,7 @@ vi.mock('../../hooks/useVoiceSettings', () => ({
     voiceIsolation: mockVoiceIsolation,
     setInputMode: vi.fn(),
     setPushToTalkKey: vi.fn(),
-    setVoiceActivityThreshold: vi.fn(),
+    setVoiceActivityThreshold: mockSetVoiceActivityThreshold,
     setAudioProcessing: mockSetAudioProcessing,
   }),
   VoiceInputMode: {},
@@ -155,6 +156,48 @@ describe('AudioVideoSettingsPanel — threshold preview', () => {
     renderWithProviders(<AudioVideoSettingsPanel />);
 
     expect(screen.getByText(/marker shows your sensitivity threshold/i)).toBeInTheDocument();
+  });
+
+  it('renders Input Sensitivity control inside the Test Microphone section', () => {
+    renderWithProviders(<AudioVideoSettingsPanel />);
+
+    const sensitivityLabel = screen.getByText('Input Sensitivity');
+    const testMicLabel = screen.getByText('Test Microphone');
+    // Both labels live inside the same Paper card.
+    expect(sensitivityLabel.closest('.MuiPaper-root')).toBe(
+      testMicLabel.closest('.MuiPaper-root')
+    );
+  });
+
+  it('hides the Input Sensitivity control in push_to_talk mode', () => {
+    mockInputMode = 'push_to_talk';
+
+    renderWithProviders(<AudioVideoSettingsPanel />);
+
+    expect(screen.queryByText('Input Sensitivity')).not.toBeInTheDocument();
+  });
+
+  it('calls setVoiceActivityThreshold when the Input Sensitivity slider moves', () => {
+    renderWithProviders(<AudioVideoSettingsPanel />);
+
+    const slider = screen.getByRole('slider', { name: /input sensitivity/i });
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+
+    expect(mockSetVoiceActivityThreshold).toHaveBeenCalled();
+    expect(mockSetVoiceActivityThreshold).toHaveBeenLastCalledWith(26);
+  });
+
+  it('threshold marker on the volume meter is keyboard-interactive and calls setVoiceActivityThreshold', () => {
+    mockTestingAudio = true;
+    mockRawAudioLevel = 30;
+
+    renderWithProviders(<AudioVideoSettingsPanel />);
+
+    const thresholdSlider = screen.getByRole('slider', { name: /voice activity threshold/i });
+    fireEvent.keyDown(thresholdSlider, { key: 'ArrowLeft' });
+
+    expect(mockSetVoiceActivityThreshold).toHaveBeenCalled();
+    expect(mockSetVoiceActivityThreshold).toHaveBeenLastCalledWith(24);
   });
 });
 

--- a/frontend/src/__tests__/components/VoiceSettings.test.tsx
+++ b/frontend/src/__tests__/components/VoiceSettings.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+const mocks = vi.hoisted(() => ({
+  switchAudioInputDevice: vi.fn(),
+  switchAudioOutputDevice: vi.fn(),
+  switchVideoInputDevice: vi.fn(),
+  loggerError: vi.fn(),
+  capturedOnDeviceChange: undefined as
+    | ((type: 'audio' | 'video' | 'audioOutput', deviceId: string) => void | Promise<void>)
+    | undefined,
+}));
+
+vi.mock('../../hooks/useVoiceConnection', () => ({
+  useVoiceConnection: () => ({
+    state: {},
+    actions: {
+      switchAudioInputDevice: mocks.switchAudioInputDevice,
+      switchAudioOutputDevice: mocks.switchAudioOutputDevice,
+      switchVideoInputDevice: mocks.switchVideoInputDevice,
+    },
+  }),
+}));
+
+// Stub panel so we can capture the onDeviceChange prop and call it directly.
+vi.mock('../../components/Settings/AudioVideoSettingsPanel', () => ({
+  default: (props: {
+    onDeviceChange?: (type: 'audio' | 'video' | 'audioOutput', deviceId: string) => void | Promise<void>;
+  }) => {
+    mocks.capturedOnDeviceChange = props.onDeviceChange;
+    return <div data-testid="audio-video-panel" />;
+  },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    error: mocks.loggerError,
+    info: vi.fn(),
+    warn: vi.fn(),
+    dev: vi.fn(),
+  },
+}));
+
+import VoiceSettings from '../../components/Settings/VoiceSettings';
+
+describe('VoiceSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.capturedOnDeviceChange = undefined;
+  });
+
+  it('passes an onDeviceChange callback to AudioVideoSettingsPanel', () => {
+    render(<VoiceSettings />);
+    expect(mocks.capturedOnDeviceChange).toBeInstanceOf(Function);
+  });
+
+  it('routes audio input device changes to switchAudioInputDevice', async () => {
+    render(<VoiceSettings />);
+    await mocks.capturedOnDeviceChange!('audio', 'mic-new');
+    expect(mocks.switchAudioInputDevice).toHaveBeenCalledWith('mic-new');
+    expect(mocks.switchAudioOutputDevice).not.toHaveBeenCalled();
+    expect(mocks.switchVideoInputDevice).not.toHaveBeenCalled();
+  });
+
+  it('routes audio output device changes to switchAudioOutputDevice', async () => {
+    render(<VoiceSettings />);
+    await mocks.capturedOnDeviceChange!('audioOutput', 'spk-new');
+    expect(mocks.switchAudioOutputDevice).toHaveBeenCalledWith('spk-new');
+    expect(mocks.switchAudioInputDevice).not.toHaveBeenCalled();
+    expect(mocks.switchVideoInputDevice).not.toHaveBeenCalled();
+  });
+
+  it('routes video input device changes to switchVideoInputDevice', async () => {
+    render(<VoiceSettings />);
+    await mocks.capturedOnDeviceChange!('video', 'cam-new');
+    expect(mocks.switchVideoInputDevice).toHaveBeenCalledWith('cam-new');
+    expect(mocks.switchAudioInputDevice).not.toHaveBeenCalled();
+    expect(mocks.switchAudioOutputDevice).not.toHaveBeenCalled();
+  });
+
+  it('logs and swallows errors from the underlying action', async () => {
+    mocks.switchAudioInputDevice.mockRejectedValueOnce(new Error('boom'));
+    render(<VoiceSettings />);
+    await expect(mocks.capturedOnDeviceChange!('audio', 'mic-bad')).resolves.toBeUndefined();
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to switch audio device'),
+      expect.any(Error)
+    );
+  });
+});

--- a/frontend/src/components/Settings/AudioVideoSettingsPanel.tsx
+++ b/frontend/src/components/Settings/AudioVideoSettingsPanel.tsx
@@ -222,32 +222,6 @@ const AudioVideoSettingsPanel: React.FC<AudioVideoSettingsPanelProps> = ({
         </Typography>
       </Box>
 
-      {/* Input Sensitivity (only shown when voice_activity mode is selected) */}
-      {inputMode === 'voice_activity' && (
-        <Box sx={{ mb: 3 }}>
-          <Typography variant="subtitle2" gutterBottom>
-            Input Sensitivity
-          </Typography>
-          <Slider
-            value={voiceActivityThreshold}
-            onChange={(_, val) => setVoiceActivityThreshold(val as number)}
-            min={0}
-            max={100}
-            marks={[
-              { value: 0, label: 'High' },
-              { value: 50, label: 'Medium' },
-              { value: 100, label: 'Low' },
-            ]}
-            valueLabelDisplay="auto"
-            valueLabelFormat={(v) => `Sensitivity: ${100 - v}%`}
-            size="small"
-          />
-          <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
-            Move the slider left for higher sensitivity (picks up quieter sounds), right for lower sensitivity.
-          </Typography>
-        </Box>
-      )}
-
       {/* Push to Talk Key (only shown when PTT mode is selected) */}
       {inputMode === 'push_to_talk' && (
         <Box sx={{ mb: 3 }}>
@@ -445,6 +419,31 @@ const AudioVideoSettingsPanel: React.FC<AudioVideoSettingsPanelProps> = ({
             {testingAudio ? 'Stop' : 'Test'}
           </Button>
         </Box>
+        {inputMode === 'voice_activity' && (
+          <Box sx={{ mt: 2 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+              Input Sensitivity
+            </Typography>
+            <Slider
+              value={voiceActivityThreshold}
+              onChange={(_, val) => setVoiceActivityThreshold(val as number)}
+              min={0}
+              max={100}
+              marks={[
+                { value: 0, label: 'High' },
+                { value: 50, label: 'Medium' },
+                { value: 100, label: 'Low' },
+              ]}
+              valueLabelDisplay="auto"
+              valueLabelFormat={(v) => `Sensitivity: ${100 - v}%`}
+              size="small"
+              aria-label="Input sensitivity"
+            />
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+              Drag the slider — or the marker on the meter below — to set the threshold.
+            </Typography>
+          </Box>
+        )}
         {testingAudio && (
           <Box sx={{ mt: 2 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
@@ -465,7 +464,7 @@ const AudioVideoSettingsPanel: React.FC<AudioVideoSettingsPanelProps> = ({
                 </Typography>
               )}
             </Box>
-            <Box sx={{ position: 'relative' }}>
+            <Box sx={{ position: 'relative', height: 8 }}>
               <LinearProgress
                 variant="determinate"
                 value={inputMode === 'voice_activity' ? rawAudioLevel : audioLevel}
@@ -481,18 +480,32 @@ const AudioVideoSettingsPanel: React.FC<AudioVideoSettingsPanelProps> = ({
                 }}
               />
               {inputMode === 'voice_activity' && (
-                <Box
+                <Slider
                   data-testid="threshold-marker"
+                  value={voiceActivityThreshold}
+                  onChange={(_, val) => setVoiceActivityThreshold(val as number)}
+                  min={0}
+                  max={100}
+                  size="small"
+                  aria-label="Voice activity threshold"
+                  valueLabelDisplay="auto"
+                  valueLabelFormat={(v) => `Sensitivity: ${100 - v}%`}
                   sx={{
                     position: 'absolute',
-                    // Marker position matches the raw-scale progress bar.
-                    left: `${voiceActivityThreshold}%`,
-                    top: -2,
-                    bottom: -2,
-                    width: 2,
-                    backgroundColor: 'warning.main',
-                    borderRadius: 1,
-                    pointerEvents: 'none',
+                    inset: 0,
+                    padding: 0,
+                    height: 8,
+                    '& .MuiSlider-rail': { opacity: 0 },
+                    '& .MuiSlider-track': { display: 'none' },
+                    '& .MuiSlider-thumb': {
+                      width: 4,
+                      height: 16,
+                      borderRadius: 1,
+                      backgroundColor: 'warning.main',
+                      boxShadow: 'none',
+                      '&:hover, &.Mui-focusVisible, &.Mui-active': { boxShadow: 'none' },
+                      '&::before, &::after': { display: 'none' },
+                    },
                   }}
                 />
               )}

--- a/frontend/src/components/Settings/VoiceSettings.tsx
+++ b/frontend/src/components/Settings/VoiceSettings.tsx
@@ -1,13 +1,36 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Card, CardContent } from '@mui/material';
 import AudioVideoSettingsPanel from './AudioVideoSettingsPanel';
+import { useVoiceConnection } from '../../hooks/useVoiceConnection';
+import { logger } from '../../utils/logger';
 
-const VoiceSettings: React.FC = () => (
-  <Card sx={{ mb: 3 }}>
-    <CardContent>
-      <AudioVideoSettingsPanel />
-    </CardContent>
-  </Card>
-);
+const VoiceSettings: React.FC = () => {
+  const { actions } = useVoiceConnection();
+
+  const handleDeviceChange = useCallback(
+    async (type: 'audio' | 'video' | 'audioOutput', deviceId: string) => {
+      try {
+        if (type === 'audio') {
+          await actions.switchAudioInputDevice(deviceId);
+        } else if (type === 'audioOutput') {
+          await actions.switchAudioOutputDevice(deviceId);
+        } else {
+          await actions.switchVideoInputDevice(deviceId);
+        }
+      } catch (error) {
+        logger.error(`Failed to switch ${type} device:`, error);
+      }
+    },
+    [actions]
+  );
+
+  return (
+    <Card sx={{ mb: 3 }}>
+      <CardContent>
+        <AudioVideoSettingsPanel onDeviceChange={handleDeviceChange} />
+      </CardContent>
+    </Card>
+  );
+};
 
 export default VoiceSettings;


### PR DESCRIPTION
## Summary

Fixes two voice-settings issues reported against the **Settings → Voice & Video** panel:

- **#346** — Changing the microphone / speaker / camera in the Settings page updated the saved preference but the active LiveKit track kept using the old device. `VoiceSettings.tsx` was rendering `AudioVideoSettingsPanel` without the `onDeviceChange` prop, so device picks never reached LiveKit. Now wired to `useVoiceConnection().actions.switch{Audio,AudioOutput,Video}Device` (same callback the in-call `DeviceSettingsDialog` already uses). The switch actions early-return when no room is connected, so it's a safe no-op when not in a call.
- **#347** — Input Sensitivity slider was in a separate section from the Test Microphone bar, and the threshold marker on the volume meter was a static decorative div (`pointerEvents: 'none'`). Moved the slider into the Test Microphone card and replaced the static marker with a transparent-rail MUI `Slider` overlay on the `LinearProgress` so the threshold is now click/drag/keyboard operable directly on the meter. Both controls bind to the same `voiceActivityThreshold`, so they move in sync.

## Files changed

- `frontend/src/components/Settings/VoiceSettings.tsx` — wires `onDeviceChange` to voice actions
- `frontend/src/components/Settings/AudioVideoSettingsPanel.tsx` — relocates sensitivity slider, replaces static threshold marker with interactive `Slider` overlay
- `frontend/src/__tests__/components/AudioVideoSettingsPanel.test.tsx` — new coverage for relocation and slider interactivity
- `frontend/src/__tests__/components/VoiceSettings.test.tsx` *(new)* — verifies device-change routing for audio/audioOutput/video plus error handling

## Test plan

- [x] `pnpm run test` (frontend) — 1193 tests across 116 files passing
- [x] `pnpm run lint` (frontend) — clean
- [x] `pnpm run type-check` (frontend) — clean
- [ ] Manual: join a voice channel, open Settings → Voice & Video, change mic — verify the LiveKit input switches live without rejoining
- [ ] Manual: repeat for speakers and camera
- [ ] Manual: in voice-activity mode, click "Test", drag the warning-colored thumb on the meter, verify the sensitivity slider above moves in sync and Transmitting/Gated state updates
- [ ] Manual: switch input mode to PTT and back — sensitivity slider hides/shows
- [ ] Manual: in-call device picker (`VoiceBottomBar` → settings → Device Settings) still works (no regression)

Closes #346
Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)