### PR TITLE
fix: resilient voice subscriptions + per-participant audio diagnostics

### DIFF
--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -12,6 +12,7 @@ import ProfileIcon from "./components/NavBar/ProfileIcon";
 import { VoiceBottomBar, AudioRenderer } from "./components/Voice";
 import { PersistentVideoOverlay } from "./components/Voice/PersistentVideoOverlay";
 import { TrackSubscriptionProvider } from "./components/Voice/TrackSubscriptionProvider";
+import { VoiceEventLogProvider } from "./hooks/useVoiceEventLog";
 import { useVoiceConnection } from "./hooks/useVoiceConnection";
 import { useVoiceRecovery } from "./hooks/useVoiceRecovery";
 import { MobileLayout } from "./components/Mobile/MobileLayout";
@@ -247,12 +248,14 @@ const Layout: React.FC = () => {
               appBarHeight={APPBAR_HEIGHT}
             />
             <TrackSubscriptionProvider>
-              <LayoutContentArea voiceConnected={voiceState.isConnected} isMenuExpanded={isMenuExpanded} />
+              <VoiceEventLogProvider>
+                <LayoutContentArea voiceConnected={voiceState.isConnected} isMenuExpanded={isMenuExpanded} />
 
-              {/* Voice Components */}
-              <VoiceBottomBar />
-              <AudioRenderer />
-              <PersistentVideoOverlay />
+                {/* Voice Components */}
+                <VoiceBottomBar />
+                <AudioRenderer />
+                <PersistentVideoOverlay />
+              </VoiceEventLogProvider>
             </TrackSubscriptionProvider>
           </VideoOverlayProvider>
         </IncomingCallProvider>

--- a/frontend/src/__tests__/hooks/useTrackSubscription.test.ts
+++ b/frontend/src/__tests__/hooks/useTrackSubscription.test.ts
@@ -7,6 +7,9 @@ vi.mock('livekit-client', () => ({
     TrackPublished: 'trackPublished',
     TrackUnpublished: 'trackUnpublished',
     ParticipantConnected: 'participantConnected',
+    Reconnected: 'reconnected',
+    TrackSubscriptionStatusChanged: 'trackSubscriptionStatusChanged',
+    TrackSubscriptionFailed: 'trackSubscriptionFailed',
   },
   Track: {
     Source: {
@@ -328,8 +331,125 @@ describe('useTrackSubscription', () => {
     });
   });
 
+  describe('on Reconnected', () => {
+    it('re-applies subscription policy to all participants with force=true', () => {
+      // Pre-populate room with one participant whose mic is already subscribed
+      // (mirroring the steady-state right before a reconnect)
+      const micPub = createMockPublication('microphone');
+      micPub.isSubscribed = true;
+      micPub.subscriptionStatus = 'subscribed';
+      const participant = createMockParticipant('user-1', [micPub]);
+      mockRoom!.remoteParticipants.set('user-1', participant);
+
+      renderHook(() => useTrackSubscription());
+      // setSubscribed call from the initial mount
+      const initialCallCount = micPub.setSubscribed.mock.calls.length;
+
+      act(() => {
+        emitRoomEvent('reconnected');
+      });
+
+      // forceResubscribePublication toggles false→true to force a fresh signal,
+      // so we expect TWO additional setSubscribed calls after Reconnected.
+      const newCalls = micPub.setSubscribed.mock.calls.slice(initialCallCount);
+      expect(newCalls).toEqual([[false], [true]]);
+    });
+
+    it('force-resubscribes mics for multiple participants', () => {
+      const micA = createMockPublication('microphone');
+      micA.isSubscribed = true;
+      const micB = createMockPublication('microphone');
+      micB.isSubscribed = true;
+      mockRoom!.remoteParticipants.set('a', createMockParticipant('a', [micA]));
+      mockRoom!.remoteParticipants.set('b', createMockParticipant('b', [micB]));
+
+      renderHook(() => useTrackSubscription());
+      const aBefore = micA.setSubscribed.mock.calls.length;
+      const bBefore = micB.setSubscribed.mock.calls.length;
+
+      act(() => {
+        emitRoomEvent('reconnected');
+      });
+
+      expect(micA.setSubscribed.mock.calls.slice(aBefore)).toEqual([[false], [true]]);
+      expect(micB.setSubscribed.mock.calls.slice(bBefore)).toEqual([[false], [true]]);
+    });
+  });
+
+  describe('on TrackSubscriptionStatusChanged', () => {
+    it('forces re-subscribe when a mic transitions to unsubscribed', () => {
+      renderHook(() => useTrackSubscription());
+
+      const micPub = createMockPublication('microphone');
+      micPub.isSubscribed = false; // post-status-change state
+      const participant = createMockParticipant('user-1', [micPub]);
+
+      act(() => {
+        emitRoomEvent('trackSubscriptionStatusChanged', micPub, 'unsubscribed', participant);
+      });
+
+      // forceResubscribePublication: skips the false call (already false), then sets true
+      expect(micPub.setSubscribed).toHaveBeenCalledWith(true);
+    });
+
+    it('ignores non-mic publication status changes', () => {
+      renderHook(() => useTrackSubscription());
+
+      const camPub = createMockPublication('camera');
+      const participant = createMockParticipant('user-1', [camPub]);
+
+      act(() => {
+        emitRoomEvent('trackSubscriptionStatusChanged', camPub, 'unsubscribed', participant);
+      });
+
+      // No re-subscribe attempt for camera tracks via the status-changed path
+      expect(camPub.setSubscribed).not.toHaveBeenCalled();
+    });
+
+    it('ignores subscribed→subscribed (not a drop)', () => {
+      renderHook(() => useTrackSubscription());
+
+      const micPub = createMockPublication('microphone');
+      micPub.isSubscribed = true;
+      const participant = createMockParticipant('user-1', [micPub]);
+
+      act(() => {
+        emitRoomEvent('trackSubscriptionStatusChanged', micPub, 'subscribed', participant);
+      });
+
+      expect(micPub.setSubscribed).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('forceResubscribeMic action', () => {
+    it('toggles a subscribed mic false→true to issue a fresh subscribe', () => {
+      const micPub = createMockPublication('microphone');
+      micPub.isSubscribed = true;
+      const participant = createMockParticipant('user-1', [micPub]);
+      mockRoom!.remoteParticipants.set('user-1', participant);
+
+      const { result } = renderHook(() => useTrackSubscription());
+      const before = micPub.setSubscribed.mock.calls.length;
+
+      act(() => {
+        result.current.forceResubscribeMic('user-1');
+      });
+
+      expect(micPub.setSubscribed.mock.calls.slice(before)).toEqual([[false], [true]]);
+    });
+
+    it('does nothing when participant not found', () => {
+      const { result } = renderHook(() => useTrackSubscription());
+      expect(() => {
+        act(() => {
+          result.current.forceResubscribeMic('nonexistent');
+        });
+      }).not.toThrow();
+    });
+  });
+
   describe('cleanup', () => {
-    it('removes event listeners on unmount', () => {
+    it('removes all event listeners on unmount', () => {
       const { unmount } = renderHook(() => useTrackSubscription());
 
       unmount();
@@ -337,6 +457,9 @@ describe('useTrackSubscription', () => {
       expect(mockRoom!.off).toHaveBeenCalledWith('trackPublished', expect.any(Function));
       expect(mockRoom!.off).toHaveBeenCalledWith('trackUnpublished', expect.any(Function));
       expect(mockRoom!.off).toHaveBeenCalledWith('participantConnected', expect.any(Function));
+      expect(mockRoom!.off).toHaveBeenCalledWith('reconnected', expect.any(Function));
+      expect(mockRoom!.off).toHaveBeenCalledWith('trackSubscriptionStatusChanged', expect.any(Function));
+      expect(mockRoom!.off).toHaveBeenCalledWith('trackSubscriptionFailed', expect.any(Function));
     });
 
     it('does nothing when room is null', () => {
@@ -346,6 +469,7 @@ describe('useTrackSubscription', () => {
       // Should return actions without crashing
       expect(result.current.watchCamera).toBeDefined();
       expect(result.current.stopWatchingCamera).toBeDefined();
+      expect(result.current.forceResubscribeMic).toBeDefined();
     });
   });
 });

--- a/frontend/src/__tests__/hooks/useVoiceEventLog.test.tsx
+++ b/frontend/src/__tests__/hooks/useVoiceEventLog.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+
+// --- Mock livekit-client ---
+vi.mock('livekit-client', () => ({
+  RoomEvent: {
+    Reconnecting: 'reconnecting',
+    Reconnected: 'reconnected',
+    SignalConnected: 'signalConnected',
+    Disconnected: 'disconnected',
+    ConnectionStateChanged: 'connectionStateChanged',
+    ParticipantConnected: 'participantConnected',
+    ParticipantDisconnected: 'participantDisconnected',
+    TrackPublished: 'trackPublished',
+    TrackUnpublished: 'trackUnpublished',
+    TrackMuted: 'trackMuted',
+    TrackUnmuted: 'trackUnmuted',
+    TrackSubscribed: 'trackSubscribed',
+    TrackUnsubscribed: 'trackUnsubscribed',
+    TrackSubscriptionFailed: 'trackSubscriptionFailed',
+    TrackSubscriptionStatusChanged: 'trackSubscriptionStatusChanged',
+    ConnectionQualityChanged: 'connectionQualityChanged',
+  },
+  ConnectionQuality: {
+    Excellent: 'excellent',
+    Good: 'good',
+    Poor: 'poor',
+    Lost: 'lost',
+  },
+  Track: {
+    Source: {
+      Microphone: 'microphone',
+      Camera: 'camera',
+      ScreenShare: 'screen_share',
+      ScreenShareAudio: 'screen_share_audio',
+    },
+  },
+}));
+
+type Listener = (...args: unknown[]) => void;
+
+function createMockRoom() {
+  const handlers = new Map<string, Set<Listener>>();
+  return {
+    state: 'connected',
+    localParticipant: { identity: 'me' },
+    on: vi.fn((event: string, handler: Listener) => {
+      if (!handlers.has(event)) handlers.set(event, new Set());
+      handlers.get(event)!.add(handler);
+    }),
+    off: vi.fn((event: string, handler: Listener) => {
+      handlers.get(event)?.delete(handler);
+    }),
+    emit: (event: string, ...args: unknown[]) =>
+      handlers.get(event)?.forEach((h) => h(...args)),
+  };
+}
+
+let mockRoom: ReturnType<typeof createMockRoom> | null = null;
+
+vi.mock('../../hooks/useRoom', () => ({
+  useRoom: vi.fn(() => ({ room: mockRoom })),
+}));
+
+import { VoiceEventLogProvider } from '../../hooks/useVoiceEventLog';
+import { useVoiceEventLog } from '../../hooks/useVoiceEventLogDef';
+
+function wrapWithProvider({ children }: { children: React.ReactNode }) {
+  return <VoiceEventLogProvider>{children}</VoiceEventLogProvider>;
+}
+
+describe('useVoiceEventLog', () => {
+  beforeEach(() => {
+    mockRoom = createMockRoom();
+  });
+
+  it('returns null when used outside the provider', () => {
+    const { result } = renderHook(() => useVoiceEventLog());
+    expect(result.current).toBeNull();
+  });
+
+  it('records the initial "Room available" event when a room is present', () => {
+    const { result } = renderHook(() => useVoiceEventLog(), { wrapper: wrapWithProvider });
+    expect(result.current?.events.length).toBe(1);
+    expect(result.current?.events[0].message).toMatch(/Room available/);
+    expect(result.current?.events[0].category).toBe('connection');
+  });
+
+  it('appends a Reconnected entry when the room emits the event', () => {
+    const { result } = renderHook(() => useVoiceEventLog(), { wrapper: wrapWithProvider });
+    act(() => mockRoom!.emit('reconnected'));
+    const messages = result.current!.events.map((e) => e.message);
+    expect(messages.some((m) => m.includes('Reconnected'))).toBe(true);
+  });
+
+  it('logs participant connect/disconnect with severity', () => {
+    const { result } = renderHook(() => useVoiceEventLog(), { wrapper: wrapWithProvider });
+    const alice = { identity: 'alice', name: 'Alice', trackPublications: new Map() };
+    act(() => mockRoom!.emit('participantConnected', alice));
+    act(() => mockRoom!.emit('participantDisconnected', alice));
+
+    const events = result.current!.events;
+    expect(events.find((e) => e.message.includes('Alice connected'))?.severity).toBe('success');
+    expect(events.find((e) => e.message.includes('Alice disconnected'))?.severity).toBe('info');
+  });
+
+  it('logs track subscription failures as errors', () => {
+    const { result } = renderHook(() => useVoiceEventLog(), { wrapper: wrapWithProvider });
+    const alice = { identity: 'alice', name: 'Alice' };
+    act(() => mockRoom!.emit('trackSubscriptionFailed', 'sid-12345678', alice, 'codec_unsupported'));
+    const failed = result.current!.events.find((e) => e.message.includes('FAILED'));
+    expect(failed).toBeDefined();
+    expect(failed!.severity).toBe('error');
+  });
+
+  it('only logs mic transitions for trackSubscriptionStatusChanged', () => {
+    const { result } = renderHook(() => useVoiceEventLog(), { wrapper: wrapWithProvider });
+    const alice = { identity: 'alice', name: 'Alice' };
+    const camPub = { source: 'camera', trackSid: 'cam-sid' };
+    const micPub = { source: 'microphone', trackSid: 'mic-sid' };
+
+    act(() => {
+      mockRoom!.emit('trackSubscriptionStatusChanged', camPub, 'unsubscribed', alice);
+      mockRoom!.emit('trackSubscriptionStatusChanged', micPub, 'unsubscribed', alice);
+    });
+
+    const subscriptionEvents = result.current!.events.filter((e) => e.category === 'subscription');
+    expect(subscriptionEvents.length).toBe(1);
+    expect(subscriptionEvents[0].message).toContain('mic subscription → unsubscribed');
+    expect(subscriptionEvents[0].severity).toBe('error');
+  });
+
+  it('skips remote-participant quality changes that are excellent/good', () => {
+    const { result } = renderHook(() => useVoiceEventLog(), { wrapper: wrapWithProvider });
+    const alice = { identity: 'alice', name: 'Alice' };
+    act(() => mockRoom!.emit('connectionQualityChanged', 'excellent', alice));
+    act(() => mockRoom!.emit('connectionQualityChanged', 'good', alice));
+
+    const qualityEvents = result.current!.events.filter((e) => e.category === 'quality');
+    expect(qualityEvents.length).toBe(0);
+  });
+
+  it('records remote-participant Poor and Lost quality changes', () => {
+    const { result } = renderHook(() => useVoiceEventLog(), { wrapper: wrapWithProvider });
+    const alice = { identity: 'alice', name: 'Alice' };
+    act(() => mockRoom!.emit('connectionQualityChanged', 'poor', alice));
+    act(() => mockRoom!.emit('connectionQualityChanged', 'lost', alice));
+
+    const qualityEvents = result.current!.events.filter((e) => e.category === 'quality');
+    expect(qualityEvents.length).toBe(2);
+    expect(qualityEvents[0].severity).toBe('warn');
+    expect(qualityEvents[1].severity).toBe('error');
+  });
+
+  it('always records local-participant quality changes (any quality)', () => {
+    const { result } = renderHook(() => useVoiceEventLog(), { wrapper: wrapWithProvider });
+    const local = { identity: 'me' };
+    act(() => mockRoom!.emit('connectionQualityChanged', 'excellent', local));
+    const qualityEvents = result.current!.events.filter((e) => e.category === 'quality');
+    expect(qualityEvents.some((e) => e.message.includes('local quality'))).toBe(true);
+  });
+
+  it('clear() empties the event list', () => {
+    const { result } = renderHook(() => useVoiceEventLog(), { wrapper: wrapWithProvider });
+    act(() => mockRoom!.emit('reconnected'));
+    expect(result.current!.events.length).toBeGreaterThan(0);
+    act(() => result.current!.clear());
+    expect(result.current!.events.length).toBe(0);
+  });
+
+  it('caps the buffer at 250 entries (oldest dropped)', () => {
+    const { result } = renderHook(() => useVoiceEventLog(), { wrapper: wrapWithProvider });
+    const alice = { identity: 'alice', name: 'Alice', trackPublications: new Map() };
+    act(() => {
+      for (let i = 0; i < 300; i++) {
+        mockRoom!.emit('participantConnected', alice);
+      }
+    });
+    expect(result.current!.events.length).toBe(250);
+  });
+});

--- a/frontend/src/__tests__/hooks/useVoiceEventLog.test.tsx
+++ b/frontend/src/__tests__/hooks/useVoiceEventLog.test.tsx
@@ -169,6 +169,34 @@ describe('useVoiceEventLog', () => {
     expect(result.current!.events.length).toBe(0);
   });
 
+  it('resets the buffer when the room reference changes', () => {
+    const { result, rerender } = renderHook(() => useVoiceEventLog(), {
+      wrapper: wrapWithProvider,
+    });
+    act(() => mockRoom!.emit('reconnected'));
+    expect(result.current!.events.length).toBeGreaterThan(1);
+
+    // Swap to a brand-new room — simulates leaving and re-joining a channel.
+    mockRoom = createMockRoom();
+    rerender();
+
+    // Buffer should reset and contain only the new "Room available" entry.
+    expect(result.current!.events.length).toBe(1);
+    expect(result.current!.events[0].message).toMatch(/Room available/);
+  });
+
+  it('clears the buffer when the room becomes null', () => {
+    const { result, rerender } = renderHook(() => useVoiceEventLog(), {
+      wrapper: wrapWithProvider,
+    });
+    expect(result.current!.events.length).toBe(1);
+
+    mockRoom = null;
+    rerender();
+
+    expect(result.current!.events.length).toBe(0);
+  });
+
   it('caps the buffer at 250 entries (oldest dropped)', () => {
     const { result } = renderHook(() => useVoiceEventLog(), { wrapper: wrapWithProvider });
     const alice = { identity: 'alice', name: 'Alice', trackPublications: new Map() };

--- a/frontend/src/__tests__/integration/voiceLifecycle.test.tsx
+++ b/frontend/src/__tests__/integration/voiceLifecycle.test.tsx
@@ -1,0 +1,547 @@
+/**
+ * Voice lifecycle integration tests.
+ *
+ * The voice subsystem is composed of multiple cooperating hooks
+ * (useTrackSubscription, useDeafenEffect, useRemoteVolumeEffect) and a
+ * top-level renderer (AudioRenderer). Per-hook unit tests exist, but bugs in
+ * this area tend to live in the *interactions* between them — and the most
+ * painful symptom (asymmetric audio in 3-person voice calls) is exactly that
+ * kind of cross-hook bug.
+ *
+ * These tests exercise the whole stack against a fake LiveKit Room, asserting
+ * the externally-observable behaviour: did we tell the SFU to subscribe? did
+ * we attach the track to an <audio> element? did deafen mute the right tracks?
+ * did Reconnected re-issue subscription requests? They are intentionally
+ * loose about implementation detail and tight about the contract that
+ * downstream WebRTC behaviour depends on.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// --- Mock livekit-client BEFORE importing app code -------------------------
+//
+// We mirror the live enums and provide a `RemoteTrackPublication` class so
+// the duck-type check in useTrackSubscription works against our fakes.
+vi.mock('livekit-client', () => {
+  class RemoteTrackPublication {}
+  return {
+    RoomEvent: {
+      TrackPublished: 'trackPublished',
+      TrackUnpublished: 'trackUnpublished',
+      TrackSubscribed: 'trackSubscribed',
+      TrackUnsubscribed: 'trackUnsubscribed',
+      TrackMuted: 'trackMuted',
+      TrackUnmuted: 'trackUnmuted',
+      ParticipantConnected: 'participantConnected',
+      ParticipantDisconnected: 'participantDisconnected',
+      Reconnected: 'reconnected',
+      Reconnecting: 'reconnecting',
+      SignalConnected: 'signalConnected',
+      Disconnected: 'disconnected',
+      ConnectionQualityChanged: 'connectionQualityChanged',
+      TrackSubscriptionStatusChanged: 'trackSubscriptionStatusChanged',
+      TrackSubscriptionFailed: 'trackSubscriptionFailed',
+    },
+    Track: {
+      Source: {
+        Microphone: 'microphone',
+        Camera: 'camera',
+        ScreenShare: 'screen_share',
+        ScreenShareAudio: 'screen_share_audio',
+      },
+    },
+    RemoteTrackPublication,
+    ConnectionQuality: {
+      Excellent: 'excellent',
+      Good: 'good',
+      Poor: 'poor',
+      Lost: 'lost',
+    },
+  };
+});
+
+// Import AFTER the mock. These resolve the mocked module above.
+import { RoomEvent, Track } from 'livekit-client';
+import type { Room as LKRoom, RemoteParticipant as LKRemoteParticipant } from 'livekit-client';
+import { VoiceProvider } from '../../contexts/VoiceContext';
+import { RoomContext } from '../../contexts/RoomContextDef';
+import { TrackSubscriptionProvider } from '../../components/Voice/TrackSubscriptionProvider';
+import { useTrackSubscriptionActions } from '../../hooks/useTrackSubscription';
+import { AudioRenderer } from '../../components/Voice/AudioRenderer';
+import { useDeafenEffect } from '../../hooks/useDeafenEffect';
+import { useRemoteVolumeEffect } from '../../hooks/useRemoteVolumeEffect';
+import { useVoiceDispatch, VoiceActionType } from '../../contexts/VoiceContext';
+import { VOLUME_STORAGE_PREFIX } from '../../constants/voice';
+
+// =========================================================================
+// Fake LiveKit primitives
+// =========================================================================
+
+type Listener = (...args: unknown[]) => void;
+
+class FakeEmitter {
+  private listeners = new Map<string, Set<Listener>>();
+  on(event: string, l: Listener) {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(l);
+    return this;
+  }
+  off(event: string, l: Listener) {
+    this.listeners.get(event)?.delete(l);
+    return this;
+  }
+  emit(event: string, ...args: unknown[]) {
+    this.listeners.get(event)?.forEach((l) => l(...args));
+  }
+}
+
+interface FakeAudioTrack {
+  mediaStreamTrack: { enabled: boolean };
+  attach: ReturnType<typeof vi.fn>;
+  detach: ReturnType<typeof vi.fn>;
+  setVolume: ReturnType<typeof vi.fn>;
+  getVolume: ReturnType<typeof vi.fn>;
+  attachedElements: HTMLMediaElement[];
+}
+
+function createFakeAudioTrack(): FakeAudioTrack {
+  const attachedElements: HTMLMediaElement[] = [];
+  return {
+    mediaStreamTrack: { enabled: true },
+    attachedElements,
+    attach: vi.fn((el: HTMLMediaElement) => {
+      attachedElements.push(el);
+      return el;
+    }),
+    detach: vi.fn((el?: HTMLMediaElement) => {
+      if (el) {
+        const i = attachedElements.indexOf(el);
+        if (i >= 0) attachedElements.splice(i, 1);
+      }
+      return el;
+    }),
+    setVolume: vi.fn(),
+    getVolume: vi.fn(() => 1.0),
+  };
+}
+
+// Use a class so `instanceof RemoteTrackPublication` from the mock passes for
+// objects created via Object.create(prototype) when we extend it.
+import { RemoteTrackPublication as MockRTP } from 'livekit-client';
+
+class FakeRemoteTrackPublication extends MockRTP {
+  source: string;
+  trackSid: string;
+  kind: 'audio' | 'video';
+  isSubscribed: boolean;
+  subscriptionStatus: string;
+  isMuted: boolean;
+  track?: FakeAudioTrack;
+  setSubscribedSpy: ReturnType<typeof vi.fn>;
+
+  constructor(source: string, opts: { withTrack?: boolean; isMuted?: boolean } = {}) {
+    super();
+    this.source = source;
+    this.trackSid = `sid-${source}-${Math.random().toString(36).slice(2)}`;
+    this.kind =
+      source === Track.Source.Camera || source === Track.Source.ScreenShare ? 'video' : 'audio';
+    this.isSubscribed = false;
+    this.subscriptionStatus = 'unsubscribed';
+    this.isMuted = opts.isMuted ?? false;
+    if (opts.withTrack && this.kind === 'audio') {
+      this.track = createFakeAudioTrack();
+    }
+    this.setSubscribedSpy = vi.fn((subscribed: boolean) => {
+      this.isSubscribed = subscribed;
+      this.subscriptionStatus = subscribed ? 'subscribed' : 'unsubscribed';
+    });
+  }
+
+  setSubscribed(subscribed: boolean) {
+    this.setSubscribedSpy(subscribed);
+  }
+}
+
+class FakeRemoteParticipant extends FakeEmitter {
+  identity: string;
+  name: string;
+  isSpeaking = false;
+  connectionQuality = 'excellent';
+  trackPublications = new Map<string, FakeRemoteTrackPublication>();
+  audioTrackPublications = new Map<string, FakeRemoteTrackPublication>();
+
+  constructor(identity: string, name?: string) {
+    super();
+    this.identity = identity;
+    this.name = name ?? identity;
+  }
+
+  addPublication(pub: FakeRemoteTrackPublication) {
+    this.trackPublications.set(pub.trackSid, pub);
+    if (pub.kind === 'audio') {
+      this.audioTrackPublications.set(pub.trackSid, pub);
+    }
+  }
+}
+
+class FakeLocalParticipant extends FakeEmitter {
+  identity = 'local-user';
+  isSpeaking = false;
+  connectionQuality = 'excellent';
+  metadata = '';
+  isMicrophoneEnabled = true;
+  trackPublications = new Map<string, FakeRemoteTrackPublication>();
+  setMetadata = vi.fn(async (m: string) => {
+    this.metadata = m;
+  });
+  getTrackPublication = vi.fn(() => undefined);
+  getTrackPublications = vi.fn(() => Array.from(this.trackPublications.values()));
+  setMicrophoneEnabled = vi.fn(async () => {});
+}
+
+class FakeRoom extends FakeEmitter {
+  state = 'connected';
+  localParticipant = new FakeLocalParticipant();
+  remoteParticipants = new Map<string, FakeRemoteParticipant>();
+  numParticipants = 1;
+
+  addRemote(p: FakeRemoteParticipant) {
+    this.remoteParticipants.set(p.identity, p);
+    this.numParticipants = this.remoteParticipants.size + 1;
+  }
+}
+
+// =========================================================================
+// Test harness
+// =========================================================================
+
+/**
+ * Mounts the same provider stack the real app uses around a voice session, but
+ * with a hand-rolled RoomContext.Provider so we can swap in a FakeRoom without
+ * involving voiceActions/connectToLiveKitRoom.
+ *
+ * Crucially, this also calls useDeafenEffect + useRemoteVolumeEffect inside
+ * the provider tree so cross-hook interactions are exercised, not just the
+ * subscription hook in isolation.
+ */
+function VoiceFx({ deafened }: { deafened: boolean }) {
+  const { dispatch } = useVoiceDispatch();
+  // Sync the deafened prop into VoiceContext so useDeafenEffect picks it up.
+  useEffect(() => {
+    dispatch({ type: VoiceActionType.SetDeafened, payload: deafened });
+  }, [dispatch, deafened]);
+
+  useDeafenEffect();
+  useRemoteVolumeEffect();
+  return null;
+}
+
+interface HarnessProps {
+  room: FakeRoom;
+  deafened?: boolean;
+  onActions?: (actions: ReturnType<typeof useTrackSubscriptionActions>) => void;
+}
+
+function ActionsBridge({ onActions }: { onActions?: HarnessProps['onActions'] }) {
+  const actions = useTrackSubscriptionActions();
+  useEffect(() => {
+    onActions?.(actions);
+  }, [actions, onActions]);
+  return null;
+}
+
+function Harness({ room, deafened = false, onActions }: HarnessProps) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const roomCtx = {
+    room: room as unknown as LKRoom,
+    setRoom: () => {},
+    getRoom: () => room as unknown as LKRoom,
+  };
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <VoiceProvider>
+        <RoomContext.Provider value={roomCtx}>
+          <TrackSubscriptionProvider>
+            <VoiceFx deafened={deafened} />
+            <ActionsBridge onActions={onActions} />
+            <AudioRenderer />
+          </TrackSubscriptionProvider>
+        </RoomContext.Provider>
+      </VoiceProvider>
+    </QueryClientProvider>
+  );
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+describe('voice lifecycle (integration)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe('initial join with existing remote participant', () => {
+    it('subscribes to a remote mic that was already published when we joined', () => {
+      const room = new FakeRoom();
+      const remote = new FakeRemoteParticipant('alice');
+      const micPub = new FakeRemoteTrackPublication(Track.Source.Microphone);
+      remote.addPublication(micPub);
+      room.addRemote(remote);
+
+      render(<Harness room={room} />);
+
+      // The mount-time iteration should have asked the SFU to subscribe.
+      expect(micPub.setSubscribedSpy).toHaveBeenCalledWith(true);
+    });
+
+    it('attaches the audio track to a hidden <audio> element once it has data', () => {
+      const room = new FakeRoom();
+      const remote = new FakeRemoteParticipant('alice');
+      const micPub = new FakeRemoteTrackPublication(Track.Source.Microphone, { withTrack: true });
+      micPub.isSubscribed = true;
+      micPub.subscriptionStatus = 'subscribed';
+      remote.addPublication(micPub);
+      room.addRemote(remote);
+
+      render(<Harness room={room} />);
+
+      // Without a TrackSubscribed event the renderer's listener-based update
+      // won't fire, but the initial updateAudioTracks call on mount picks it
+      // up because publication.track is already populated.
+      expect(micPub.track!.attach).toHaveBeenCalledTimes(1);
+      expect(micPub.track!.attachedElements.length).toBe(1);
+    });
+
+    it('does NOT attach a track when the publication has no track yet (subscription in flight)', () => {
+      const room = new FakeRoom();
+      const remote = new FakeRemoteParticipant('alice');
+      const micPub = new FakeRemoteTrackPublication(Track.Source.Microphone);
+      // No withTrack: track is undefined until SFU starts forwarding.
+      remote.addPublication(micPub);
+      room.addRemote(remote);
+
+      const { container } = render(<Harness room={room} />);
+
+      // No <audio> element rendered yet — AudioRenderer waits for publication.track
+      expect(container.querySelector('audio')).toBeNull();
+    });
+  });
+
+  describe('mid-session participant joining', () => {
+    it('subscribes to a participant who connects after we joined', () => {
+      const room = new FakeRoom();
+      render(<Harness room={room} />);
+
+      const bob = new FakeRemoteParticipant('bob');
+      const micPub = new FakeRemoteTrackPublication(Track.Source.Microphone);
+      bob.addPublication(micPub);
+      room.addRemote(bob);
+
+      act(() => {
+        room.emit(RoomEvent.ParticipantConnected, bob);
+      });
+
+      expect(micPub.setSubscribedSpy).toHaveBeenCalledWith(true);
+    });
+
+    it('subscribes to a mic that gets published after the participant joined', () => {
+      const room = new FakeRoom();
+      const bob = new FakeRemoteParticipant('bob');
+      room.addRemote(bob);
+      render(<Harness room={room} />);
+
+      const micPub = new FakeRemoteTrackPublication(Track.Source.Microphone);
+      bob.addPublication(micPub);
+
+      act(() => {
+        room.emit(RoomEvent.TrackPublished, micPub, bob);
+      });
+
+      expect(micPub.setSubscribedSpy).toHaveBeenCalledWith(true);
+    });
+
+    it('attaches a remote audio element after a TrackSubscribed event', () => {
+      const room = new FakeRoom();
+      const bob = new FakeRemoteParticipant('bob');
+      room.addRemote(bob);
+      render(<Harness room={room} />);
+
+      const micPub = new FakeRemoteTrackPublication(Track.Source.Microphone, { withTrack: true });
+      micPub.isSubscribed = true;
+      micPub.subscriptionStatus = 'subscribed';
+      bob.addPublication(micPub);
+
+      act(() => {
+        room.emit(RoomEvent.TrackPublished, micPub, bob);
+        room.emit(RoomEvent.TrackSubscribed, micPub.track, micPub, bob);
+      });
+
+      expect(micPub.track!.attach).toHaveBeenCalled();
+      expect(micPub.track!.attachedElements.length).toBe(1);
+    });
+  });
+
+  describe('reconnection (the asymmetric-audio root cause)', () => {
+    it('force-resubscribes mics after a Reconnected event', () => {
+      const room = new FakeRoom();
+      const alice = new FakeRemoteParticipant('alice');
+      const bob = new FakeRemoteParticipant('bob');
+
+      const micA = new FakeRemoteTrackPublication(Track.Source.Microphone);
+      const micB = new FakeRemoteTrackPublication(Track.Source.Microphone);
+      // After mount the policy will mark these subscribed; mirror that state
+      // by setting isSubscribed=true to simulate the "stale state" the SFU
+      // forgets across a reconnect.
+      micA.isSubscribed = true;
+      micA.subscriptionStatus = 'subscribed';
+      micB.isSubscribed = true;
+      micB.subscriptionStatus = 'subscribed';
+      alice.addPublication(micA);
+      bob.addPublication(micB);
+      room.addRemote(alice);
+      room.addRemote(bob);
+
+      render(<Harness room={room} />);
+      const aBefore = micA.setSubscribedSpy.mock.calls.length;
+      const bBefore = micB.setSubscribedSpy.mock.calls.length;
+
+      act(() => {
+        room.emit(RoomEvent.Reconnected);
+      });
+
+      // Both participants get force-resubscribed via toggle false→true
+      expect(micA.setSubscribedSpy.mock.calls.slice(aBefore)).toEqual([[false], [true]]);
+      expect(micB.setSubscribedSpy.mock.calls.slice(bBefore)).toEqual([[false], [true]]);
+    });
+
+    it('self-heals when SFU drops a mic subscription mid-session', () => {
+      const room = new FakeRoom();
+      const alice = new FakeRemoteParticipant('alice');
+      const micPub = new FakeRemoteTrackPublication(Track.Source.Microphone);
+      alice.addPublication(micPub);
+      room.addRemote(alice);
+
+      render(<Harness room={room} />);
+
+      // Simulate SFU sending a status change that drops the subscription
+      micPub.isSubscribed = false;
+      micPub.subscriptionStatus = 'unsubscribed';
+
+      act(() => {
+        room.emit(RoomEvent.TrackSubscriptionStatusChanged, micPub, 'unsubscribed', alice);
+      });
+
+      // The hook should immediately re-issue setSubscribed(true)
+      expect(micPub.setSubscribedSpy).toHaveBeenLastCalledWith(true);
+    });
+  });
+
+  describe('deafen / undeafen', () => {
+    it('mutes all remote audio tracks (volume = 0) when deafened', () => {
+      const room = new FakeRoom();
+      const alice = new FakeRemoteParticipant('alice');
+      const micA = new FakeRemoteTrackPublication(Track.Source.Microphone, { withTrack: true });
+      micA.isSubscribed = true;
+      alice.addPublication(micA);
+
+      const bob = new FakeRemoteParticipant('bob');
+      const micB = new FakeRemoteTrackPublication(Track.Source.Microphone, { withTrack: true });
+      micB.isSubscribed = true;
+      bob.addPublication(micB);
+
+      room.addRemote(alice);
+      room.addRemote(bob);
+
+      const { rerender } = render(<Harness room={room} deafened={false} />);
+      // Reset spies to clear any volume calls fired during initial volume application
+      micA.track!.setVolume.mockClear();
+      micB.track!.setVolume.mockClear();
+
+      rerender(<Harness room={room} deafened={true} />);
+
+      expect(micA.track!.setVolume).toHaveBeenCalledWith(0);
+      expect(micB.track!.setVolume).toHaveBeenCalledWith(0);
+    });
+
+    it('restores per-user stored volumes from localStorage when undeafened', () => {
+      localStorage.setItem(`${VOLUME_STORAGE_PREFIX}alice`, '0.7');
+      localStorage.setItem(`${VOLUME_STORAGE_PREFIX}bob`, '1.0');
+
+      const room = new FakeRoom();
+      const alice = new FakeRemoteParticipant('alice');
+      const micA = new FakeRemoteTrackPublication(Track.Source.Microphone, { withTrack: true });
+      micA.isSubscribed = true;
+      alice.addPublication(micA);
+
+      const bob = new FakeRemoteParticipant('bob');
+      const micB = new FakeRemoteTrackPublication(Track.Source.Microphone, { withTrack: true });
+      micB.isSubscribed = true;
+      bob.addPublication(micB);
+
+      room.addRemote(alice);
+      room.addRemote(bob);
+
+      const { rerender } = render(<Harness room={room} deafened={true} />);
+      micA.track!.setVolume.mockClear();
+      micB.track!.setVolume.mockClear();
+
+      rerender(<Harness room={room} deafened={false} />);
+
+      expect(micA.track!.setVolume).toHaveBeenCalledWith(0.7);
+      expect(micB.track!.setVolume).toHaveBeenCalledWith(1.0);
+    });
+  });
+
+  describe('manual recovery via debug action', () => {
+    it('forceResubscribeMic toggles the SDK state and re-issues subscribe', () => {
+      const room = new FakeRoom();
+      const alice = new FakeRemoteParticipant('alice');
+      const micPub = new FakeRemoteTrackPublication(Track.Source.Microphone);
+      micPub.isSubscribed = true;
+      micPub.subscriptionStatus = 'subscribed';
+      alice.addPublication(micPub);
+      room.addRemote(alice);
+
+      let captured: ReturnType<typeof useTrackSubscriptionActions> = null;
+      render(<Harness room={room} onActions={(a) => (captured = a)} />);
+
+      const before = micPub.setSubscribedSpy.mock.calls.length;
+      act(() => {
+        captured!.forceResubscribeMic('alice');
+      });
+
+      expect(micPub.setSubscribedSpy.mock.calls.slice(before)).toEqual([[false], [true]]);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('detaches audio tracks when a participant disconnects', () => {
+      const room = new FakeRoom();
+      const alice = new FakeRemoteParticipant('alice');
+      const micPub = new FakeRemoteTrackPublication(Track.Source.Microphone, { withTrack: true });
+      micPub.isSubscribed = true;
+      micPub.subscriptionStatus = 'subscribed';
+      alice.addPublication(micPub);
+      room.addRemote(alice);
+
+      render(<Harness room={room} />);
+      expect(micPub.track!.attach).toHaveBeenCalledTimes(1);
+
+      // Simulate participant leaving
+      room.remoteParticipants.delete('alice');
+      act(() => {
+        room.emit(RoomEvent.ParticipantDisconnected, alice as unknown as LKRemoteParticipant);
+      });
+
+      expect(micPub.track!.detach).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/__tests__/integration/voiceLifecycle.test.tsx
+++ b/frontend/src/__tests__/integration/voiceLifecycle.test.tsx
@@ -254,12 +254,20 @@ function ActionsBridge({ onActions }: { onActions?: HarnessProps['onActions'] })
 }
 
 function Harness({ room, deafened = false, onActions }: HarnessProps) {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  const roomCtx = {
-    room: room as unknown as LKRoom,
-    setRoom: () => {},
-    getRoom: () => room as unknown as LKRoom,
-  };
+  // Stable QueryClient + RoomContext value across rerenders so React Query
+  // state isn't reset and consumers don't see a flapping context value.
+  const queryClient = React.useMemo(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+    [],
+  );
+  const roomCtx = React.useMemo(
+    () => ({
+      room: room as unknown as LKRoom,
+      setRoom: () => {},
+      getRoom: () => room as unknown as LKRoom,
+    }),
+    [room],
+  );
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/frontend/src/components/Mobile/MobileLayout.tsx
+++ b/frontend/src/components/Mobile/MobileLayout.tsx
@@ -19,6 +19,7 @@ import { VoiceBottomBar } from '../Voice/VoiceBottomBar';
 import { AudioRenderer } from '../Voice/AudioRenderer';
 import { PersistentVideoOverlay } from '../Voice/PersistentVideoOverlay';
 import { TrackSubscriptionProvider } from '../Voice/TrackSubscriptionProvider';
+import { VoiceEventLogProvider } from '../../hooks/useVoiceEventLog';
 import { MobileNavigationProvider } from './Navigation/MobileNavigationContext';
 import { MobileBottomNavigation } from './Navigation/MobileBottomNavigation';
 import MobileCommunityDrawer from './Navigation/MobileCommunityDrawer';
@@ -57,28 +58,30 @@ export const MobileLayout: React.FC = () => {
         }}
       >
         <TrackSubscriptionProvider>
-          {/* Community drawer - swipe from left edge */}
-          <MobileCommunityDrawer />
+          <VoiceEventLogProvider>
+            {/* Community drawer - swipe from left edge */}
+            <MobileCommunityDrawer />
 
-          {/* Screen container - main content area */}
-          <Box
-            sx={{
-              flex: 1,
-              overflow: 'hidden',
-              position: 'relative',
-            }}
-          >
-            <MobileScreenContainer bottomOffset={voiceBarOffset} />
-          </Box>
+            {/* Screen container - main content area */}
+            <Box
+              sx={{
+                flex: 1,
+                overflow: 'hidden',
+                position: 'relative',
+              }}
+            >
+              <MobileScreenContainer bottomOffset={voiceBarOffset} />
+            </Box>
 
-          {/* Voice bar (only shows when in call) */}
-          {hasVoiceBar && <VoiceBottomBar />}
+            {/* Voice bar (only shows when in call) */}
+            {hasVoiceBar && <VoiceBottomBar />}
 
-          {/* Audio renderer for remote participants */}
-          <AudioRenderer />
+            {/* Audio renderer for remote participants */}
+            <AudioRenderer />
 
-          {/* Floating video overlay */}
-          <PersistentVideoOverlay />
+            {/* Floating video overlay */}
+            <PersistentVideoOverlay />
+          </VoiceEventLogProvider>
         </TrackSubscriptionProvider>
 
         {/* Bottom navigation - always visible */}

--- a/frontend/src/components/Mobile/Tablet/TabletLayout.tsx
+++ b/frontend/src/components/Mobile/Tablet/TabletLayout.tsx
@@ -14,6 +14,7 @@ import { VoiceBottomBar } from '../../Voice/VoiceBottomBar';
 import { AudioRenderer } from '../../Voice/AudioRenderer';
 import { PersistentVideoOverlay } from '../../Voice/PersistentVideoOverlay';
 import { TrackSubscriptionProvider } from '../../Voice/TrackSubscriptionProvider';
+import { VoiceEventLogProvider } from '../../../hooks/useVoiceEventLog';
 import { MobileNavigationProvider, useMobileNavigation } from '../Navigation/MobileNavigationContext';
 import { MobileBottomNavigation } from '../Navigation/MobileBottomNavigation';
 import MobileCommunityDrawer from '../Navigation/MobileCommunityDrawer';
@@ -58,33 +59,35 @@ const TabletLayoutInner: React.FC = () => {
 
       {/* Main content area */}
       <TrackSubscriptionProvider>
-        <Box
-          sx={{
-            flex: 1,
-            display: 'flex',
-            overflow: 'hidden',
-          }}
-        >
-          {/* Sidebar - channel list (only visible on home tab with community selected) */}
-          {showSidebar && state.communityId && (
-            <TabletSidebar communityId={state.communityId} />
-          )}
+        <VoiceEventLogProvider>
+          <Box
+            sx={{
+              flex: 1,
+              display: 'flex',
+              overflow: 'hidden',
+            }}
+          >
+            {/* Sidebar - channel list (only visible on home tab with community selected) */}
+            {showSidebar && state.communityId && (
+              <TabletSidebar communityId={state.communityId} />
+            )}
 
-          {/* Content area */}
-          <TabletContentArea
-            showSidebar={showSidebar && !!state.communityId}
-            bottomOffset={hasVoiceBar ? LAYOUT_CONSTANTS.VOICE_BAR_HEIGHT_MOBILE : 0}
-          />
-        </Box>
+            {/* Content area */}
+            <TabletContentArea
+              showSidebar={showSidebar && !!state.communityId}
+              bottomOffset={hasVoiceBar ? LAYOUT_CONSTANTS.VOICE_BAR_HEIGHT_MOBILE : 0}
+            />
+          </Box>
 
-        {/* Voice bar (only shows when in call) */}
-        {hasVoiceBar && <VoiceBottomBar />}
+          {/* Voice bar (only shows when in call) */}
+          {hasVoiceBar && <VoiceBottomBar />}
 
-        {/* Audio renderer for remote participants */}
-        <AudioRenderer />
+          {/* Audio renderer for remote participants */}
+          <AudioRenderer />
 
-        {/* Floating video overlay */}
-        <PersistentVideoOverlay />
+          {/* Floating video overlay */}
+          <PersistentVideoOverlay />
+        </VoiceEventLogProvider>
       </TrackSubscriptionProvider>
 
       {/* Bottom navigation - always visible */}

--- a/frontend/src/components/Voice/VoiceDebugPanel.tsx
+++ b/frontend/src/components/Voice/VoiceDebugPanel.tsx
@@ -1,25 +1,73 @@
-import React, { useEffect, useState } from 'react';
-import { Box, Paper, Typography, Chip, Divider } from '@mui/material';
-import { useTheme, alpha } from '@mui/material/styles';
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, Paper, Typography, Chip, Divider, Button, Stack, Tooltip } from '@mui/material';
+import { useTheme, alpha, type Theme } from '@mui/material/styles';
+import {
+  ConnectionQuality,
+  RemoteParticipant,
+  RemoteTrackPublication,
+  Track,
+  RoomEvent,
+} from 'livekit-client';
 import { useRoom } from '../../hooks/useRoom';
 import { useSpeakingDetection } from '../../hooks/useSpeakingDetection';
+import { useTrackSubscriptionActions } from '../../hooks/useTrackSubscription';
+import {
+  useVoiceEventLog,
+  type VoiceEventEntry,
+  type VoiceEventSeverity,
+} from '../../hooks/useVoiceEventLogDef';
 import { useQuery } from '@tanstack/react-query';
 import { userControllerGetProfileOptions } from '../../api-client/@tanstack/react-query.gen';
+import { VOLUME_STORAGE_PREFIX } from '../../constants/voice';
 
 /**
- * Debug panel to help diagnose voice and speaking detection issues
+ * Debug panel for diagnosing voice and remote-audio issues.
+ *
+ * Toggle with Ctrl+Shift+D while in a voice channel.
+ *
  * Shows:
- * - LiveKit room connection status
- * - Microphone track status
- * - Speaking detection state
- * - Audio levels
+ * - Room connection state and counts
+ * - Local participant: mic publish state, speaking detection, audio level
+ * - **Per-remote-participant audio diagnostics** — the part that helps users
+ *   pinpoint asymmetric audio: subscription state, track presence, attached
+ *   `<audio>` element count, current volume, and a manual "Force resubscribe"
+ *   button as a last-resort recovery action.
  */
 export const VoiceDebugPanel: React.FC = () => {
   const theme = useTheme();
   const { room } = useRoom();
   const { speakingMap, isSpeaking } = useSpeakingDetection();
+  const trackActions = useTrackSubscriptionActions();
   const { data: currentUser } = useQuery(userControllerGetProfileOptions());
   const [audioLevel, setAudioLevel] = useState(0);
+
+  // Force re-renders on relevant LiveKit events so per-participant chips stay
+  // current even when no React state update would otherwise fire.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    if (!room) return;
+    const refresh = () => setTick((t) => t + 1);
+    const events = [
+      RoomEvent.ParticipantConnected,
+      RoomEvent.ParticipantDisconnected,
+      RoomEvent.TrackPublished,
+      RoomEvent.TrackUnpublished,
+      RoomEvent.TrackSubscribed,
+      RoomEvent.TrackUnsubscribed,
+      RoomEvent.TrackMuted,
+      RoomEvent.TrackUnmuted,
+      RoomEvent.ConnectionQualityChanged,
+      RoomEvent.TrackSubscriptionStatusChanged,
+      RoomEvent.Reconnected,
+    ] as const;
+    events.forEach((e) => room.on(e, refresh));
+    // Also tick at 1Hz so derived fields like volume/attachedElements stay live.
+    const interval = setInterval(refresh, 1000);
+    return () => {
+      events.forEach((e) => room.off(e, refresh));
+      clearInterval(interval);
+    };
+  }, [room]);
 
   const isCurrentUserSpeaking = currentUser ? isSpeaking(currentUser.id) : false;
 
@@ -34,7 +82,6 @@ export const VoiceDebugPanel: React.FC = () => {
 
     if (!audioTrack?.track) return;
 
-    // Create audio context to monitor levels
     const audioContext = new AudioContext();
     const analyser = audioContext.createAnalyser();
     analyser.fftSize = 256;
@@ -78,7 +125,9 @@ export const VoiceDebugPanel: React.FC = () => {
           right: 16,
           p: 2,
           zIndex: 9999,
-          minWidth: 300,
+          minWidth: 320,
+          maxHeight: '85vh',
+          overflowY: 'auto',
           backgroundColor: alpha(theme.palette.background.paper, 0.95),
           color: theme.palette.text.primary,
         }}
@@ -93,13 +142,11 @@ export const VoiceDebugPanel: React.FC = () => {
   }
 
   const localParticipant = room.localParticipant;
-  const audioPublication = Array.from(localParticipant.trackPublications.values()).find(
+  const localAudioPub = Array.from(localParticipant.trackPublications.values()).find(
     (pub) => pub.kind === 'audio'
   );
 
-  const allSpeakingUsers = Array.from(speakingMap.entries())
-    .filter(([, speaking]) => speaking)
-    .map(([identity]) => identity);
+  const remoteParticipants = Array.from(room.remoteParticipants.values());
 
   return (
     <Paper
@@ -109,8 +156,10 @@ export const VoiceDebugPanel: React.FC = () => {
         right: 16,
         p: 2,
         zIndex: 9999,
-        minWidth: 300,
-        maxWidth: 400,
+        minWidth: 360,
+        maxWidth: 480,
+        maxHeight: '85vh',
+        overflowY: 'auto',
         backgroundColor: alpha(theme.palette.background.paper, 0.95),
         color: theme.palette.text.primary,
       }}
@@ -118,17 +167,20 @@ export const VoiceDebugPanel: React.FC = () => {
       <Typography variant="h6" gutterBottom>
         🔧 Voice Debug Panel
       </Typography>
+      <Typography variant="caption" sx={{ color: 'grey.500', display: 'block', mb: 1 }}>
+        Refresh tick: {tick} (auto-updates on events + 1s interval)
+      </Typography>
       <Divider sx={{ mb: 2, borderColor: 'grey.700' }} />
 
-      {/* Room Status */}
+      {/* ────────────── Room ────────────── */}
       <Box sx={{ mb: 2 }}>
         <Typography variant="caption" sx={{ color: 'grey.400' }}>
-          Room Status
+          Room
         </Typography>
         <Box sx={{ display: 'flex', gap: 1, mt: 0.5, flexWrap: 'wrap' }}>
           <Chip
-            label={`Connected: ${room.state}`}
-            color="success"
+            label={`State: ${room.state}`}
+            color={room.state === 'connected' ? 'success' : 'warning'}
             size="small"
           />
           <Chip
@@ -136,74 +188,54 @@ export const VoiceDebugPanel: React.FC = () => {
             color="info"
             size="small"
           />
-        </Box>
-      </Box>
-
-      {/* Audio Track Status */}
-      <Box sx={{ mb: 2 }}>
-        <Typography variant="caption" sx={{ color: 'grey.400' }}>
-          Microphone Track
-        </Typography>
-        <Box sx={{ display: 'flex', gap: 1, mt: 0.5, flexWrap: 'wrap' }}>
-          {audioPublication ? (
-            <>
-              <Chip
-                label={audioPublication.isMuted ? 'MUTED' : 'UNMUTED'}
-                color={audioPublication.isMuted ? 'error' : 'success'}
-                size="small"
-              />
-              <Chip
-                label={audioPublication.track ? 'Track Active' : 'No Track'}
-                color={audioPublication.track ? 'success' : 'error'}
-                size="small"
-              />
-            </>
-          ) : (
-            <Chip label="NO AUDIO TRACK" color="error" size="small" />
-          )}
-        </Box>
-      </Box>
-
-      {/* Speaking Detection */}
-      <Box sx={{ mb: 2 }}>
-        <Typography variant="caption" sx={{ color: 'grey.400' }}>
-          Speaking Detection
-        </Typography>
-        <Box sx={{ mt: 0.5 }}>
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 1,
-              mb: 1,
-            }}
-          >
-            <Box
-              sx={{
-                width: 16,
-                height: 16,
-                borderRadius: '50%',
-                backgroundColor: isCurrentUserSpeaking ? theme.palette.semantic.status.positive : theme.palette.action.disabled,
-                transition: 'background-color 0.2s',
-              }}
-            />
-            <Typography variant="body2">
-              {isCurrentUserSpeaking ? 'YOU ARE SPEAKING' : 'Not speaking'}
-            </Typography>
-          </Box>
           <Chip
-            label={`LiveKit isSpeaking: ${localParticipant.isSpeaking}`}
-            color={localParticipant.isSpeaking ? 'success' : 'default'}
+            label={`Local quality: ${localParticipant.connectionQuality}`}
+            color={qualityColor(localParticipant.connectionQuality)}
             size="small"
           />
         </Box>
       </Box>
 
-      {/* Audio Level Meter */}
-      {audioPublication && !audioPublication.isMuted && (
+      {/* ────────────── Local participant ────────────── */}
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="caption" sx={{ color: 'grey.400' }}>
+          Local Mic
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1, mt: 0.5, flexWrap: 'wrap' }}>
+          {localAudioPub ? (
+            <>
+              <Chip
+                label={localAudioPub.isMuted ? 'MUTED' : 'UNMUTED'}
+                color={localAudioPub.isMuted ? 'error' : 'success'}
+                size="small"
+              />
+              <Chip
+                label={localAudioPub.track ? 'Track Active' : 'No Track'}
+                color={localAudioPub.track ? 'success' : 'error'}
+                size="small"
+              />
+              <Chip
+                label={localParticipant.isSpeaking ? 'Speaking' : 'Silent'}
+                color={localParticipant.isSpeaking ? 'success' : 'default'}
+                size="small"
+              />
+              <Chip
+                label={isCurrentUserSpeaking ? 'Gate: open' : 'Gate: closed'}
+                color={isCurrentUserSpeaking ? 'success' : 'default'}
+                size="small"
+              />
+            </>
+          ) : (
+            <Chip label="NO MIC PUBLICATION" color="error" size="small" />
+          )}
+        </Box>
+      </Box>
+
+      {/* ────────────── Local audio level ────────────── */}
+      {localAudioPub && !localAudioPub.isMuted && (
         <Box sx={{ mb: 2 }}>
           <Typography variant="caption" sx={{ color: 'grey.400' }}>
-            Audio Level: {Math.round(audioLevel)}%
+            Mic Level: {Math.round(audioLevel)}%
           </Typography>
           <Box
             sx={{
@@ -228,43 +260,416 @@ export const VoiceDebugPanel: React.FC = () => {
         </Box>
       )}
 
-      {/* All Speaking Users */}
-      {allSpeakingUsers.length > 0 && (
-        <Box sx={{ mb: 2 }}>
-          <Typography variant="caption" sx={{ color: 'grey.400' }}>
-            Currently Speaking ({allSpeakingUsers.length})
-          </Typography>
-          <Box sx={{ mt: 0.5 }}>
-            {allSpeakingUsers.map((identity) => (
-              <Chip
-                key={identity}
-                label={identity === currentUser?.id ? 'YOU' : identity.slice(0, 8)}
-                color="success"
-                size="small"
-                sx={{ mr: 0.5, mb: 0.5 }}
-              />
-            ))}
-          </Box>
-        </Box>
+      <Divider sx={{ my: 2, borderColor: 'grey.700' }} />
+
+      {/* ────────────── Remote participants ────────────── */}
+      <Typography variant="subtitle2" sx={{ color: 'grey.300', mb: 1 }}>
+        Remote Participants ({remoteParticipants.length})
+      </Typography>
+      {remoteParticipants.length === 0 ? (
+        <Typography variant="caption" sx={{ color: 'grey.500' }}>
+          No other participants in the room.
+        </Typography>
+      ) : (
+        <Stack spacing={1.5}>
+          {remoteParticipants.map((p) => (
+            <RemoteParticipantDiagnostic
+              key={p.identity}
+              participant={p}
+              speaking={speakingMap.get(p.identity) ?? false}
+              onForceResubscribe={trackActions?.forceResubscribeMic}
+            />
+          ))}
+        </Stack>
       )}
 
-      {/* Instructions */}
-      <Box sx={{ mt: 2, pt: 2, borderTop: 1, borderColor: 'grey.700' }}>
-        <Typography variant="caption" sx={{ color: 'grey.400', display: 'block' }}>
-          <strong>How to test:</strong>
-        </Typography>
-        <Typography variant="caption" sx={{ color: 'grey.500', display: 'block', mt: 0.5 }}>
-          1. Check if "Microphone Track" shows UNMUTED
-          <br />
-          2. Speak - watch "Audio Level" bar move
-          <br />
-          3. If audio level moves but no speaking detection:
-          <br />
-          &nbsp;&nbsp;→ LiveKit threshold may be too high
-          <br />
-          4. Green dot appears when LiveKit detects speaking
-        </Typography>
-      </Box>
+      <Divider sx={{ my: 2, borderColor: 'grey.700' }} />
+
+      {/* ────────────── Live event log ────────────── */}
+      <EventLogSection />
+
+      <Divider sx={{ my: 2, borderColor: 'grey.700' }} />
+
+      <Typography variant="caption" sx={{ color: 'grey.500', display: 'block' }}>
+        <strong>Toggle:</strong> Ctrl+Shift+D
+      </Typography>
+      <Typography variant="caption" sx={{ color: 'grey.500', display: 'block', mt: 0.5 }}>
+        If a remote shows <strong>NOT SUBSCRIBED</strong>, <strong>NO TRACK</strong>, or
+        attached element count = 0, click <em>Force resubscribe</em> to re-issue the
+        subscription. If volume is 0, you may have muted them via the user context menu.
+      </Typography>
     </Paper>
   );
 };
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Newest-first scrollable feed of LiveKit room events. Sourced from
+ * VoiceEventLogProvider (mounted in Layout/MobileLayout/TabletLayout) so the
+ * log includes events that fired before the user opened the panel.
+ */
+const EventLogSection: React.FC = () => {
+  const theme = useTheme();
+  const log = useVoiceEventLog();
+  const [paused, setPaused] = useState(false);
+  // Snapshot the events when paused, so the rendered list freezes for inspection.
+  const snapshotRef = useRef<VoiceEventEntry[] | null>(null);
+
+  if (!log) {
+    return (
+      <Box>
+        <Typography variant="subtitle2" sx={{ color: 'grey.300', mb: 1 }}>
+          Event Log
+        </Typography>
+        <Typography variant="caption" sx={{ color: 'grey.500' }}>
+          (VoiceEventLogProvider not mounted — log unavailable)
+        </Typography>
+      </Box>
+    );
+  }
+
+  const displayEvents = paused
+    ? snapshotRef.current ?? log.events
+    : log.events;
+
+  // Newest-first: render in reverse without mutating the source array.
+  const ordered = [...displayEvents].reverse();
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          mb: 1,
+        }}
+      >
+        <Typography variant="subtitle2" sx={{ color: 'grey.300' }}>
+          Event Log ({log.events.length})
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 0.5 }}>
+          <Button
+            size="small"
+            variant="outlined"
+            color="inherit"
+            onClick={() => {
+              if (!paused) snapshotRef.current = log.events;
+              setPaused((p) => !p);
+            }}
+            sx={{ minWidth: 0, px: 1 }}
+          >
+            {paused ? 'Resume' : 'Pause'}
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            color="inherit"
+            onClick={() => {
+              log.clear();
+              snapshotRef.current = null;
+            }}
+            sx={{ minWidth: 0, px: 1 }}
+          >
+            Clear
+          </Button>
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          fontFamily: 'monospace',
+          fontSize: 11,
+          backgroundColor: 'grey.900',
+          color: 'grey.100',
+          borderRadius: 1,
+          maxHeight: 220,
+          overflowY: 'auto',
+          p: 0.75,
+          border: 1,
+          borderColor: 'grey.800',
+        }}
+      >
+        {ordered.length === 0 ? (
+          <Typography variant="caption" sx={{ color: 'grey.500' }}>
+            (no events yet — connection events will appear here)
+          </Typography>
+        ) : (
+          ordered.map((e) => (
+            <Box
+              key={e.id}
+              sx={{
+                py: 0.25,
+                color: severityColor(e.severity, theme),
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+              }}
+            >
+              <span style={{ color: theme.palette.grey[500] }}>
+                {formatTime(e.timestamp)}
+              </span>{' '}
+              <span style={{ color: theme.palette.grey[400] }}>
+                [{e.category}]
+              </span>{' '}
+              {e.message}
+            </Box>
+          ))
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+function severityColor(severity: VoiceEventSeverity, theme: Theme): string {
+  switch (severity) {
+    case 'success':
+      return theme.palette.success.light;
+    case 'warn':
+      return theme.palette.warning.light;
+    case 'error':
+      return theme.palette.error.light;
+    default:
+      return theme.palette.grey[200];
+  }
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  const ss = String(d.getSeconds()).padStart(2, '0');
+  const ms = String(d.getMilliseconds()).padStart(3, '0');
+  return `${hh}:${mm}:${ss}.${ms}`;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+interface RemoteParticipantDiagnosticProps {
+  participant: RemoteParticipant;
+  speaking: boolean;
+  onForceResubscribe?: (identity: string) => void;
+}
+
+const RemoteParticipantDiagnostic: React.FC<RemoteParticipantDiagnosticProps> = ({
+  participant,
+  speaking,
+  onForceResubscribe,
+}) => {
+  const theme = useTheme();
+
+  const micPub = findMicPublication(participant);
+  const summary = summarizeMicState(micPub);
+  const storedVolume = readStoredVolume(participant.identity);
+
+  const cardColor =
+    summary.severity === 'error'
+      ? alpha(theme.palette.error.main, 0.08)
+      : summary.severity === 'warn'
+      ? alpha(theme.palette.warning.main, 0.06)
+      : alpha(theme.palette.success.main, 0.06);
+
+  return (
+    <Box
+      sx={{
+        p: 1,
+        borderRadius: 1,
+        backgroundColor: cardColor,
+        border: 1,
+        borderColor:
+          summary.severity === 'error'
+            ? theme.palette.error.dark
+            : summary.severity === 'warn'
+            ? theme.palette.warning.dark
+            : 'grey.700',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
+        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+          {participant.name || participant.identity.slice(0, 12)}
+        </Typography>
+        <Chip
+          label={participant.connectionQuality}
+          color={qualityColor(participant.connectionQuality)}
+          size="small"
+        />
+      </Box>
+
+      <Typography variant="caption" sx={{ color: 'grey.500', display: 'block', mb: 0.75 }}>
+        identity: <code>{participant.identity}</code>
+      </Typography>
+
+      <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mb: 0.75 }}>
+        <Chip
+          label={micPub ? 'mic published' : 'NO MIC PUB'}
+          color={micPub ? 'success' : 'error'}
+          size="small"
+        />
+        {micPub && (
+          <>
+            <Tooltip title="livekit publication.subscriptionStatus">
+              <Chip
+                label={`sub: ${micPub.subscriptionStatus}`}
+                color={micPub.subscriptionStatus === 'subscribed' ? 'success' : 'error'}
+                size="small"
+              />
+            </Tooltip>
+            <Tooltip title="publication.track is set (data is flowing)">
+              <Chip
+                label={micPub.track ? 'track ✓' : 'track ✗'}
+                color={micPub.track ? 'success' : 'error'}
+                size="small"
+              />
+            </Tooltip>
+            <Tooltip title="publication.isMuted (sender muted their mic)">
+              <Chip
+                label={micPub.isMuted ? 'sender muted' : 'sender live'}
+                color={micPub.isMuted ? 'warning' : 'default'}
+                size="small"
+              />
+            </Tooltip>
+            <Chip
+              label={speaking ? 'speaking' : 'silent'}
+              color={speaking ? 'success' : 'default'}
+              size="small"
+            />
+            {micPub.track && (
+              <>
+                <Tooltip title="Number of <audio> elements this track is attached to">
+                  <Chip
+                    label={`attached: ${micPub.track.attachedElements?.length ?? 0}`}
+                    color={(micPub.track.attachedElements?.length ?? 0) > 0 ? 'success' : 'error'}
+                    size="small"
+                  />
+                </Tooltip>
+                <Tooltip title="Current playback volume on the audio track">
+                  <Chip
+                    label={`vol: ${formatVolume(getTrackVolume(micPub))}`}
+                    color={
+                      getTrackVolume(micPub) === 0
+                        ? 'error'
+                        : (getTrackVolume(micPub) ?? 1) < 0.05
+                        ? 'warning'
+                        : 'default'
+                    }
+                    size="small"
+                  />
+                </Tooltip>
+              </>
+            )}
+          </>
+        )}
+      </Box>
+
+      {storedVolume !== null && (
+        <Typography variant="caption" sx={{ color: 'grey.500', display: 'block' }}>
+          stored localStorage volume: {storedVolume.toFixed(2)}{' '}
+          {storedVolume === 0 && (
+            <span style={{ color: theme.palette.error.light }}>
+              (← user-muted via context menu)
+            </span>
+          )}
+        </Typography>
+      )}
+
+      <Box sx={{ mt: 0.75, display: 'flex', gap: 0.5, alignItems: 'center' }}>
+        <Chip
+          label={summary.label}
+          color={summary.severity === 'ok' ? 'success' : summary.severity === 'warn' ? 'warning' : 'error'}
+          size="small"
+          sx={{ flex: 1, justifyContent: 'flex-start' }}
+        />
+        {onForceResubscribe && (
+          <Button
+            size="small"
+            variant="outlined"
+            color="warning"
+            onClick={() => onForceResubscribe(participant.identity)}
+            disabled={!micPub}
+          >
+            Force resubscribe
+          </Button>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+
+function findMicPublication(participant: RemoteParticipant): RemoteTrackPublication | undefined {
+  for (const [, pub] of participant.trackPublications) {
+    if (pub.source === Track.Source.Microphone) return pub as RemoteTrackPublication;
+  }
+  return undefined;
+}
+
+interface MicSummary {
+  severity: 'ok' | 'warn' | 'error';
+  label: string;
+}
+
+function summarizeMicState(micPub: RemoteTrackPublication | undefined): MicSummary {
+  if (!micPub) {
+    return { severity: 'warn', label: 'No mic published — they may have joined muted' };
+  }
+  if (micPub.subscriptionStatus !== 'subscribed') {
+    return { severity: 'error', label: `Not subscribed (${micPub.subscriptionStatus}) — try Force resubscribe` };
+  }
+  if (!micPub.track) {
+    return { severity: 'error', label: 'Subscribed but no track yet — SFU not forwarding' };
+  }
+  const attached = micPub.track.attachedElements?.length ?? 0;
+  if (attached === 0) {
+    return { severity: 'error', label: 'Track present but not attached to any <audio> element' };
+  }
+  const volume = getTrackVolume(micPub);
+  if (volume === 0) {
+    return { severity: 'error', label: 'Track volume is 0 (deafened or muted-for-me)' };
+  }
+  if (micPub.isMuted) {
+    return { severity: 'ok', label: 'Healthy — sender is muted' };
+  }
+  return { severity: 'ok', label: 'Healthy' };
+}
+
+function getTrackVolume(pub: RemoteTrackPublication): number | undefined {
+  const track = pub.track as { getVolume?: () => number } | undefined;
+  if (!track || typeof track.getVolume !== 'function') return undefined;
+  try {
+    return track.getVolume();
+  } catch {
+    return undefined;
+  }
+}
+
+function formatVolume(v: number | undefined): string {
+  if (v === undefined) return 'n/a';
+  return v.toFixed(2);
+}
+
+function readStoredVolume(identity: string): number | null {
+  try {
+    const raw = localStorage.getItem(`${VOLUME_STORAGE_PREFIX}${identity}`);
+    if (raw === null) return null;
+    const parsed = parseFloat(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function qualityColor(q: ConnectionQuality): 'success' | 'warning' | 'error' | 'default' {
+  switch (q) {
+    case ConnectionQuality.Excellent:
+    case ConnectionQuality.Good:
+      return 'success';
+    case ConnectionQuality.Poor:
+      return 'warning';
+    case ConnectionQuality.Lost:
+      return 'error';
+    default:
+      return 'default';
+  }
+}

--- a/frontend/src/hooks/useTrackSubscription.ts
+++ b/frontend/src/hooks/useTrackSubscription.ts
@@ -4,10 +4,23 @@ import {
   Track,
   RemoteTrackPublication,
   RemoteParticipant,
+  type SubscriptionError,
 } from 'livekit-client';
 import { useRoom } from './useRoom';
 import { useVoiceDispatch, VoiceActionType } from '../contexts/VoiceContext';
 import { logger } from '../utils/logger';
+
+/**
+ * Duck-types a TrackPublication as a RemoteTrackPublication. Avoids relying on
+ * `instanceof RemoteTrackPublication`, which can false-fail when the same
+ * livekit-client module is loaded twice (HMR, dual bundles, jest mocks).
+ */
+function isRemotePublication(publication: unknown): publication is RemoteTrackPublication {
+  return (
+    !!publication &&
+    typeof (publication as RemoteTrackPublication).setSubscribed === 'function'
+  );
+}
 
 /**
  * Unsubscribes a remote track publication from the SFU (saves bandwidth).
@@ -34,24 +47,62 @@ function isOptInSource(source: Track.Source | string): boolean {
 }
 
 /**
- * Subscribes to a remote track publication.
+ * Subscribes a mic publication. Always issues the SDK call (no isSubscribed
+ * guard) so subscription state can self-heal after reconnects, where the
+ * client's view of `isSubscribed` may diverge from the SFU's session state.
+ *
+ * The SDK is internally idempotent, so redundant calls are cheap.
  */
 function subscribePublication(publication: RemoteTrackPublication, reason: string) {
-  if (!publication.isSubscribed) {
-    logger.info('[TrackSubscription] Subscribing', reason, publication.trackSid, publication.source);
-    publication.setSubscribed(true);
+  logger.info(
+    '[TrackSubscription] Subscribing',
+    reason,
+    publication.trackSid,
+    publication.source,
+    'wasSubscribed:',
+    publication.isSubscribed,
+  );
+  publication.setSubscribed(true);
+}
+
+/**
+ * Force a fresh subscription request even when the SDK believes the track is
+ * already subscribed. After a full reconnect, the SFU has a brand-new session
+ * and forgets prior subscriptions, but the client's local `isSubscribed` flag
+ * may still read true. Toggling false→true emits a fresh subscribe message.
+ */
+function forceResubscribePublication(publication: RemoteTrackPublication, reason: string) {
+  logger.info(
+    '[TrackSubscription] Force-resubscribing',
+    reason,
+    publication.trackSid,
+    publication.source,
+    'currentlySubscribed:',
+    publication.isSubscribed,
+  );
+  // Toggle to ensure the SDK emits a fresh subscriptionUpdateNeeded event.
+  if (publication.isSubscribed) {
+    publication.setSubscribed(false);
   }
+  publication.setSubscribed(true);
 }
 
 /**
  * Applies subscription policy to a participant: subscribe mic, unsubscribe opt-in sources.
  * Called on mount for existing participants and when new participants connect.
+ *
+ * When `force` is true (used after a full reconnect), mic subscriptions are
+ * re-issued even if the publication already reports `isSubscribed: true`.
  */
-function applySubscriptionPolicy(participant: RemoteParticipant) {
+function applySubscriptionPolicy(participant: RemoteParticipant, force = false) {
   for (const [, publication] of participant.trackPublications) {
-    if (!(publication instanceof RemoteTrackPublication)) continue;
+    if (!isRemotePublication(publication)) continue;
     if (publication.source === Track.Source.Microphone) {
-      subscribePublication(publication, `auto-subscribe-mic:${participant.identity}`);
+      if (force) {
+        forceResubscribePublication(publication, `reconnect-resubscribe-mic:${participant.identity}`);
+      } else {
+        subscribePublication(publication, `auto-subscribe-mic:${participant.identity}`);
+      }
     } else if (isOptInSource(publication.source)) {
       unsubscribePublication(publication, `initial-unsubscribe:${participant.identity}`);
     }
@@ -63,6 +114,12 @@ export interface TrackSubscriptionActions {
   stopWatchingCamera: (identity: string) => void;
   watchScreenShare: (identity: string) => void;
   stopWatchingScreenShare: (identity: string) => void;
+  /**
+   * Force-resubscribe to a participant's mic. Used as a manual recovery from
+   * the debug panel when audio asymmetry is suspected. Toggles the SDK's
+   * subscribed flag false→true so a fresh SUBSCRIBE message is sent to the SFU.
+   */
+  forceResubscribeMic: (identity: string) => void;
 }
 
 export const TrackSubscriptionContext = createContext<TrackSubscriptionActions | null>(null);
@@ -95,7 +152,7 @@ export function useTrackSubscription(): TrackSubscriptionActions {
       publication: RemoteTrackPublication,
       participant: RemoteParticipant,
     ) => {
-      if (!(publication instanceof RemoteTrackPublication)) return;
+      if (!isRemotePublication(publication)) return;
       logger.info('[TrackSubscription] TrackPublished', participant.identity, publication.source, publication.trackSid);
       if (publication.source === Track.Source.Microphone) {
         subscribePublication(publication, `published-mic:${participant.identity}`);
@@ -123,6 +180,45 @@ export function useTrackSubscription(): TrackSubscriptionActions {
       applySubscriptionPolicy(participant);
     };
 
+    // Re-apply subscription policy on full reconnect. The SFU has a fresh
+    // session after a reconnect and does not remember prior subscriptions; we
+    // must re-issue them. This is the most common cause of asymmetric audio
+    // (a single client's brief network blip silently drops mic subscriptions).
+    const handleReconnected = () => {
+      logger.info(
+        '[TrackSubscription] Reconnected — re-applying subscription policy to',
+        room.remoteParticipants.size,
+        'participants',
+      );
+      for (const [, participant] of room.remoteParticipants) {
+        applySubscriptionPolicy(participant, /* force */ true);
+      }
+    };
+
+    // Self-heal: if a mic subscription drops without us asking (e.g. SFU sends
+    // a subscription update during a partial reconnect), re-subscribe.
+    const handleSubscriptionStatusChanged = (
+      publication: RemoteTrackPublication,
+      status: string,
+      participant: RemoteParticipant,
+    ) => {
+      if (publication.source !== Track.Source.Microphone) return;
+      logger.info(
+        '[TrackSubscription] SubscriptionStatusChanged',
+        participant.identity,
+        publication.trackSid,
+        status,
+      );
+      if (status === 'unsubscribed') {
+        forceResubscribePublication(publication, `status-changed:${participant.identity}`);
+      }
+    };
+
+    // Surface subscription failures so we can see them in logs / debug panel.
+    const handleSubscriptionFailed = (trackSid: string, reason?: SubscriptionError) => {
+      logger.error('[TrackSubscription] Subscription failed', trackSid, reason);
+    };
+
     // Apply subscription policy to existing participants on mount
     logger.info('[TrackSubscription] Applying initial subscription policy to', room.remoteParticipants.size, 'participants');
     for (const [, participant] of room.remoteParticipants) {
@@ -132,11 +228,17 @@ export function useTrackSubscription(): TrackSubscriptionActions {
     room.on(RoomEvent.TrackPublished, handleTrackPublished);
     room.on(RoomEvent.TrackUnpublished, handleTrackUnpublished);
     room.on(RoomEvent.ParticipantConnected, handleParticipantConnected);
+    room.on(RoomEvent.Reconnected, handleReconnected);
+    room.on(RoomEvent.TrackSubscriptionStatusChanged, handleSubscriptionStatusChanged);
+    room.on(RoomEvent.TrackSubscriptionFailed, handleSubscriptionFailed);
 
     return () => {
       room.off(RoomEvent.TrackPublished, handleTrackPublished);
       room.off(RoomEvent.TrackUnpublished, handleTrackUnpublished);
       room.off(RoomEvent.ParticipantConnected, handleParticipantConnected);
+      room.off(RoomEvent.Reconnected, handleReconnected);
+      room.off(RoomEvent.TrackSubscriptionStatusChanged, handleSubscriptionStatusChanged);
+      room.off(RoomEvent.TrackSubscriptionFailed, handleSubscriptionFailed);
     };
   }, [room, dispatch]);
 
@@ -163,7 +265,7 @@ export function useTrackSubscription(): TrackSubscriptionActions {
       for (const [, publication] of participant.trackPublications) {
         if (
           sources.includes(publication.source as Track.Source) &&
-          publication instanceof RemoteTrackPublication
+          isRemotePublication(publication)
         ) {
           logger.info(
             '[TrackSubscription]',
@@ -219,5 +321,30 @@ export function useTrackSubscription(): TrackSubscriptionActions {
     [setSubscribedForSource, dispatch],
   );
 
-  return { watchCamera, stopWatchingCamera, watchScreenShare, stopWatchingScreenShare };
+  const forceResubscribeMic = useCallback(
+    (identity: string) => {
+      const participant = findParticipant(identity);
+      if (!participant) {
+        logger.warn('[TrackSubscription] forceResubscribeMic: participant not found:', identity);
+        return;
+      }
+      for (const [, publication] of participant.trackPublications) {
+        if (
+          publication.source === Track.Source.Microphone &&
+          isRemotePublication(publication)
+        ) {
+          forceResubscribePublication(publication, `manual-resubscribe:${identity}`);
+        }
+      }
+    },
+    [findParticipant],
+  );
+
+  return {
+    watchCamera,
+    stopWatchingCamera,
+    watchScreenShare,
+    stopWatchingScreenShare,
+    forceResubscribeMic,
+  };
 }

--- a/frontend/src/hooks/useTrackSubscription.ts
+++ b/frontend/src/hooks/useTrackSubscription.ts
@@ -215,8 +215,22 @@ export function useTrackSubscription(): TrackSubscriptionActions {
     };
 
     // Surface subscription failures so we can see them in logs / debug panel.
-    const handleSubscriptionFailed = (trackSid: string, reason?: SubscriptionError) => {
-      logger.error('[TrackSubscription] Subscription failed', trackSid, reason);
+    // The participant argument is essential for diagnosing asymmetric audio:
+    // it tells us *which* remote peer's mic we failed to subscribe to.
+    const handleSubscriptionFailed = (
+      trackSid: string,
+      participant: RemoteParticipant,
+      reason?: SubscriptionError,
+    ) => {
+      logger.error(
+        '[TrackSubscription] Subscription failed',
+        'participant:',
+        participant.identity,
+        'trackSid:',
+        trackSid,
+        'reason:',
+        reason,
+      );
     };
 
     // Apply subscription policy to existing participants on mount

--- a/frontend/src/hooks/useVoiceEventLog.tsx
+++ b/frontend/src/hooks/useVoiceEventLog.tsx
@@ -1,0 +1,229 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { RoomEvent, ConnectionQuality, Track } from 'livekit-client';
+import type {
+  RemoteParticipant,
+  RemoteTrackPublication,
+  Participant,
+  TrackPublication,
+  RemoteTrack,
+  SubscriptionError,
+  DisconnectReason,
+  ConnectionState,
+} from 'livekit-client';
+import { useRoom } from './useRoom';
+import {
+  VoiceEventLogContext,
+  type VoiceEventEntry,
+  type VoiceEventSeverity,
+} from './useVoiceEventLogDef';
+
+const MAX_EVENTS = 250;
+
+/**
+ * Subscribes to a room's lifecycle and subscription events whenever a Room is
+ * available, recording each one into a ring buffer. Mount this once per app
+ * (next to TrackSubscriptionProvider) so the log starts collecting immediately
+ * on voice join — not only when the debug panel is opened.
+ *
+ * Chatty/uninteresting events (active speakers, data packets, transcription)
+ * are intentionally filtered out to keep the log readable.
+ */
+export const VoiceEventLogProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { room } = useRoom();
+  const [events, setEvents] = useState<VoiceEventEntry[]>([]);
+  const idCounter = useRef(0);
+
+  const push = useCallback((entry: Omit<VoiceEventEntry, 'id' | 'timestamp'>) => {
+    setEvents((prev) => {
+      const next = prev.length >= MAX_EVENTS ? prev.slice(prev.length - MAX_EVENTS + 1) : prev.slice();
+      next.push({
+        ...entry,
+        id: idCounter.current++,
+        timestamp: Date.now(),
+      });
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(() => setEvents([]), []);
+
+  useEffect(() => {
+    if (!room) return;
+
+    push({ severity: 'success', category: 'connection', message: `Room available (state: ${room.state})` });
+
+    // ---------------- Connection lifecycle ----------------
+    const onReconnecting = () =>
+      push({ severity: 'warn', category: 'connection', message: 'Reconnecting…' });
+    const onReconnected = () =>
+      push({ severity: 'success', category: 'connection', message: 'Reconnected — re-subscribing to mics' });
+    const onSignalConnected = () =>
+      push({ severity: 'info', category: 'connection', message: 'Signal connected' });
+    const onDisconnected = (reason?: DisconnectReason) =>
+      push({
+        severity: 'error',
+        category: 'connection',
+        message: `Disconnected${reason !== undefined ? ` (reason: ${reason})` : ''}`,
+      });
+    const onConnectionStateChanged = (state: ConnectionState) =>
+      push({ severity: 'info', category: 'connection', message: `Connection state → ${state}` });
+
+    // ---------------- Participants ----------------
+    const onParticipantConnected = (p: RemoteParticipant) =>
+      push({
+        severity: 'success',
+        category: 'participant',
+        message: `${shortName(p)} connected (${p.trackPublications.size} tracks)`,
+      });
+    const onParticipantDisconnected = (p: RemoteParticipant) =>
+      push({
+        severity: 'info',
+        category: 'participant',
+        message: `${shortName(p)} disconnected`,
+      });
+
+    // ---------------- Tracks (publish/unpublish) ----------------
+    const onTrackPublished = (pub: RemoteTrackPublication, p: RemoteParticipant) =>
+      push({
+        severity: 'info',
+        category: 'track',
+        message: `${shortName(p)} published ${pub.source} (${pub.trackSid.slice(0, 8)}…)`,
+      });
+    const onTrackUnpublished = (pub: RemoteTrackPublication, p: RemoteParticipant) =>
+      push({
+        severity: 'info',
+        category: 'track',
+        message: `${shortName(p)} unpublished ${pub.source}`,
+      });
+    const onTrackMuted = (pub: TrackPublication, p: Participant) => {
+      // Only log mic mutes — video mute is noisy and less actionable here.
+      if (pub.source !== Track.Source.Microphone) return;
+      push({
+        severity: 'info',
+        category: 'track',
+        message: `${shortName(p)} muted mic`,
+      });
+    };
+    const onTrackUnmuted = (pub: TrackPublication, p: Participant) => {
+      if (pub.source !== Track.Source.Microphone) return;
+      push({
+        severity: 'info',
+        category: 'track',
+        message: `${shortName(p)} unmuted mic`,
+      });
+    };
+
+    // ---------------- Subscriptions (the asymmetric-audio signal) ----------------
+    const onTrackSubscribed = (
+      _track: RemoteTrack,
+      pub: RemoteTrackPublication,
+      p: RemoteParticipant,
+    ) =>
+      push({
+        severity: 'success',
+        category: 'subscription',
+        message: `subscribed to ${shortName(p)}'s ${pub.source}`,
+      });
+    const onTrackUnsubscribed = (
+      _track: RemoteTrack,
+      pub: RemoteTrackPublication,
+      p: RemoteParticipant,
+    ) =>
+      push({
+        severity: 'warn',
+        category: 'subscription',
+        message: `unsubscribed from ${shortName(p)}'s ${pub.source}`,
+      });
+    const onTrackSubscriptionFailed = (
+      trackSid: string,
+      p: RemoteParticipant,
+      reason?: SubscriptionError,
+    ) =>
+      push({
+        severity: 'error',
+        category: 'subscription',
+        message: `subscription FAILED for ${shortName(p)} (${trackSid.slice(0, 8)}…)${
+          reason !== undefined ? ` — ${reason}` : ''
+        }`,
+      });
+    const onTrackSubscriptionStatusChanged = (
+      pub: RemoteTrackPublication,
+      status: TrackPublication.SubscriptionStatus,
+      p: RemoteParticipant,
+    ) => {
+      // Only log mic transitions to keep noise down.
+      if (pub.source !== Track.Source.Microphone) return;
+      const severity: VoiceEventSeverity =
+        status === 'subscribed' ? 'success' : status === 'unsubscribed' ? 'error' : 'info';
+      push({
+        severity,
+        category: 'subscription',
+        message: `${shortName(p)} mic subscription → ${status}`,
+      });
+    };
+
+    // ---------------- Quality ----------------
+    // Always log local quality; for remotes, only log Poor/Lost transitions.
+    const onConnectionQualityChanged = (quality: ConnectionQuality, p: Participant) => {
+      const isLocal = p.identity === room.localParticipant.identity;
+      if (!isLocal && quality !== ConnectionQuality.Poor && quality !== ConnectionQuality.Lost) {
+        return;
+      }
+      const severity: VoiceEventSeverity =
+        quality === ConnectionQuality.Lost
+          ? 'error'
+          : quality === ConnectionQuality.Poor
+          ? 'warn'
+          : 'info';
+      push({
+        severity,
+        category: 'quality',
+        message: `${isLocal ? 'local' : shortName(p)} quality → ${quality}`,
+      });
+    };
+
+    room.on(RoomEvent.Reconnecting, onReconnecting);
+    room.on(RoomEvent.Reconnected, onReconnected);
+    room.on(RoomEvent.SignalConnected, onSignalConnected);
+    room.on(RoomEvent.Disconnected, onDisconnected);
+    room.on(RoomEvent.ConnectionStateChanged, onConnectionStateChanged);
+    room.on(RoomEvent.ParticipantConnected, onParticipantConnected);
+    room.on(RoomEvent.ParticipantDisconnected, onParticipantDisconnected);
+    room.on(RoomEvent.TrackPublished, onTrackPublished);
+    room.on(RoomEvent.TrackUnpublished, onTrackUnpublished);
+    room.on(RoomEvent.TrackMuted, onTrackMuted);
+    room.on(RoomEvent.TrackUnmuted, onTrackUnmuted);
+    room.on(RoomEvent.TrackSubscribed, onTrackSubscribed);
+    room.on(RoomEvent.TrackUnsubscribed, onTrackUnsubscribed);
+    room.on(RoomEvent.TrackSubscriptionFailed, onTrackSubscriptionFailed);
+    room.on(RoomEvent.TrackSubscriptionStatusChanged, onTrackSubscriptionStatusChanged);
+    room.on(RoomEvent.ConnectionQualityChanged, onConnectionQualityChanged);
+
+    return () => {
+      room.off(RoomEvent.Reconnecting, onReconnecting);
+      room.off(RoomEvent.Reconnected, onReconnected);
+      room.off(RoomEvent.SignalConnected, onSignalConnected);
+      room.off(RoomEvent.Disconnected, onDisconnected);
+      room.off(RoomEvent.ConnectionStateChanged, onConnectionStateChanged);
+      room.off(RoomEvent.ParticipantConnected, onParticipantConnected);
+      room.off(RoomEvent.ParticipantDisconnected, onParticipantDisconnected);
+      room.off(RoomEvent.TrackPublished, onTrackPublished);
+      room.off(RoomEvent.TrackUnpublished, onTrackUnpublished);
+      room.off(RoomEvent.TrackMuted, onTrackMuted);
+      room.off(RoomEvent.TrackUnmuted, onTrackUnmuted);
+      room.off(RoomEvent.TrackSubscribed, onTrackSubscribed);
+      room.off(RoomEvent.TrackUnsubscribed, onTrackUnsubscribed);
+      room.off(RoomEvent.TrackSubscriptionFailed, onTrackSubscriptionFailed);
+      room.off(RoomEvent.TrackSubscriptionStatusChanged, onTrackSubscriptionStatusChanged);
+      room.off(RoomEvent.ConnectionQualityChanged, onConnectionQualityChanged);
+    };
+  }, [room, push]);
+
+  const value = useMemo(() => ({ events, clear }), [events, clear]);
+
+  return <VoiceEventLogContext.Provider value={value}>{children}</VoiceEventLogContext.Provider>;
+};
+
+function shortName(p: { name?: string; identity: string }): string {
+  return p.name && p.name.length > 0 ? p.name : p.identity.slice(0, 8);
+}

--- a/frontend/src/hooks/useVoiceEventLog.tsx
+++ b/frontend/src/hooks/useVoiceEventLog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { RoomEvent, ConnectionQuality, Track } from 'livekit-client';
 import type {
   RemoteParticipant,
@@ -14,10 +14,50 @@ import { useRoom } from './useRoom';
 import {
   VoiceEventLogContext,
   type VoiceEventEntry,
+  type VoiceEventLogStore,
   type VoiceEventSeverity,
 } from './useVoiceEventLogDef';
 
 const MAX_EVENTS = 250;
+
+/**
+ * Creates a store that holds the event ring buffer outside React state.
+ * Writes don't trigger Provider re-renders; consumers update via
+ * useSyncExternalStore subscription.
+ */
+function createVoiceEventLogStore(): VoiceEventLogStore {
+  let events: VoiceEventEntry[] = [];
+  let idCounter = 0;
+  const listeners = new Set<() => void>();
+
+  const notify = () => listeners.forEach((l) => l());
+
+  return {
+    getSnapshot: () => events,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    push: (entry) => {
+      const next = events.length >= MAX_EVENTS ? events.slice(events.length - MAX_EVENTS + 1) : events.slice();
+      next.push({
+        ...entry,
+        id: idCounter++,
+        timestamp: Date.now(),
+      });
+      events = next;
+      notify();
+    },
+    clear: () => {
+      if (events.length === 0 && idCounter === 0) return;
+      events = [];
+      idCounter = 0;
+      notify();
+    },
+  };
+}
 
 /**
  * Subscribes to a room's lifecycle and subscription events whenever a Room is
@@ -25,58 +65,68 @@ const MAX_EVENTS = 250;
  * (next to TrackSubscriptionProvider) so the log starts collecting immediately
  * on voice join — not only when the debug panel is opened.
  *
+ * The buffer is reset whenever the underlying Room reference changes (e.g.
+ * the user leaves voice or joins a different channel) so events from prior
+ * sessions don't bleed into the next.
+ *
  * Chatty/uninteresting events (active speakers, data packets, transcription)
  * are intentionally filtered out to keep the log readable.
  */
 export const VoiceEventLogProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { room } = useRoom();
-  const [events, setEvents] = useState<VoiceEventEntry[]>([]);
-  const idCounter = useRef(0);
-
-  const push = useCallback((entry: Omit<VoiceEventEntry, 'id' | 'timestamp'>) => {
-    setEvents((prev) => {
-      const next = prev.length >= MAX_EVENTS ? prev.slice(prev.length - MAX_EVENTS + 1) : prev.slice();
-      next.push({
-        ...entry,
-        id: idCounter.current++,
-        timestamp: Date.now(),
-      });
-      return next;
-    });
-  }, []);
-
-  const clear = useCallback(() => setEvents([]), []);
+  const storeRef = useRef<VoiceEventLogStore | null>(null);
+  if (storeRef.current === null) {
+    storeRef.current = createVoiceEventLogStore();
+  }
+  const store = storeRef.current;
 
   useEffect(() => {
+    // Reset on room changes so the log only contains events for the current
+    // session. `null → Room` (joining), `Room → null` (leaving), and
+    // `RoomA → RoomB` (channel switch) all clear the buffer.
+    store.clear();
+
     if (!room) return;
 
-    push({ severity: 'success', category: 'connection', message: `Room available (state: ${room.state})` });
+    store.push({
+      severity: 'success',
+      category: 'connection',
+      message: `Room available (state: ${room.state})`,
+    });
 
     // ---------------- Connection lifecycle ----------------
     const onReconnecting = () =>
-      push({ severity: 'warn', category: 'connection', message: 'Reconnecting…' });
+      store.push({ severity: 'warn', category: 'connection', message: 'Reconnecting…' });
     const onReconnected = () =>
-      push({ severity: 'success', category: 'connection', message: 'Reconnected — re-subscribing to mics' });
+      store.push({
+        severity: 'success',
+        category: 'connection',
+        message: 'Reconnected — re-subscribing to mics',
+      });
     const onSignalConnected = () =>
-      push({ severity: 'info', category: 'connection', message: 'Signal connected' });
+      store.push({ severity: 'info', category: 'connection', message: 'Signal connected' });
     const onDisconnected = (reason?: DisconnectReason) =>
-      push({
+      store.push({
         severity: 'error',
         category: 'connection',
         message: `Disconnected${reason !== undefined ? ` (reason: ${reason})` : ''}`,
       });
     const onConnectionStateChanged = (state: ConnectionState) =>
-      push({ severity: 'info', category: 'connection', message: `Connection state → ${state}` });
+      store.push({
+        severity: 'info',
+        category: 'connection',
+        message: `Connection state → ${state}`,
+      });
 
     // ---------------- Participants ----------------
     const onParticipantConnected = (p: RemoteParticipant) =>
-      push({
+      store.push({
         severity: 'success',
         category: 'participant',
         message: `${shortName(p)} connected (${p.trackPublications.size} tracks)`,
       });
     const onParticipantDisconnected = (p: RemoteParticipant) =>
-      push({
+      store.push({
         severity: 'info',
         category: 'participant',
         message: `${shortName(p)} disconnected`,
@@ -84,13 +134,13 @@ export const VoiceEventLogProvider: React.FC<{ children: React.ReactNode }> = ({
 
     // ---------------- Tracks (publish/unpublish) ----------------
     const onTrackPublished = (pub: RemoteTrackPublication, p: RemoteParticipant) =>
-      push({
+      store.push({
         severity: 'info',
         category: 'track',
         message: `${shortName(p)} published ${pub.source} (${pub.trackSid.slice(0, 8)}…)`,
       });
     const onTrackUnpublished = (pub: RemoteTrackPublication, p: RemoteParticipant) =>
-      push({
+      store.push({
         severity: 'info',
         category: 'track',
         message: `${shortName(p)} unpublished ${pub.source}`,
@@ -98,19 +148,11 @@ export const VoiceEventLogProvider: React.FC<{ children: React.ReactNode }> = ({
     const onTrackMuted = (pub: TrackPublication, p: Participant) => {
       // Only log mic mutes — video mute is noisy and less actionable here.
       if (pub.source !== Track.Source.Microphone) return;
-      push({
-        severity: 'info',
-        category: 'track',
-        message: `${shortName(p)} muted mic`,
-      });
+      store.push({ severity: 'info', category: 'track', message: `${shortName(p)} muted mic` });
     };
     const onTrackUnmuted = (pub: TrackPublication, p: Participant) => {
       if (pub.source !== Track.Source.Microphone) return;
-      push({
-        severity: 'info',
-        category: 'track',
-        message: `${shortName(p)} unmuted mic`,
-      });
+      store.push({ severity: 'info', category: 'track', message: `${shortName(p)} unmuted mic` });
     };
 
     // ---------------- Subscriptions (the asymmetric-audio signal) ----------------
@@ -119,7 +161,7 @@ export const VoiceEventLogProvider: React.FC<{ children: React.ReactNode }> = ({
       pub: RemoteTrackPublication,
       p: RemoteParticipant,
     ) =>
-      push({
+      store.push({
         severity: 'success',
         category: 'subscription',
         message: `subscribed to ${shortName(p)}'s ${pub.source}`,
@@ -129,7 +171,7 @@ export const VoiceEventLogProvider: React.FC<{ children: React.ReactNode }> = ({
       pub: RemoteTrackPublication,
       p: RemoteParticipant,
     ) =>
-      push({
+      store.push({
         severity: 'warn',
         category: 'subscription',
         message: `unsubscribed from ${shortName(p)}'s ${pub.source}`,
@@ -139,7 +181,7 @@ export const VoiceEventLogProvider: React.FC<{ children: React.ReactNode }> = ({
       p: RemoteParticipant,
       reason?: SubscriptionError,
     ) =>
-      push({
+      store.push({
         severity: 'error',
         category: 'subscription',
         message: `subscription FAILED for ${shortName(p)} (${trackSid.slice(0, 8)}…)${
@@ -151,11 +193,10 @@ export const VoiceEventLogProvider: React.FC<{ children: React.ReactNode }> = ({
       status: TrackPublication.SubscriptionStatus,
       p: RemoteParticipant,
     ) => {
-      // Only log mic transitions to keep noise down.
       if (pub.source !== Track.Source.Microphone) return;
       const severity: VoiceEventSeverity =
         status === 'subscribed' ? 'success' : status === 'unsubscribed' ? 'error' : 'info';
-      push({
+      store.push({
         severity,
         category: 'subscription',
         message: `${shortName(p)} mic subscription → ${status}`,
@@ -175,7 +216,7 @@ export const VoiceEventLogProvider: React.FC<{ children: React.ReactNode }> = ({
           : quality === ConnectionQuality.Poor
           ? 'warn'
           : 'info';
-      push({
+      store.push({
         severity,
         category: 'quality',
         message: `${isLocal ? 'local' : shortName(p)} quality → ${quality}`,
@@ -217,11 +258,9 @@ export const VoiceEventLogProvider: React.FC<{ children: React.ReactNode }> = ({
       room.off(RoomEvent.TrackSubscriptionStatusChanged, onTrackSubscriptionStatusChanged);
       room.off(RoomEvent.ConnectionQualityChanged, onConnectionQualityChanged);
     };
-  }, [room, push]);
+  }, [room, store]);
 
-  const value = useMemo(() => ({ events, clear }), [events, clear]);
-
-  return <VoiceEventLogContext.Provider value={value}>{children}</VoiceEventLogContext.Provider>;
+  return <VoiceEventLogContext.Provider value={store}>{children}</VoiceEventLogContext.Provider>;
 };
 
 function shortName(p: { name?: string; identity: string }): string {

--- a/frontend/src/hooks/useVoiceEventLogDef.ts
+++ b/frontend/src/hooks/useVoiceEventLogDef.ts
@@ -1,0 +1,34 @@
+import { createContext, useContext } from 'react';
+
+export type VoiceEventSeverity = 'info' | 'success' | 'warn' | 'error';
+export type VoiceEventCategory =
+  | 'connection'
+  | 'participant'
+  | 'track'
+  | 'subscription'
+  | 'quality';
+
+export interface VoiceEventEntry {
+  id: number;
+  timestamp: number;
+  severity: VoiceEventSeverity;
+  category: VoiceEventCategory;
+  /** Short, single-line description (rendered in the debug panel). */
+  message: string;
+}
+
+export interface VoiceEventLogValue {
+  events: VoiceEventEntry[];
+  clear: () => void;
+}
+
+export const VoiceEventLogContext = createContext<VoiceEventLogValue | null>(null);
+
+/**
+ * Reads the live voice event log. Returns null if no provider is mounted.
+ * The log persists across debug-panel toggles so users can see history that
+ * happened before they opened the panel.
+ */
+export function useVoiceEventLog(): VoiceEventLogValue | null {
+  return useContext(VoiceEventLogContext);
+}

--- a/frontend/src/hooks/useVoiceEventLogDef.ts
+++ b/frontend/src/hooks/useVoiceEventLogDef.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useSyncExternalStore } from 'react';
 
 export type VoiceEventSeverity = 'info' | 'success' | 'warn' | 'error';
 export type VoiceEventCategory =
@@ -22,7 +22,26 @@ export interface VoiceEventLogValue {
   clear: () => void;
 }
 
-export const VoiceEventLogContext = createContext<VoiceEventLogValue | null>(null);
+/**
+ * The Provider exposes a mutable store rather than React state so writes to
+ * the event log don't cause the Provider component (or its children) to
+ * re-render. Only consumers of `useVoiceEventLog()` re-render, via
+ * `useSyncExternalStore`. This lets us mount the provider broadly (so the log
+ * is already populated when the user opens the debug panel) without paying
+ * a per-event re-render cost across the layout subtree.
+ */
+export interface VoiceEventLogStore {
+  getSnapshot: () => VoiceEventEntry[];
+  subscribe: (listener: () => void) => () => void;
+  push: (entry: Omit<VoiceEventEntry, 'id' | 'timestamp'>) => void;
+  clear: () => void;
+}
+
+export const VoiceEventLogContext = createContext<VoiceEventLogStore | null>(null);
+
+const NOOP_SUBSCRIBE = () => () => {};
+const EMPTY_EVENTS: VoiceEventEntry[] = Object.freeze([]) as VoiceEventEntry[];
+const emptySnapshot = () => EMPTY_EVENTS;
 
 /**
  * Reads the live voice event log. Returns null if no provider is mounted.
@@ -30,5 +49,14 @@ export const VoiceEventLogContext = createContext<VoiceEventLogValue | null>(nul
  * happened before they opened the panel.
  */
 export function useVoiceEventLog(): VoiceEventLogValue | null {
-  return useContext(VoiceEventLogContext);
+  const store = useContext(VoiceEventLogContext);
+  // useSyncExternalStore must be called unconditionally — pass noop fns when
+  // there is no store so the hook composes safely outside the provider.
+  const events = useSyncExternalStore(
+    store?.subscribe ?? NOOP_SUBSCRIBE,
+    store?.getSnapshot ?? emptySnapshot,
+    store?.getSnapshot ?? emptySnapshot,
+  );
+  if (!store) return null;
+  return { events, clear: store.clear };
 }


### PR DESCRIPTION
## Summary
- Self-heal voice mic subscriptions across reconnects so users stop randomly losing audio from specific peers
- Add per-participant audio diagnostics to the voice debug panel with a *Force resubscribe* recovery action
- Add a live event log (always recording while in a room) so users have history when they open the debug panel after a problem

## Why

3-person voice calls were intermittently asymmetric: A could hear B and C, but A couldn't hear B (while B and C still heard each other fine). Disconnecting / reconnecting fixed it.

The voice subsystem uses `autoSubscribe: false`, which makes the client fully responsible for subscribing to each remote mic. `useTrackSubscription` listened to `TrackPublished` / `TrackUnpublished` / `ParticipantConnected` — but **not** `Reconnected`. After a brief network blip the SFU treats the reconnect as a fresh session and forgets prior subscriptions, but the client's `publication.isSubscribed` may still read `true`. The early-return guard in `subscribePublication` then skipped the re-issue, locking in a silent state for that single peer pair. Each client's reconnects are independent, so the asymmetry pattern emerges naturally.

## Changes

### Subscription resilience (`useTrackSubscription.ts`)
- Listen for `RoomEvent.Reconnected` and re-apply policy with `force=true` (toggle `false`→`true` so a fresh SUBSCRIBE message is emitted)
- Listen for `RoomEvent.TrackSubscriptionStatusChanged` to self-heal mid-session if a mic transitions to `unsubscribed` without us asking
- Listen for `RoomEvent.TrackSubscriptionFailed` (logged with participant identity for visibility)
- Drop the `if (!isSubscribed)` guard in `subscribePublication` — always issue the call (SDK is idempotent)
- Replace `instanceof RemoteTrackPublication` with a duck-type check so it doesn't false-fail under HMR / duplicate module loads
- Expose a new `forceResubscribeMic(identity)` action via `TrackSubscriptionContext` for manual recovery

### Per-participant audio diagnostics (`VoiceDebugPanel.tsx`)
The panel was a single info card. It now also shows, **per remote participant**:
- Connection quality
- Mic publication exists, subscription status, track present, attached `<audio>` element count, current track volume, sender-muted state, speaking state
- Stored localStorage volume (with a hint when the user has muted the participant via the context menu)
- A health summary chip (Healthy / Not subscribed / No track / volume = 0)
- A **Force resubscribe** button per participant

Auto-refreshes on relevant LiveKit events plus a 1Hz interval so derived fields stay live.

### Live event log (`useVoiceEventLog.tsx` + `useVoiceEventLogDef.ts`)
A `VoiceEventLogProvider` mounted next to `TrackSubscriptionProvider` in Layout / MobileLayout / TabletLayout records LiveKit room events into a 250-item ring buffer the moment a room exists. The buffer is held in a ref-backed store and exposed via `useSyncExternalStore`, so writes never re-render the Provider or its subtree — only consumers (the debug panel) update on event arrivals. The buffer resets when the room reference changes or becomes null, so prior-session events don't bleed in.

The debug panel renders entries newest-first with severity coloring, timestamps to the millisecond, and Pause / Clear controls. Crucially, the log is *already populated* when the panel is opened — so users can see what happened before the panel was visible.

Tracked events: connection lifecycle (Reconnecting, Reconnected, SignalConnected, Disconnected, ConnectionStateChanged), participant connect/disconnect, track publish/unpublish, mic mute/unmute, full subscription lifecycle (subscribed/unsubscribed/failed/status-changed mic-only), local quality always + remote Poor/Lost only.

### Tests
- `useTrackSubscription.test.ts`: 14 → 23 cases (Reconnected, TrackSubscriptionStatusChanged self-heal, forceResubscribeMic, all listener cleanup)
- New `useVoiceEventLog.test.tsx`: 13 cases (provider gating, severity classification, mic-only filter, local-vs-remote quality rules, ring buffer cap, clear, **buffer reset on room change/null**)
- New `voiceLifecycle.test.tsx` integration suite: 12 cases mounting `VoiceProvider` + `RoomContext` + `TrackSubscriptionProvider` + `AudioRenderer` + `useDeafenEffect` + `useRemoteVolumeEffect` together against a fake LiveKit room. Covers initial join with existing mic, mid-session participant connect, mid-session mic publish, **Reconnected → force re-subscribe (the asymmetry repro)**, deafen/undeafen volume restore, manual recovery, participant-disconnect cleanup

This integration harness can be reused as a template for adding more cross-hook voice tests.

## Caveats

I didn't reproduce the original asymmetry locally — the fix is informed-guess + defense-in-depth rather than a confirmed-by-repro fix. If it still happens after this change, the debug panel will pinpoint the failure mode (subscription state, missing track, attached element count, stored volume, recent events), and *Force resubscribe* is one-click recovery while we collect more data.

## Test plan
- [ ] `pnpm run test` passes locally (1216 frontend tests, +13)
- [ ] `pnpm run type-check` clean
- [ ] `pnpm run lint` at baseline 20 warnings (no new warnings)
- [ ] Join a 3-person voice call; force a network blip on one client; verify all clients still hear all others
- [ ] Open Voice Debug Panel (Ctrl+Shift+D) while in voice; verify event log populates; trigger a participant join/leave/mute and verify entries appear
- [ ] Click *Force resubscribe* on a remote participant and verify it doesn't break their audio
- [ ] Test on Electron (primary platform) and web browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)