### PR TITLE
fix(ci): bump Playwright to 1.60.0 — fixes deterministic E2E install hang on Node 24.16+

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -76,13 +76,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       # NOTE: no `--with-deps`. The ubuntu-latest image already ships chromium's
       # system libs (apt reported every dep "already the newest version"), and
       # `--with-deps` shells out to apt-get which intermittently HANGS on the
-      # runner. The browser-binary download from the Playwright CDN can also be
-      # slow/stall, so retry up to 3× on a cache miss. (Both the apt hang and a
-      # stalled CDN download had been timing this step out / cancelling nightlies.)
+      # runner. The retry guards against genuine CDN stalls. (The deterministic
+      # post-download hang seen on Node 24.16+ was a yauzl extraction bug, fixed
+      # in Playwright >= 1.60.0 — keep @playwright/test at or above that.)
       - name: Install Playwright browser
         if: steps.pw-cache.outputs.cache-hit != 'true'
         timeout-minutes: 15
@@ -266,7 +266,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install Playwright browser
         if: steps.pw-cache.outputs.cache-hit != 'true'
         timeout-minutes: 15

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -97,7 +97,7 @@ services:
 
   # Playwright test runner
   playwright:
-    image: mcr.microsoft.com/playwright:v1.40.0-jammy
+    image: mcr.microsoft.com/playwright:v1.60.0-jammy
     volumes:
       - ./frontend:/app
       - ./frontend/playwright-report:/app/playwright-report

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@eslint/js": "^9.22.0",
     "@hey-api/openapi-ts": "^0.92.3",
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,8 +314,8 @@ importers:
         specifier: ^0.92.3
         version: 0.92.4(magicast@0.5.2)(typescript@5.7.3)
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.2
+        specifier: ^1.60.0
+        version: 1.60.0
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -2241,8 +2241,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6004,13 +6004,13 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9563,9 +9563,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.60.0
 
   '@popperjs/core@2.11.8': {}
 
@@ -13875,11 +13875,11 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.58.2:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## Why E2E has been failing at "Install Playwright browser"

The step downloads chromium to 100% in ~2s, then hangs silently until the timeout kills it — on every attempt. This is a known upstream bug: **yauzl (Playwright's zip extractor) hangs on Node 24.16+** ([microsoft/playwright#41092](https://github.com/microsoft/playwright/issues/41092), [#40724](https://github.com/microsoft/playwright/issues/40724)). Our workflow uses `node-version: '24'`, which now resolves to 24.16.0, and `@playwright/test ^1.57.0` resolved to 1.58.2 — a pre-fix version.

Because the hang is deterministic (extraction, not network), the earlier mitigations (#357: drop `--with-deps`, add cache + 3× retry with `timeout 240`) could never work — every retry re-downloads fine and hangs again at the same spot.

## Fix

- Bump `@playwright/test` to `^1.60.0` — the yauzl fix is vendored in 1.60.0 via [microsoft/playwright#40747](https://github.com/microsoft/playwright/pull/40747).
- Fix the browser cache key: it hashed `frontend/pnpm-lock.yaml`, which doesn't exist (the lockfile is at the repo root), so the key was static (`playwright-Linux-`) and wouldn't rotate on version bumps.
- Bump the (CI-unused) dockerized runner image in `docker-compose.e2e.yml` to `v1.60.0-jammy` to match the package (was stale at v1.40.0).

The lockfile diff is purely the playwright 1.58.2 → 1.60.0 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)