### PR TITLE
fix(voice): live-update audio devices during calls

### DIFF
--- a/frontend/src/__tests__/features/voiceActions.test.ts
+++ b/frontend/src/__tests__/features/voiceActions.test.ts
@@ -20,7 +20,11 @@ const mockRoomInstance = {
   state: 'connected',
   localParticipant: mockLocalParticipant,
   switchActiveDevice: vi.fn().mockResolvedValue(undefined),
+  getActiveDevice: vi.fn().mockReturnValue(undefined),
 };
+
+// Captures handlers registered via room.on() so tests can fire room events
+const roomEventHandlers: Record<string, (...args: unknown[]) => unknown> = {};
 
 vi.mock('livekit-client', () => {
   class MockRoom {
@@ -29,7 +33,11 @@ vi.mock('livekit-client', () => {
     state = mockRoomInstance.state;
     localParticipant = mockRoomInstance.localParticipant;
     switchActiveDevice = mockRoomInstance.switchActiveDevice;
-    on = vi.fn().mockReturnThis();
+    getActiveDevice = mockRoomInstance.getActiveDevice;
+    on = vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
+      roomEventHandlers[event] = handler;
+      return this;
+    });
   }
   return {
     Room: MockRoom,
@@ -38,6 +46,8 @@ vi.mock('livekit-client', () => {
       Reconnected: 'reconnected',
       SignalConnected: 'signalConnected',
       Disconnected: 'disconnected',
+      MediaDevicesChanged: 'mediaDevicesChanged',
+      ActiveDeviceChanged: 'activeDeviceChanged',
     },
     DisconnectReason: {},
     VideoCaptureOptions: {},
@@ -151,6 +161,8 @@ describe('voiceActions', () => {
     vi.clearAllMocks();
     mockRoomInstance.localParticipant.isMicrophoneEnabled = true;
     mockRoomInstance.localParticipant.metadata = JSON.stringify({ isDeafened: false });
+    mockRoomInstance.getActiveDevice.mockReturnValue(undefined);
+    Object.keys(roomEventHandlers).forEach((key) => delete roomEventHandlers[key]);
   });
 
   describe('joinVoiceChannel', () => {
@@ -413,6 +425,120 @@ describe('voiceActions', () => {
     it('returns early when no room or channel', async () => {
       const deps = createMockDeps({ channelId: null, dmGroupId: null });
       await switchAudioOutputDevice('device-456', deps);
+
+      expect(mockRoomInstance.switchActiveDevice).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('device change handling (#346)', () => {
+    const params = {
+      channelId: 'ch-1',
+      channelName: 'General',
+      communityId: 'c1',
+      isPrivate: false,
+      createdAt: '2025-01-01',
+      user: { id: 'user-1', username: 'testuser', displayName: 'Test User' },
+      connectionInfo: { url: 'ws://localhost:7880' },
+    };
+
+    const setDeviceList = (devices: { deviceId: string; kind: string; label: string; groupId: string }[]) => {
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: { enumerateDevices: vi.fn().mockResolvedValue(devices) },
+        configurable: true,
+      });
+    };
+
+    const mockDevicePrefs = (prefs: { audioInputDeviceId: string; audioOutputDeviceId: string; videoInputDeviceId: string } | null) => {
+      vi.mocked(getCachedItem).mockImplementation((key: string) =>
+        key === 'semaphore_device_preferences' ? prefs : null
+      );
+    };
+
+    const defaultMic = { deviceId: 'default', kind: 'audioinput', label: 'Default Mic', groupId: 'g1' };
+    const usbMic = { deviceId: 'mic-123', kind: 'audioinput', label: 'USB Mic', groupId: 'g2' };
+    const defaultSpeaker = { deviceId: 'default', kind: 'audiooutput', label: 'Default Speaker', groupId: 'g1' };
+
+    it('binds audio to the default pseudo-device on join when no preferences saved', async () => {
+      mockDevicePrefs(null);
+      setDeviceList([defaultMic, usbMic, defaultSpeaker]);
+
+      await joinVoiceChannel(params, createMockDeps());
+
+      expect(mockRoomInstance.switchActiveDevice).toHaveBeenCalledWith('audioinput', 'default');
+      expect(mockRoomInstance.switchActiveDevice).toHaveBeenCalledWith('audiooutput', 'default');
+    });
+
+    it('skips default binding when the browser has no default pseudo-device', async () => {
+      mockDevicePrefs(null);
+      setDeviceList([
+        { deviceId: 'mic-ff', kind: 'audioinput', label: 'Mic', groupId: 'g1' },
+        { deviceId: 'spk-ff', kind: 'audiooutput', label: 'Speaker', groupId: 'g1' },
+      ]);
+
+      await joinVoiceChannel(params, createMockDeps());
+
+      expect(mockRoomInstance.switchActiveDevice).not.toHaveBeenCalled();
+    });
+
+    it('dispatches selected-device updates when LiveKit reports an active device change', async () => {
+      mockDevicePrefs(null);
+      setDeviceList([]);
+      const deps = createMockDeps();
+      await joinVoiceChannel(params, deps);
+
+      roomEventHandlers['activeDeviceChanged']('audioinput', 'mic-new');
+      roomEventHandlers['activeDeviceChanged']('audiooutput', 'spk-new');
+
+      expect(deps.dispatch).toHaveBeenCalledWith({ type: VoiceActionType.SetSelectedAudioInputId, payload: 'mic-new' });
+      expect(deps.dispatch).toHaveBeenCalledWith({ type: VoiceActionType.SetSelectedAudioOutputId, payload: 'spk-new' });
+    });
+
+    it('falls back to the default device when the active mic is unplugged', async () => {
+      mockDevicePrefs({ audioInputDeviceId: 'mic-123', audioOutputDeviceId: 'default', videoInputDeviceId: 'default' });
+      setDeviceList([defaultMic, usbMic, defaultSpeaker]);
+      const deps = createMockDeps();
+      await joinVoiceChannel(params, deps);
+      mockRoomInstance.switchActiveDevice.mockClear();
+
+      mockRoomInstance.getActiveDevice.mockImplementation((kind: string) =>
+        kind === 'audioinput' ? 'mic-123' : 'default'
+      );
+      setDeviceList([defaultMic, defaultSpeaker]); // USB mic unplugged
+      await roomEventHandlers['mediaDevicesChanged']();
+
+      expect(mockRoomInstance.switchActiveDevice).toHaveBeenCalledTimes(1);
+      expect(mockRoomInstance.switchActiveDevice).toHaveBeenCalledWith('audioinput', 'default');
+      expect(deps.dispatch).toHaveBeenCalledWith({ type: VoiceActionType.SetSelectedAudioInputId, payload: 'default' });
+    });
+
+    it('switches back to the preferred mic when it is reconnected', async () => {
+      mockDevicePrefs({ audioInputDeviceId: 'mic-123', audioOutputDeviceId: 'default', videoInputDeviceId: 'default' });
+      setDeviceList([defaultMic, defaultSpeaker]); // preferred mic missing at join
+      const deps = createMockDeps();
+      await joinVoiceChannel(params, deps);
+      mockRoomInstance.switchActiveDevice.mockClear();
+
+      mockRoomInstance.getActiveDevice.mockReturnValue('default');
+      setDeviceList([defaultMic, usbMic, defaultSpeaker]); // USB mic plugged back in
+      await roomEventHandlers['mediaDevicesChanged']();
+
+      expect(mockRoomInstance.switchActiveDevice).toHaveBeenCalledTimes(1);
+      expect(mockRoomInstance.switchActiveDevice).toHaveBeenCalledWith('audioinput', 'mic-123');
+      expect(deps.dispatch).toHaveBeenCalledWith({ type: VoiceActionType.SetSelectedAudioInputId, payload: 'mic-123' });
+    });
+
+    it('does nothing on device change when the room is disconnected', async () => {
+      mockDevicePrefs(null);
+      setDeviceList([]);
+      const deps = createMockDeps();
+      await joinVoiceChannel(params, deps);
+      const room = deps.setRoom.mock.calls[0][0] as { state: string };
+      room.state = 'disconnected';
+      mockRoomInstance.switchActiveDevice.mockClear();
+
+      mockRoomInstance.getActiveDevice.mockReturnValue('mic-123');
+      setDeviceList([defaultMic, defaultSpeaker]);
+      await roomEventHandlers['mediaDevicesChanged']();
 
       expect(mockRoomInstance.switchActiveDevice).not.toHaveBeenCalled();
     });

--- a/frontend/src/features/voice/voiceActions.ts
+++ b/frontend/src/features/voice/voiceActions.ts
@@ -97,13 +97,82 @@ interface VoiceActionDeps {
   setRoom: (room: Room | null) => void;
 }
 
+function dispatchSelectedDevice(
+  dispatch: React.Dispatch<VoiceAction>,
+  kind: MediaDeviceKind,
+  deviceId: string
+) {
+  if (kind === 'audioinput') {
+    dispatch({ type: VoiceActionType.SetSelectedAudioInputId, payload: deviceId });
+  } else if (kind === 'audiooutput') {
+    dispatch({ type: VoiceActionType.SetSelectedAudioOutputId, payload: deviceId });
+  } else if (kind === 'videoinput') {
+    dispatch({ type: VoiceActionType.SetSelectedVideoInputId, payload: deviceId });
+  }
+}
+
+/**
+ * Handle OS-level device changes (plug/unplug) during an active call.
+ *
+ * livekit-client's built-in devicechange handling follows OS-default changes,
+ * but on Chromium it never moves audio input off a device that was unplugged,
+ * and it never returns to a preferred device that was plugged back in (#346).
+ * This runs after LiveKit's own handler (it fires on RoomEvent.MediaDevicesChanged,
+ * which LiveKit emits once its handling is done).
+ */
+async function handleMediaDevicesChanged(
+  room: Room,
+  dispatch: React.Dispatch<VoiceAction>
+) {
+  if (room.state !== 'connected') return;
+
+  try {
+    const prefs = getCachedItem<DevicePreferences>(DEVICE_PREFERENCES_KEY);
+    const devices = await navigator.mediaDevices.enumerateDevices();
+
+    const kinds: { kind: MediaDeviceKind; preferred: string | undefined }[] = [
+      { kind: 'audioinput', preferred: prefs?.audioInputDeviceId },
+      { kind: 'audiooutput', preferred: prefs?.audioOutputDeviceId },
+    ];
+
+    for (const { kind, preferred } of kinds) {
+      const available = devices.filter(d => d.kind === kind);
+      if (available.length === 0) continue;
+
+      const active = room.getActiveDevice(kind);
+
+      // The user's preferred device was plugged back in — return to it
+      if (preferred && preferred !== 'default' && preferred !== active &&
+          available.some(d => d.deviceId === preferred)) {
+        await room.switchActiveDevice(kind, preferred);
+        dispatchSelectedDevice(dispatch, kind, preferred);
+        logger.info('[Voice] Preferred', kind, 'device reconnected, switched back to:', preferred);
+        continue;
+      }
+
+      // The active device was unplugged — fall back to the default device
+      if (active && active !== 'default' && !available.some(d => d.deviceId === active)) {
+        const fallback = available.some(d => d.deviceId === 'default')
+          ? 'default'
+          : available[0].deviceId;
+        await room.switchActiveDevice(kind, fallback);
+        dispatchSelectedDevice(dispatch, kind, fallback);
+        logger.info('[Voice] Active', kind, 'device disconnected, fell back to:', fallback);
+      }
+    }
+  } catch (error) {
+    logger.warn('[Voice] Failed to handle media device change:', error);
+  }
+}
+
 /**
  * Shared helper to connect to LiveKit room and enable microphone
  */
 async function connectToLiveKitRoom(
   url: string,
   token: string,
-  setRoom: (room: Room | null) => void
+  setRoom: (room: Room | null) => void,
+  dispatch: React.Dispatch<VoiceAction>
 ): Promise<Room> {
   logger.info('[Voice] Creating new LiveKit room instance');
   const room = new Room({
@@ -128,6 +197,13 @@ async function connectToLiveKitRoom(
     }
     logger.error('[Voice] LiveKit disconnected unexpectedly, reason:', reason);
   });
+  // Keep voice state in sync when LiveKit switches devices on its own
+  // (OS default change, device plugged/unplugged mid-call).
+  room.on(RoomEvent.ActiveDeviceChanged, (kind: MediaDeviceKind, deviceId: string) => {
+    logger.info('[Voice] Active device changed:', kind, deviceId);
+    dispatchSelectedDevice(dispatch, kind, deviceId);
+  });
+  room.on(RoomEvent.MediaDevicesChanged, () => handleMediaDevicesChanged(room, dispatch));
 
   try {
     logger.info('[Voice] Connecting to LiveKit server:', url);
@@ -168,37 +244,36 @@ async function connectToLiveKitRoom(
   }
 
   const savedPreferences = getCachedItem<DevicePreferences>(DEVICE_PREFERENCES_KEY);
-  if (savedPreferences) {
-    logger.info('[Voice] Applying saved device preferences:', savedPreferences);
+  // Without a saved preference, bind to the browser's 'default' pseudo-device:
+  // Chromium reroutes 'default'-bound tracks when the OS default changes, which
+  // is what makes plugging in a headset mid-call switch audio over (#346).
+  // Browsers without a 'default' device (Firefox/Safari) skip this via the
+  // existence check below — LiveKit's own devicechange handling covers them.
+  const preferredAudioInput = savedPreferences?.audioInputDeviceId || 'default';
+  const preferredAudioOutput = savedPreferences?.audioOutputDeviceId || 'default';
+  logger.info('[Voice] Applying device preferences:', { preferredAudioInput, preferredAudioOutput });
 
-    try {
-      const devices = await navigator.mediaDevices.enumerateDevices();
-      const audioInputDevices = devices.filter(d => d.kind === 'audioinput');
-      const audioOutputDevices = devices.filter(d => d.kind === 'audiooutput');
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const audioInputDevices = devices.filter(d => d.kind === 'audioinput');
+    const audioOutputDevices = devices.filter(d => d.kind === 'audiooutput');
 
-      if (savedPreferences.audioInputDeviceId) {
-        if (savedPreferences.audioInputDeviceId === 'default' ||
-            audioInputDevices.some(d => d.deviceId === savedPreferences.audioInputDeviceId)) {
-          await room.switchActiveDevice('audioinput', savedPreferences.audioInputDeviceId);
-          logger.info('[Voice] Applied saved audio input device:', savedPreferences.audioInputDeviceId);
-        } else {
-          logger.warn('[Voice] Saved audio input device not found, using default. Saved ID:', savedPreferences.audioInputDeviceId);
-          logger.info('[Voice] Available audio input devices:', audioInputDevices.map(d => ({ id: d.deviceId, label: d.label })));
-        }
-      }
-
-      if (savedPreferences.audioOutputDeviceId) {
-        if (savedPreferences.audioOutputDeviceId === 'default' ||
-            audioOutputDevices.some(d => d.deviceId === savedPreferences.audioOutputDeviceId)) {
-          await room.switchActiveDevice('audiooutput', savedPreferences.audioOutputDeviceId);
-          logger.info('[Voice] Applied saved audio output device:', savedPreferences.audioOutputDeviceId);
-        } else {
-          logger.warn('[Voice] Saved audio output device not found, using default. Saved ID:', savedPreferences.audioOutputDeviceId);
-        }
-      }
-    } catch (error) {
-      logger.warn('[Voice] Failed to apply saved device preferences:', error);
+    if (audioInputDevices.some(d => d.deviceId === preferredAudioInput)) {
+      await room.switchActiveDevice('audioinput', preferredAudioInput);
+      logger.info('[Voice] Applied audio input device:', preferredAudioInput);
+    } else {
+      logger.warn('[Voice] Audio input device not available, leaving browser default. Wanted:', preferredAudioInput);
+      logger.info('[Voice] Available audio input devices:', audioInputDevices.map(d => ({ id: d.deviceId, label: d.label })));
     }
+
+    if (audioOutputDevices.some(d => d.deviceId === preferredAudioOutput)) {
+      await room.switchActiveDevice('audiooutput', preferredAudioOutput);
+      logger.info('[Voice] Applied audio output device:', preferredAudioOutput);
+    } else {
+      logger.warn('[Voice] Audio output device not available, leaving browser default. Wanted:', preferredAudioOutput);
+    }
+  } catch (error) {
+    logger.warn('[Voice] Failed to apply device preferences:', error);
   }
 
   logger.info('[Voice] Room connection complete');
@@ -258,7 +333,7 @@ export async function joinVoiceChannel(
     logger.info('[Voice] Got LiveKit token');
 
     logger.info('[Voice] Connecting to LiveKit room...');
-    await connectToLiveKitRoom(connectionInfo.url, tokenResponse.token, setRoom);
+    await connectToLiveKitRoom(connectionInfo.url, tokenResponse.token, setRoom, dispatch);
 
     dispatch({
       type: VoiceActionType.SetConnected,
@@ -379,7 +454,7 @@ export async function joinDmVoice(
       }
     }
 
-    await connectToLiveKitRoom(connectionInfo.url, tokenResponse.token, setRoom);
+    await connectToLiveKitRoom(connectionInfo.url, tokenResponse.token, setRoom, dispatch);
 
     dispatch({
       type: VoiceActionType.SetDmConnected,


### PR DESCRIPTION
Fixes #346

## Problem

Plugging in or unplugging an audio device while connected to voice chat did nothing — the call kept using the old device (or went silent) until the user rejoined.

Three gaps around OS-level device changes during a call:

1. **No `'default'` binding.** Unless the user had explicitly saved a device preference, the mic track was bound to a physical device at join time. Chromium only reroutes a live track to a new OS default when the track is bound to the `'default'` pseudo-device, so plugging in a headset mid-call never moved audio over.
2. **Unplugged mic goes silent.** livekit-client's built-in `devicechange` handling deliberately skips auto-switching `audioinput` on Chromium (it's Safari-only there), so unplugging the active mic silently killed outgoing audio.
3. **Stale state.** When LiveKit *does* auto-switch devices, it emits `RoomEvent.ActiveDeviceChanged` / `MediaDevicesChanged`, which the app never listened to — `VoiceContext`'s selected-device state went stale.

## Fix (all in `voiceActions.ts`)

- On join, apply device preferences with a `'default'` fallback when none are saved, gated on a `'default'` device actually existing (Chromium/Electron; Firefox/Safari skip it and rely on LiveKit's own handling).
- Listen to `RoomEvent.MediaDevicesChanged` (fires after LiveKit's own handler finishes) and cover the cases it skips on Chromium:
  - active audio device unplugged → fall back to `'default'` (or first available)
  - user's preferred device plugged back in → switch back to it
- Listen to `RoomEvent.ActiveDeviceChanged` and sync `VoiceContext`'s selected-device state. The saved preference in localStorage is intentionally *not* overwritten by automatic switches — only explicit user selection updates it.

## Testing

- 6 new unit tests in `voiceActions.test.ts` covering default binding (and skipping it without a `'default'` device), unplug fallback, preferred-device reconnect, `ActiveDeviceChanged` state sync, and the disconnected-room guard; livekit mock extended to capture room event handlers. 35/35 pass.
- Full frontend suite: failures match the pre-existing flaky-timeout baseline on `main` (12–15 random 5s timeouts, different files each run); no failures attributable to this change.
- Backend suite: 2133/2133 pass (untouched by this change).
- Lint: 0 errors. `tsc --noEmit`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)