### PR TITLE
fix(files): video thumbnails — close post-time race, backfill old videos, persist uploads in compose prod

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -100,6 +100,10 @@ LABEL org.opencontainers.image.created="${BUILD_DATE}"
 # Force layer rebuild with current timestamp (ensures ArgoCD Image Updater sees fresh image)
 RUN echo "Build timestamp: ${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}" > /tmp/build-time.txt
 
+# Pre-create the uploads dir owned by the app user so a named volume mounted
+# there (docker-compose.prod.yml) inherits writable ownership
+RUN mkdir -p /app/uploads && chown nestjs:nodejs /app/uploads
+
 # Switch to non-root user
 USER nestjs
 

--- a/backend/src/file-upload/file-upload.module.ts
+++ b/backend/src/file-upload/file-upload.module.ts
@@ -8,10 +8,11 @@ import { StorageModule } from '@/storage/storage.module';
 import { StorageQuotaModule } from '@/storage-quota/storage-quota.module';
 import { LivekitModule } from '@/livekit/livekit.module';
 import { ThumbnailService } from '@/file/thumbnail.service';
+import { ThumbnailBackfillService } from '@/file/thumbnail-backfill.service';
 
 @Module({
   controllers: [FileUploadController],
-  providers: [FileUploadService, ThumbnailService],
+  providers: [FileUploadService, ThumbnailService, ThumbnailBackfillService],
   imports: [
     MulterModule.registerAsync({
       imports: [ConfigModule],

--- a/backend/src/file-upload/file-upload.service.spec.ts
+++ b/backend/src/file-upload/file-upload.service.spec.ts
@@ -161,6 +161,96 @@ describe('FileUploadService', () => {
       expect(result).toBeInstanceOf(FileUploadResponseDto);
     });
 
+    describe('video thumbnail generation', () => {
+      const videoFile: Express.Multer.File = {
+        ...mockFile,
+        originalname: 'clip.mp4',
+        mimetype: 'video/mp4',
+        filename: 'clip-123.mp4',
+        path: '/tmp/clip-123.mp4',
+      };
+
+      const createDto = {
+        resourceType: ResourceType.MESSAGE_ATTACHMENT,
+        resourceId: 'msg-123',
+      };
+
+      const createdFile = {
+        id: 'file-video-1',
+        filename: 'clip.mp4',
+        mimeType: 'video/mp4',
+        fileType: FileType.VIDEO,
+        thumbnailPath: null,
+      };
+
+      beforeEach(() => {
+        databaseService.file.create.mockResolvedValue(createdFile as any);
+
+        const {
+          ResourceTypeFileValidator,
+        } = require('./validators/resource-type-file.validator');
+        ResourceTypeFileValidator.mockImplementation(() => ({
+          isValid: jest.fn().mockResolvedValue(true),
+        }));
+      });
+
+      it('should generate the thumbnail before responding and return the updated record', async () => {
+        thumbnailService.generateVideoThumbnail.mockResolvedValue(
+          'uploads/thumbnails/file-video-1.jpg',
+        );
+        databaseService.file.update.mockResolvedValue({
+          ...createdFile,
+          thumbnailPath: 'uploads/thumbnails/file-video-1.jpg',
+        } as any);
+
+        const result = await service.uploadFile(videoFile, createDto, mockUser);
+
+        expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledWith(
+          '/tmp/clip-123.mp4',
+          'file-video-1',
+        );
+        expect(databaseService.file.update).toHaveBeenCalledWith({
+          where: { id: 'file-video-1' },
+          data: { thumbnailPath: 'uploads/thumbnails/file-video-1.jpg' },
+        });
+        expect(result.thumbnailPath).toBe(
+          'uploads/thumbnails/file-video-1.jpg',
+        );
+      });
+
+      it('should still succeed when thumbnail generation returns null', async () => {
+        thumbnailService.generateVideoThumbnail.mockResolvedValue(null);
+
+        const result = await service.uploadFile(videoFile, createDto, mockUser);
+
+        expect(result.id).toBe('file-video-1');
+        expect(result.thumbnailPath).toBeNull();
+        expect(databaseService.file.update).not.toHaveBeenCalled();
+      });
+
+      it('should still succeed when thumbnail generation throws', async () => {
+        thumbnailService.generateVideoThumbnail.mockRejectedValue(
+          new Error('FFmpeg crashed'),
+        );
+
+        const result = await service.uploadFile(videoFile, createDto, mockUser);
+
+        expect(result.id).toBe('file-video-1');
+        expect(result.thumbnailPath).toBeNull();
+      });
+
+      it('should not generate thumbnails for non-video files', async () => {
+        databaseService.file.create.mockResolvedValue({
+          id: 'file-img-1',
+          fileType: FileType.IMAGE,
+        } as any);
+
+        await service.uploadFile(mockFile, createDto, mockUser);
+
+        expect(thumbnailService.generateVideoThumbnail).not.toHaveBeenCalled();
+      });
+    });
+
     it('should throw error and cleanup file when validation fails', async () => {
       const createDto = {
         resourceType: ResourceType.MESSAGE_ATTACHMENT,

--- a/backend/src/file-upload/file-upload.service.ts
+++ b/backend/src/file-upload/file-upload.service.ts
@@ -92,12 +92,16 @@ export class FileUploadService {
         // Increment user's storage usage
         await this.storageQuotaService.incrementUserStorage(user.id, file.size);
 
-        // Generate thumbnail for video files (fire-and-forget — failure won't block upload)
-        if (fileType === FileType.VIDEO) {
-          this.generateThumbnailAsync(file.path, fileRecord.id);
-        }
+        // Generate thumbnail for video files before responding, so the
+        // attachment metadata clients receive carries hasThumbnail: true.
+        // Failure is non-fatal — the upload succeeds without a thumbnail.
+        const finalRecord =
+          fileType === FileType.VIDEO
+            ? ((await this.generateThumbnail(file.path, fileRecord.id)) ??
+              fileRecord)
+            : fileRecord;
 
-        return new FileUploadResponseDto(fileRecord);
+        return new FileUploadResponseDto(finalRecord);
       } catch (dbError) {
         // If DB insert fails, clean up the file
         await this.cleanupFile(file.path);
@@ -120,26 +124,30 @@ export class FileUploadService {
   }
 
   /**
-   * Fire-and-forget thumbnail generation for video uploads.
+   * Generate a thumbnail for a video upload and persist its path.
    * Errors are logged but never propagate to the upload response.
+   *
+   * @returns The updated file record, or null if generation failed
    */
-  private generateThumbnailAsync(filePath: string, fileId: string): void {
-    void (async () => {
-      try {
-        const thumbnailPath =
-          await this.thumbnailService.generateVideoThumbnail(filePath, fileId);
-        if (thumbnailPath) {
-          await this.databaseService.file.update({
-            where: { id: fileId },
-            data: { thumbnailPath },
-          });
-        }
-      } catch (error) {
-        this.logger.error(
-          `Failed to generate thumbnail for file ${fileId}: ${error instanceof Error ? error.message : String(error)}`,
-        );
+  private async generateThumbnail(filePath: string, fileId: string) {
+    try {
+      const thumbnailPath = await this.thumbnailService.generateVideoThumbnail(
+        filePath,
+        fileId,
+      );
+      if (!thumbnailPath) {
+        return null;
       }
-    })();
+      return await this.databaseService.file.update({
+        where: { id: fileId },
+        data: { thumbnailPath },
+      });
+    } catch (error) {
+      this.logger.error(
+        `Failed to generate thumbnail for file ${fileId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    }
   }
 
   /**

--- a/backend/src/file/thumbnail-backfill.service.spec.ts
+++ b/backend/src/file/thumbnail-backfill.service.spec.ts
@@ -107,6 +107,28 @@ describe('ThumbnailBackfillService', () => {
     });
   });
 
+  it('should continue with remaining files when one file errors mid-processing', async () => {
+    databaseService.file.findMany.mockResolvedValue([
+      { id: 'file-db-err', storagePath: '/clips/a.mp4' },
+      { id: 'file-ok', storagePath: '/clips/b.mp4' },
+    ] as any);
+    storageService.fileExists.mockResolvedValue(true);
+    thumbnailService.generateVideoThumbnail
+      .mockResolvedValueOnce('uploads/thumbnails/file-db-err.jpg')
+      .mockResolvedValueOnce('uploads/thumbnails/file-ok.jpg');
+    databaseService.file.update
+      .mockRejectedValueOnce(new Error('transient db error'))
+      .mockResolvedValueOnce({} as any);
+
+    const result = await service.backfill();
+
+    expect(result).toEqual({ generated: 1, skipped: 1 });
+    expect(databaseService.file.update).toHaveBeenCalledWith({
+      where: { id: 'file-ok' },
+      data: { thumbnailPath: 'uploads/thumbnails/file-ok.jpg' },
+    });
+  });
+
   it('should not reject from onApplicationBootstrap when backfill fails', async () => {
     databaseService.file.findMany.mockRejectedValue(new Error('db down'));
 

--- a/backend/src/file/thumbnail-backfill.service.spec.ts
+++ b/backend/src/file/thumbnail-backfill.service.spec.ts
@@ -1,0 +1,117 @@
+import { TestBed } from '@suites/unit';
+import type { Mocked } from '@suites/doubles.jest';
+import { ThumbnailBackfillService } from './thumbnail-backfill.service';
+import { DatabaseService } from '@/database/database.service';
+import { StorageService } from '@/storage/storage.service';
+import { ThumbnailService } from './thumbnail.service';
+import { FileType } from '@prisma/client';
+
+describe('ThumbnailBackfillService', () => {
+  let service: ThumbnailBackfillService;
+  let databaseService: Mocked<DatabaseService>;
+  let storageService: Mocked<StorageService>;
+  let thumbnailService: Mocked<ThumbnailService>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(
+      ThumbnailBackfillService,
+    ).compile();
+
+    service = unit;
+    databaseService = unitRef.get(DatabaseService);
+    storageService = unitRef.get(StorageService);
+    thumbnailService = unitRef.get(ThumbnailService);
+
+    jest.clearAllMocks();
+  });
+
+  it('should query only non-deleted video files without a thumbnail', async () => {
+    databaseService.file.findMany.mockResolvedValue([]);
+
+    await service.backfill();
+
+    expect(databaseService.file.findMany).toHaveBeenCalledWith({
+      where: {
+        fileType: FileType.VIDEO,
+        thumbnailPath: null,
+        deletedAt: null,
+      },
+      select: { id: true, storagePath: true },
+    });
+  });
+
+  it('should do nothing when no files need backfill', async () => {
+    databaseService.file.findMany.mockResolvedValue([]);
+
+    const result = await service.backfill();
+
+    expect(result).toEqual({ generated: 0, skipped: 0 });
+    expect(thumbnailService.generateVideoThumbnail).not.toHaveBeenCalled();
+  });
+
+  it('should generate thumbnails and persist paths for backfillable files', async () => {
+    databaseService.file.findMany.mockResolvedValue([
+      { id: 'file-1', storagePath: '/clips/a.mp4' },
+      { id: 'file-2', storagePath: '/clips/b.mp4' },
+    ] as any);
+    storageService.fileExists.mockResolvedValue(true);
+    thumbnailService.generateVideoThumbnail
+      .mockResolvedValueOnce('uploads/thumbnails/file-1.jpg')
+      .mockResolvedValueOnce('uploads/thumbnails/file-2.jpg');
+    databaseService.file.update.mockResolvedValue({} as any);
+
+    const result = await service.backfill();
+
+    expect(result).toEqual({ generated: 2, skipped: 0 });
+    expect(databaseService.file.update).toHaveBeenCalledWith({
+      where: { id: 'file-1' },
+      data: { thumbnailPath: 'uploads/thumbnails/file-1.jpg' },
+    });
+    expect(databaseService.file.update).toHaveBeenCalledWith({
+      where: { id: 'file-2' },
+      data: { thumbnailPath: 'uploads/thumbnails/file-2.jpg' },
+    });
+  });
+
+  it('should skip files whose source no longer exists on disk', async () => {
+    databaseService.file.findMany.mockResolvedValue([
+      { id: 'file-gone', storagePath: '/clips/gone.mp4' },
+    ] as any);
+    storageService.fileExists.mockResolvedValue(false);
+
+    const result = await service.backfill();
+
+    expect(result).toEqual({ generated: 0, skipped: 1 });
+    expect(thumbnailService.generateVideoThumbnail).not.toHaveBeenCalled();
+    expect(databaseService.file.update).not.toHaveBeenCalled();
+  });
+
+  it('should skip files whose generation fails and continue with the rest', async () => {
+    databaseService.file.findMany.mockResolvedValue([
+      { id: 'file-bad', storagePath: '/clips/bad.mp4' },
+      { id: 'file-good', storagePath: '/clips/good.mp4' },
+    ] as any);
+    storageService.fileExists.mockResolvedValue(true);
+    thumbnailService.generateVideoThumbnail
+      .mockResolvedValueOnce(null) // generateVideoThumbnail returns null on failure
+      .mockResolvedValueOnce('uploads/thumbnails/file-good.jpg');
+    databaseService.file.update.mockResolvedValue({} as any);
+
+    const result = await service.backfill();
+
+    expect(result).toEqual({ generated: 1, skipped: 1 });
+    expect(databaseService.file.update).toHaveBeenCalledTimes(1);
+    expect(databaseService.file.update).toHaveBeenCalledWith({
+      where: { id: 'file-good' },
+      data: { thumbnailPath: 'uploads/thumbnails/file-good.jpg' },
+    });
+  });
+
+  it('should not reject from onApplicationBootstrap when backfill fails', async () => {
+    databaseService.file.findMany.mockRejectedValue(new Error('db down'));
+
+    expect(() => service.onApplicationBootstrap()).not.toThrow();
+    // Allow the fire-and-forget promise to settle (error is logged, not thrown)
+    await new Promise((r) => setImmediate(r));
+  });
+});

--- a/backend/src/file/thumbnail-backfill.service.ts
+++ b/backend/src/file/thumbnail-backfill.service.ts
@@ -55,32 +55,41 @@ export class ThumbnailBackfillService implements OnApplicationBootstrap {
     let generated = 0;
     let skipped = 0;
 
-    // Sequential on purpose: avoids spawning concurrent ffmpeg processes
+    // Sequential on purpose: avoids spawning concurrent ffmpeg processes.
+    // Best-effort per file: one failure must not abort the remaining candidates.
     for (const file of candidates) {
-      if (!(await this.storageService.fileExists(file.storagePath))) {
+      try {
+        if (!(await this.storageService.fileExists(file.storagePath))) {
+          this.logger.warn(
+            `Skipping thumbnail backfill for file ${file.id}: source ${file.storagePath} not found`,
+          );
+          skipped++;
+          continue;
+        }
+
+        // generateVideoThumbnail logs and returns null on failure
+        const thumbnailPath =
+          await this.thumbnailService.generateVideoThumbnail(
+            file.storagePath,
+            file.id,
+          );
+
+        if (!thumbnailPath) {
+          skipped++;
+          continue;
+        }
+
+        await this.databaseService.file.update({
+          where: { id: file.id },
+          data: { thumbnailPath },
+        });
+        generated++;
+      } catch (error) {
         this.logger.warn(
-          `Skipping thumbnail backfill for file ${file.id}: source ${file.storagePath} not found`,
+          `Skipping thumbnail backfill for file ${file.id}: ${error instanceof Error ? error.message : String(error)}`,
         );
         skipped++;
-        continue;
       }
-
-      // generateVideoThumbnail logs and returns null on failure
-      const thumbnailPath = await this.thumbnailService.generateVideoThumbnail(
-        file.storagePath,
-        file.id,
-      );
-
-      if (!thumbnailPath) {
-        skipped++;
-        continue;
-      }
-
-      await this.databaseService.file.update({
-        where: { id: file.id },
-        data: { thumbnailPath },
-      });
-      generated++;
     }
 
     this.logger.log(

--- a/backend/src/file/thumbnail-backfill.service.ts
+++ b/backend/src/file/thumbnail-backfill.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { FileType } from '@prisma/client';
+import { DatabaseService } from '@/database/database.service';
+import { StorageService } from '@/storage/storage.service';
+import { ThumbnailService } from './thumbnail.service';
+
+/**
+ * Backfills missing video thumbnails on startup.
+ *
+ * Video files uploaded before thumbnail support existed — or whose
+ * generation failed at upload/capture time — have a null thumbnailPath
+ * forever, since generation only ever ran once. This service retries
+ * them on boot so old replay clips and video attachments get thumbnails
+ * retroactively. Files whose source is gone or whose generation keeps
+ * failing are skipped (and retried on the next boot, which is cheap:
+ * one ffmpeg frame-extraction per file, run sequentially).
+ */
+@Injectable()
+export class ThumbnailBackfillService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(ThumbnailBackfillService.name);
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly storageService: StorageService,
+    private readonly thumbnailService: ThumbnailService,
+  ) {}
+
+  onApplicationBootstrap(): void {
+    // Fire-and-forget: never block application startup
+    void this.backfill().catch((error) => {
+      this.logger.error(
+        `Thumbnail backfill failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+  }
+
+  async backfill(): Promise<{ generated: number; skipped: number }> {
+    const candidates = await this.databaseService.file.findMany({
+      where: {
+        fileType: FileType.VIDEO,
+        thumbnailPath: null,
+        deletedAt: null,
+      },
+      select: { id: true, storagePath: true },
+    });
+
+    if (candidates.length === 0) {
+      return { generated: 0, skipped: 0 };
+    }
+
+    this.logger.log(
+      `Backfilling thumbnails for ${candidates.length} video file(s) without one`,
+    );
+
+    let generated = 0;
+    let skipped = 0;
+
+    // Sequential on purpose: avoids spawning concurrent ffmpeg processes
+    for (const file of candidates) {
+      if (!(await this.storageService.fileExists(file.storagePath))) {
+        this.logger.warn(
+          `Skipping thumbnail backfill for file ${file.id}: source ${file.storagePath} not found`,
+        );
+        skipped++;
+        continue;
+      }
+
+      // generateVideoThumbnail logs and returns null on failure
+      const thumbnailPath = await this.thumbnailService.generateVideoThumbnail(
+        file.storagePath,
+        file.id,
+      );
+
+      if (!thumbnailPath) {
+        skipped++;
+        continue;
+      }
+
+      await this.databaseService.file.update({
+        where: { id: file.id },
+        data: { thumbnailPath },
+      });
+      generated++;
+    }
+
+    this.logger.log(
+      `Thumbnail backfill complete: ${generated} generated, ${skipped} skipped`,
+    );
+    return { generated, skipped };
+  }
+}

--- a/backend/src/livekit/livekit-replay.service.spec.ts
+++ b/backend/src/livekit/livekit-replay.service.spec.ts
@@ -715,9 +715,6 @@ describe('LivekitReplayService', () => {
     it('should call generateVideoThumbnail after file creation', async () => {
       await service.captureReplay(userId, dto);
 
-      // Allow the fire-and-forget async to settle
-      await new Promise((r) => setImmediate(r));
-
       expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledWith(
         expect.stringContaining('replay-'),
         'file-1',
@@ -726,9 +723,6 @@ describe('LivekitReplayService', () => {
 
     it('should update file record with thumbnailPath on success', async () => {
       await service.captureReplay(userId, dto);
-
-      // Allow the fire-and-forget async to settle
-      await new Promise((r) => setImmediate(r));
 
       expect(databaseService.file.update).toHaveBeenCalledWith({
         where: { id: 'file-1' },
@@ -741,14 +735,45 @@ describe('LivekitReplayService', () => {
         new Error('FFmpeg not found'),
       );
 
-      // captureReplay should still succeed
+      // captureReplay should still succeed (error is logged, not thrown)
       const result = await service.captureReplay(userId, dto);
 
       expect(result.clipId).toBe('clip-1');
       expect(result.fileId).toBe('file-1');
+    });
 
-      // Allow the fire-and-forget async to settle (error is logged, not thrown)
-      await new Promise((r) => setImmediate(r));
+    it('should finish thumbnail generation before emitting the clip message event', async () => {
+      const channelDto = {
+        durationMinutes: 1 as const,
+        destination: 'channel' as const,
+        targetChannelId: 'target-channel-1',
+      };
+      databaseService.channel.findUnique.mockResolvedValue({
+        id: 'target-channel-1',
+        communityId: 'community-1',
+      });
+      databaseService.membership.findFirst.mockResolvedValue({
+        id: 'membership-1',
+        userId,
+        communityId: 'community-1',
+      });
+      eventEmitter.emitAsync.mockResolvedValue([{ messageId: 'message-1' }]);
+
+      const callOrder: string[] = [];
+      databaseService.file.update.mockImplementation(() => {
+        callOrder.push('thumbnail-saved');
+        return Promise.resolve({});
+      });
+      eventEmitter.emitAsync.mockImplementation(() => {
+        callOrder.push('message-emitted');
+        return Promise.resolve([{ messageId: 'message-1' }]);
+      });
+
+      await service.captureReplay(userId, channelDto);
+
+      // The broadcast message must carry hasThumbnail: true, so the
+      // thumbnail has to be persisted before the message is created
+      expect(callOrder).toEqual(['thumbnail-saved', 'message-emitted']);
     });
 
     it('should pass only complete segments (from ReplaySegmentsService) to FFmpeg', async () => {

--- a/backend/src/livekit/livekit-replay.service.ts
+++ b/backend/src/livekit/livekit-replay.service.ts
@@ -885,8 +885,10 @@ export class LivekitReplayService {
 
     this.logger.log(`Created file record: ${file.id}`);
 
-    // Generate thumbnail for the video clip (fire-and-forget — failure won't block response)
-    this.generateThumbnailAsync(clipPath, file.id);
+    // Generate thumbnail for the video clip before the message is created,
+    // so the broadcast/cached message carries hasThumbnail: true.
+    // Failure is non-fatal — the clip is still posted without a thumbnail.
+    await this.generateThumbnail(clipPath, file.id);
 
     // 8. Create ReplayClip record
     const clip = await this.databaseService.replayClip.create({
@@ -1013,27 +1015,30 @@ export class LivekitReplayService {
   }
 
   /**
-   * Fire-and-forget thumbnail generation for replay clips.
+   * Generate a thumbnail for a replay clip and persist its path.
    * Errors are logged but never propagate to the capture response.
    */
-  private generateThumbnailAsync(filePath: string, fileId: string): void {
-    void (async () => {
-      try {
-        const thumbnailPath =
-          await this.thumbnailService.generateVideoThumbnail(filePath, fileId);
-        if (thumbnailPath) {
-          await this.databaseService.file.update({
-            where: { id: fileId },
-            data: { thumbnailPath },
-          });
-          this.logger.log(`Generated thumbnail for replay clip ${fileId}`);
-        }
-      } catch (error) {
-        this.logger.error(
-          `Failed to generate thumbnail for replay clip ${fileId}: ${getErrorMessage(error)}`,
-        );
+  private async generateThumbnail(
+    filePath: string,
+    fileId: string,
+  ): Promise<void> {
+    try {
+      const thumbnailPath = await this.thumbnailService.generateVideoThumbnail(
+        filePath,
+        fileId,
+      );
+      if (thumbnailPath) {
+        await this.databaseService.file.update({
+          where: { id: fileId },
+          data: { thumbnailPath },
+        });
+        this.logger.log(`Generated thumbnail for replay clip ${fileId}`);
       }
-    })();
+    } catch (error) {
+      this.logger.error(
+        `Failed to generate thumbnail for replay clip ${fileId}: ${getErrorMessage(error)}`,
+      );
+    }
   }
 
   /**

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,8 +22,12 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-semaphore}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}@postgres:5432/${POSTGRES_DB:-semaphore}
       - REDIS_HOST=redis
       - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD required}
+      - FILE_UPLOAD_DEST=/app/uploads
     ports:
       - "${BACKEND_PORT:-3000}:3000"
+    volumes:
+      # Persist uploaded files and generated thumbnails across container recreates
+      - uploads:/app/uploads
     depends_on:
       postgres:
         condition: service_healthy
@@ -87,3 +91,4 @@ services:
 volumes:
   pgdata:
   redisdata:
+  uploads:


### PR DESCRIPTION
## Problem

Replay clips and posted videos show a generic placeholder instead of a thumbnail (reported on the hosted instance — no `/file/:id/thumbnail` request is even made, meaning the server reports `hasThumbnail: false`).

Investigation found the generation pipeline itself works (verified end-to-end locally: FFmpeg extraction, DB update, serialization, access control, frontend fetch). The failures come from timing and durability around it:

## Fixes

### 1. Thumbnail generation is now awaited (was fire-and-forget)
`captureReplay()` kicked off thumbnail generation in the background and immediately emitted the clip message. Clients received (and cached) the message with `hasThumbnail: false`; the thumbnail landed in the DB moments later but **no event ever told clients**, and message queries use `staleTime: Infinity`, so the placeholder persisted for the whole session. Regular video uploads had the same race.

Generation now completes **before** the clip message is emitted / the upload response returns, so the very first broadcast carries `hasThumbnail: true`. Still non-fatal on failure; frame extraction takes ~150ms (30s hard cap), and replay capture already spends seconds in FFmpeg concat.

### 2. Startup backfill for videos with missing thumbnails
Videos uploaded before thumbnail support existed (replay-clip thumbnails arrived in #246), or whose generation failed once, kept a null `thumbnailPath` forever — generation only ever ran once. New `ThumbnailBackfillService` retries them on application bootstrap: sequential (one ffmpeg at a time), skips files missing from disk, no-ops when there's nothing to do. **This retroactively fixes existing clips on running instances.**

Verified live on the dev stack: nulled `thumbnailPath` on existing video rows, restarted the backend, and both regenerated (`Backfilling thumbnails for 2 video file(s) without one` → both rows repopulated, JPEGs on disk).

### 3. `docker-compose.prod.yml` now persists uploads
The prod compose file defined no volume for uploads, so uploaded files **and** thumbnails lived in the container filesystem and were lost on every recreate. Added a named `uploads` volume at `/app/uploads` (+ `FILE_UPLOAD_DEST`), and `Dockerfile.prod` pre-creates the dir so the volume inherits `nestjs` ownership. (The helm chart already used a PVC; this only affected compose deploys.)

## Tests
- New: `thumbnail-backfill.service.spec.ts` (6 tests: query shape, no-op, generation+persist, missing-source skip, failure skip-and-continue, bootstrap never throws)
- New: upload thumbnail behavior tests in `file-upload.service.spec.ts` (awaited generation returns updated record; null/throw still succeed; non-video skipped)
- Updated: `livekit-replay.service.spec.ts` — removed obsolete fire-and-forget waits, added ordering assertion (thumbnail persisted **before** clip message event)
- Full backend suite: 2135/2135 pass; lint + build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
