### PR TITLE
fix: real frontend type-check (349 errors → 0) + un-break the E2E workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -191,12 +191,15 @@ jobs:
         run: |
           # Full suite: push to main, schedule, manual dispatch, or PR with "e2e-full" label
           # Smoke only: PR without the label
+          # Voice specs are excluded: they need the real-LiveKit harness and run
+          # in the separate voice-e2e job (nightly/dispatch). Project selection
+          # keeps the `voice` project out; `setup` runs as a chromium dependency.
           if [ "${{ github.event_name }}" = "pull_request" ] && ! echo "${{ join(github.event.pull_request.labels.*.name, ',') }}" | grep -q "e2e-full"; then
             echo "Running smoke tests only (PR without e2e-full label)"
-            pnpm exec playwright test --grep @smoke
+            pnpm exec playwright test --project=chromium --project=auth-tests --grep @smoke
           else
             echo "Running full E2E suite (${{ github.event_name }} trigger)"
-            pnpm exec playwright test
+            pnpm exec playwright test --project=chromium --project=auth-tests
           fi
         env:
           E2E_BASE_URL: http://localhost:5174

--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -60,7 +60,9 @@ jobs:
 
       - name: Type check with TypeScript
         working-directory: frontend
-        run: pnpm exec tsc --noEmit
+        # Bare `tsc --noEmit` against the solution-style root tsconfig checks
+        # nothing (#356) — `type-check` runs reference-aware `tsc -b`
+        run: pnpm run type-check
 
   build-windows:
     name: Build Windows Installer

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -48,7 +48,9 @@ jobs:
 
       - name: Type check with TypeScript
         working-directory: ./frontend
-        run: pnpm exec tsc --noEmit
+        # Bare `tsc --noEmit` against the solution-style root tsconfig checks
+        # nothing (#356) — `type-check` runs reference-aware `tsc -b`
+        run: pnpm run type-check
 
       - name: Run unit tests with coverage
         working-directory: ./frontend

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -57,8 +57,10 @@ FROM node:24-alpine AS production
 ARG GITHUB_REPOSITORY=user/semaphore-chat
 ARG BUILD_DATE
 
-# Install OpenSSL for Prisma and FFmpeg for video processing (replay clips)
-RUN apk add --no-cache openssl ffmpeg
+# Pull in Alpine security patches (base image can lag fixed packages, which
+# fails the Trivy gate in CI), then install OpenSSL for Prisma and FFmpeg for
+# video processing (replay clips)
+RUN apk upgrade --no-cache && apk add --no-cache openssl ffmpeg
 
 # Create non-root user for security
 RUN addgroup -g 1001 -S nodejs && \

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -10129,8 +10129,15 @@
       "DebugPushSubscriptionDto": {
         "type": "object",
         "properties": {
+          "id": {
+            "type": "string"
+          },
           "endpoint": {
             "type": "string"
+          },
+          "userAgent": {
+            "type": "string",
+            "nullable": true
           },
           "createdAt": {
             "format": "date-time",
@@ -10138,6 +10145,7 @@
           }
         },
         "required": [
+          "id",
           "endpoint",
           "createdAt"
         ]

--- a/backend/src/notifications/dto/notification-response.dto.ts
+++ b/backend/src/notifications/dto/notification-response.dto.ts
@@ -77,7 +77,9 @@ export class DebugNotificationResponseDto {
 }
 
 export class DebugPushSubscriptionDto {
+  id: string;
   endpoint: string;
+  userAgent?: string | null;
   createdAt: Date;
 }
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -52,8 +52,10 @@ FROM nginx:1.29-alpine AS production
 ARG GITHUB_REPOSITORY=user/semaphore-chat
 ARG BUILD_DATE
 
-# Install gettext for envsubst (environment variable substitution)
-RUN apk add --no-cache gettext
+# Pull in Alpine security patches first — the nginx base image can lag fixed
+# packages (e.g. openssl CVEs in libcrypto3/libssl3), which fails the Trivy
+# gate in CI. Then install gettext for envsubst (env variable substitution).
+RUN apk upgrade --no-cache && apk add --no-cache gettext
 
 # Remove default nginx config
 RUN rm /etc/nginx/nginx.conf

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -36,7 +36,10 @@ export default defineConfig({
     // Auth setup — runs once, saves storageState for reuse
     { name: 'setup', testMatch: /.*\.setup\.ts/ },
 
-    // Main tests — use saved auth state (skip auth.spec.ts which tests auth itself)
+    // Main tests — use saved auth state (skip auth.spec.ts which tests auth
+    // itself, and voice/ which needs the real-LiveKit harness in the `voice`
+    // project — without this ignore, voice specs run here too and fail on
+    // every push because the standard e2e stack has no LiveKit server)
     {
       name: 'chromium',
       use: {
@@ -44,7 +47,7 @@ export default defineConfig({
         storageState: 'e2e/.auth/user.json',
       },
       dependencies: ['setup'],
-      testIgnore: /auth\.spec\.ts/,
+      testIgnore: [/auth\.spec\.ts/, /voice\//],
     },
 
     // Auth tests — run without saved state so they can test login/register flows

--- a/frontend/src/__tests__/components/DmListItem.test.tsx
+++ b/frontend/src/__tests__/components/DmListItem.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { screen } from '@testing-library/react';
 import { renderWithProviders, createDmGroup, createDmGroupMember } from '../test-utils';
 import DmListItem from '../../components/DirectMessages/DmListItem';
@@ -47,10 +47,10 @@ const thirdMember = createDmGroupMember({
 });
 
 describe('DmListItem', () => {
-  let onClick: ReturnType<typeof vi.fn>;
+  let onClick: Mock<() => void>;
 
   beforeEach(() => {
-    onClick = vi.fn();
+    onClick = vi.fn<() => void>();
   });
 
   it('renders display name for 1:1 DM (other user displayName)', () => {
@@ -113,8 +113,8 @@ describe('DmListItem', () => {
       lastMessage: {
         id: 'msg-1',
         authorId: 'other-user',
-        spans: [{ type: 'PLAINTEXT', text: 'Hey there!' }],
-        sentAt: new Date(Date.now() - 5 * 60 * 1000),
+        spans: [{ type: 'PLAINTEXT', text: 'Hey there!', userId: null, specialKind: null, communityId: null, aliasId: null }],
+        sentAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
       },
     });
 

--- a/frontend/src/__tests__/components/MessageContainer.test.tsx
+++ b/frontend/src/__tests__/components/MessageContainer.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import { screen, waitFor, act } from '@testing-library/react';
 import { renderWithProviders } from '../test-utils';
 import MessageContainer from '../../components/Message/MessageContainer';
@@ -9,9 +9,9 @@ type MockObserverInstance = {
   callback: IntersectionObserverCallback;
   options: IntersectionObserverInit | undefined;
   elements: Set<Element>;
-  observe: ReturnType<typeof vi.fn>;
-  unobserve: ReturnType<typeof vi.fn>;
-  disconnect: ReturnType<typeof vi.fn>;
+  observe: Mock<(el: Element) => void>;
+  unobserve: Mock<(el: Element) => void>;
+  disconnect: Mock<() => void>;
   trigger: (entries: Partial<IntersectionObserverEntry>[]) => void;
 };
 
@@ -24,9 +24,9 @@ class MockIntersectionObserver {
       callback,
       options,
       elements: new Set(),
-      observe: vi.fn((el: Element) => instance.elements.add(el)),
-      unobserve: vi.fn((el: Element) => instance.elements.delete(el)),
-      disconnect: vi.fn(() => instance.elements.clear()),
+      observe: vi.fn((el: Element) => { instance.elements.add(el); }),
+      unobserve: vi.fn((el: Element) => { instance.elements.delete(el); }),
+      disconnect: vi.fn(() => { instance.elements.clear(); }),
       trigger: (entries: Partial<IntersectionObserverEntry>[]) => {
         callback(
           entries as IntersectionObserverEntry[],

--- a/frontend/src/__tests__/components/MobileChatPanel.test.tsx
+++ b/frontend/src/__tests__/components/MobileChatPanel.test.tsx
@@ -30,8 +30,8 @@ vi.mock('../../api-client/@tanstack/react-query.gen', () => ({
 }));
 
 // Track which container gets rendered
-const mockChannelMessageContainer = vi.fn(() => <div data-testid="channel-message-container" />);
-const mockDirectMessageContainer = vi.fn(() => <div data-testid="direct-message-container" />);
+const mockChannelMessageContainer = vi.fn((_props: Record<string, unknown>) => <div data-testid="channel-message-container" />);
+const mockDirectMessageContainer = vi.fn((_props: Record<string, unknown>) => <div data-testid="direct-message-container" />);
 
 vi.mock('../../components/Channel/ChannelMessageContainer', () => ({
   default: (props: Record<string, unknown>) => {

--- a/frontend/src/__tests__/components/NotificationBadge.test.tsx
+++ b/frontend/src/__tests__/components/NotificationBadge.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { screen } from '@testing-library/react';
 import { renderWithProviders, createTestQueryClient } from '../test-utils';
 import { NotificationBadge } from '../../components/Notifications/NotificationBadge';
@@ -11,11 +11,11 @@ vi.mock('../../api-client/client.gen', () => ({
 }));
 
 describe('NotificationBadge', () => {
-  let onClick: ReturnType<typeof vi.fn>;
+  let onClick: Mock<() => void>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    onClick = vi.fn();
+    onClick = vi.fn<() => void>();
   });
 
   it('renders with unread count from query cache', () => {
@@ -63,6 +63,6 @@ describe('NotificationBadge', () => {
     );
     // The query should exist but should not have a refetch interval set
     expect(unreadQuery).toBeDefined();
-    expect(unreadQuery?.options.refetchInterval).toBeUndefined();
+    expect((unreadQuery?.options as { refetchInterval?: unknown } | undefined)?.refetchInterval).toBeUndefined();
   });
 });

--- a/frontend/src/__tests__/components/ScreenShareVolumeControl.test.tsx
+++ b/frontend/src/__tests__/components/ScreenShareVolumeControl.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ScreenShareVolumeControl from '../../components/Voice/ScreenShareVolumeControl';
@@ -69,8 +69,8 @@ vi.mock('@mui/material/styles', async (importOriginal) => {
 });
 
 describe('ScreenShareVolumeControl', () => {
-  let localStorageGetSpy: ReturnType<typeof vi.spyOn>;
-  let localStorageSetSpy: ReturnType<typeof vi.spyOn>;
+  let localStorageGetSpy: MockInstance<Storage['getItem']>;
+  let localStorageSetSpy: MockInstance<Storage['setItem']>;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/__tests__/components/UserModerationMenu.test.tsx
+++ b/frontend/src/__tests__/components/UserModerationMenu.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { renderWithProviders } from '../test-utils';

--- a/frontend/src/__tests__/components/UserSearchAutocomplete.test.tsx
+++ b/frontend/src/__tests__/components/UserSearchAutocomplete.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest';
 import { screen, within, waitFor } from '@testing-library/react';
 import { Chip } from '@mui/material';

--- a/frontend/src/__tests__/components/VoiceBottomBar.test.tsx
+++ b/frontend/src/__tests__/components/VoiceBottomBar.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { renderWithProviders } from '../test-utils';
 import { VoiceBottomBar } from '../../components/Voice/VoiceBottomBar';
-import { VoiceSessionType } from '../../contexts/VoiceContext';
+import { VoiceSessionType, type VoiceState } from '../../contexts/VoiceContext';
 
 vi.mock('../../api-client/client.gen', async (importOriginal) => {
   const { createClient, createConfig } = await import('../../api-client/client');
@@ -29,7 +29,7 @@ const mockActions = {
   switchAudioOutputDevice: vi.fn(),
 };
 
-const defaultVoiceState = {
+const defaultVoiceState: VoiceState & { room: null } = {
   isConnected: true,
   isConnecting: false,
   connectionError: null,
@@ -49,6 +49,10 @@ const defaultVoiceState = {
   selectedAudioInputId: null,
   selectedAudioOutputId: null,
   selectedVideoInputId: null,
+  wasMutedBeforeDeafen: false,
+  watchingCameras: new Set<string>(),
+  watchingScreenShares: new Set<string>(),
+  hiddenLocalTiles: new Set<string>(),
   room: null,
 };
 
@@ -485,7 +489,7 @@ describe('VoiceBottomBar', () => {
       if (savedSetSinkId) {
         Object.defineProperty(HTMLMediaElement.prototype, 'setSinkId', savedSetSinkId);
       } else {
-        delete (HTMLMediaElement.prototype as Record<string, unknown>).setSinkId;
+        delete (HTMLMediaElement.prototype as unknown as Record<string, unknown>).setSinkId;
       }
     });
 
@@ -499,7 +503,7 @@ describe('VoiceBottomBar', () => {
 
     function disableSetSinkId() {
       if ('setSinkId' in HTMLMediaElement.prototype) {
-        delete (HTMLMediaElement.prototype as Record<string, unknown>).setSinkId;
+        delete (HTMLMediaElement.prototype as unknown as Record<string, unknown>).setSinkId;
       }
     }
 

--- a/frontend/src/__tests__/components/VoiceChannelUserList.test.tsx
+++ b/frontend/src/__tests__/components/VoiceChannelUserList.test.tsx
@@ -4,7 +4,20 @@ import { renderWithProviders } from '../test-utils';
 import { VoiceChannelUserList } from '../../components/Voice/VoiceChannelUserList';
 import { ChannelType } from '../../types/channel.type';
 import { VoiceSessionType } from '../../contexts/VoiceContext';
-import { EventEmitter } from 'events';
+
+/** Minimal EventEmitter — only on/off are used by the mock room */
+class EventEmitter {
+  private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  on(event: string, listener: (...args: unknown[]) => void) {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(listener);
+    return this;
+  }
+  off(event: string, listener: (...args: unknown[]) => void) {
+    this.listeners.get(event)?.delete(listener);
+    return this;
+  }
+}
 
 // Mock API client
 vi.mock('../../api-client/client.gen', async (importOriginal) => {
@@ -188,6 +201,8 @@ const voiceChannel = {
   communityId: 'c1',
   isPrivate: false,
   createdAt: '2025-01-01T00:00:00Z',
+  position: 0,
+  slowmodeSeconds: 0,
 };
 
 describe('VoiceChannelUserList - Clickable Icons', () => {

--- a/frontend/src/__tests__/components/VoiceSettings.test.tsx
+++ b/frontend/src/__tests__/components/VoiceSettings.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
-import React from 'react';
 
 const mocks = vi.hoisted(() => ({
   switchAudioInputDevice: vi.fn(),

--- a/frontend/src/__tests__/contexts/FileCacheContext.test.tsx
+++ b/frontend/src/__tests__/contexts/FileCacheContext.test.tsx
@@ -21,9 +21,9 @@ const mockCreateObjectURL = vi.fn();
 const mockRevokeObjectURL = vi.fn();
 
 beforeEach(() => {
-  global.fetch = mockFetch;
-  global.URL.createObjectURL = mockCreateObjectURL;
-  global.URL.revokeObjectURL = mockRevokeObjectURL;
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
+  globalThis.URL.createObjectURL = mockCreateObjectURL as unknown as typeof URL.createObjectURL;
+  globalThis.URL.revokeObjectURL = mockRevokeObjectURL as unknown as typeof URL.revokeObjectURL;
 
   // Reset mock return value (vi.clearAllMocks does NOT reset mockReturnValue)
   vi.mocked(getAccessToken).mockReturnValue('mock-jwt-token');

--- a/frontend/src/__tests__/contexts/ThreadPanelContext.test.tsx
+++ b/frontend/src/__tests__/contexts/ThreadPanelContext.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/frontend/src/__tests__/features/voiceActions.test.ts
+++ b/frontend/src/__tests__/features/voiceActions.test.ts
@@ -102,7 +102,8 @@ import {
   switchAudioInputDevice,
   switchAudioOutputDevice,
 } from '../../features/voice/voiceActions';
-import { VoiceActionType, VoiceSessionType } from '../../contexts/VoiceContext';
+import { VoiceActionType, VoiceSessionType, type VoiceState } from '../../contexts/VoiceContext';
+import type { Room } from 'livekit-client';
 import { livekitControllerGenerateToken, voicePresenceControllerJoinPresence, voicePresenceControllerLeavePresence, voicePresenceControllerUpdateDeafenState } from '../../api-client/sdk.gen';
 import { getCachedItem } from '../../utils/storage';
 
@@ -119,17 +120,17 @@ function createMockDeps(overrides: Partial<{
   const room = hasRoomOverride ? overrides.room : mockRoomInstance;
   return {
     dispatch,
-    getVoiceState: () => ({
+    getVoiceState: (): VoiceState => ({
       isConnected: true,
       isConnecting: false,
       connectionError: null,
       contextType: VoiceSessionType.Channel,
-      currentChannelId: 'channelId' in overrides ? overrides.channelId : 'ch-1',
+      currentChannelId: 'channelId' in overrides ? (overrides.channelId ?? null) : 'ch-1',
       channelName: 'General',
       communityId: 'c1',
       isPrivate: false,
       createdAt: '2025-01-01',
-      currentDmGroupId: 'dmGroupId' in overrides ? overrides.dmGroupId : null,
+      currentDmGroupId: 'dmGroupId' in overrides ? (overrides.dmGroupId ?? null) : null,
       dmGroupName: null,
       isDeafened: overrides.isDeafened ?? false,
       isServerMuted: overrides.isServerMuted ?? false,
@@ -140,8 +141,11 @@ function createMockDeps(overrides: Partial<{
       selectedAudioOutputId: null,
       selectedVideoInputId: null,
       wasMutedBeforeDeafen: overrides.wasMutedBeforeDeafen ?? false,
+      watchingCameras: new Set<string>(),
+      watchingScreenShares: new Set<string>(),
+      hiddenLocalTiles: new Set<string>(),
     }),
-    getRoom: () => room as never,
+    getRoom: () => room as Room | null,
     setRoom: vi.fn(),
   };
 }

--- a/frontend/src/__tests__/hooks/useBackgroundVoiceKeepAlive.test.ts
+++ b/frontend/src/__tests__/hooks/useBackgroundVoiceKeepAlive.test.ts
@@ -37,7 +37,7 @@ describe('useBackgroundVoiceKeepAlive', () => {
     });
 
     // Clean window.electronAPI
-    (window as Record<string, unknown>).electronAPI = undefined;
+    (window as unknown as Record<string, unknown>).electronAPI = undefined;
   });
 
   afterEach(() => {
@@ -96,7 +96,7 @@ describe('useBackgroundVoiceKeepAlive', () => {
 
   it('should request power save block in Electron when connected', async () => {
     mockIsElectron = true;
-    (window as Record<string, unknown>).electronAPI = {
+    (window as unknown as Record<string, unknown>).electronAPI = {
       isElectron: true,
       requestPowerSaveBlock: mockRequestPowerSaveBlock,
       releasePowerSaveBlock: mockReleasePowerSaveBlock,
@@ -112,7 +112,7 @@ describe('useBackgroundVoiceKeepAlive', () => {
 
   it('should release power save block in Electron on unmount', async () => {
     mockIsElectron = true;
-    (window as Record<string, unknown>).electronAPI = {
+    (window as unknown as Record<string, unknown>).electronAPI = {
       isElectron: true,
       requestPowerSaveBlock: mockRequestPowerSaveBlock,
       releasePowerSaveBlock: mockReleasePowerSaveBlock,

--- a/frontend/src/__tests__/hooks/useSendMessage.test.ts
+++ b/frontend/src/__tests__/hooks/useSendMessage.test.ts
@@ -88,8 +88,8 @@ describe('useSendMessage', () => {
     });
 
     it('returns success with messageId on acknowledgment', async () => {
-      mockSocket.emit.mockImplementation((_event: string, _payload: unknown, ack: (id: string) => void) => {
-        ack('msg-123');
+      mockSocket.emit.mockImplementation((_event, _payload, ack) => {
+        (ack as (id: string) => void)('msg-123');
       });
 
       const { result } = renderSendMessage(VoiceSessionType.Channel);
@@ -105,8 +105,8 @@ describe('useSendMessage', () => {
 
     it('calls callback with messageId on success', async () => {
       const callback = vi.fn();
-      mockSocket.emit.mockImplementation((_event: string, _payload: unknown, ack: (id: string) => void) => {
-        ack('msg-456');
+      mockSocket.emit.mockImplementation((_event, _payload, ack) => {
+        (ack as (id: string) => void)('msg-456');
       });
 
       const { result } = renderSendMessage(VoiceSessionType.Channel, { callback });
@@ -132,8 +132,8 @@ describe('useSendMessage', () => {
 
     it('waits for reconnection when socket is disconnected', async () => {
       mockSocket.connected = false;
-      mockSocket.emit.mockImplementation((_event: string, _payload: unknown, ack: (id: string) => void) => {
-        ack('msg-reconnected');
+      mockSocket.emit.mockImplementation((_event, _payload, ack) => {
+        (ack as (id: string) => void)('msg-reconnected');
       });
 
       const { result } = renderSendMessage(VoiceSessionType.Channel, { isConnected: false });

--- a/frontend/src/__tests__/integration/voiceLifecycle.test.tsx
+++ b/frontend/src/__tests__/integration/voiceLifecycle.test.tsx
@@ -16,7 +16,7 @@
  * downstream WebRTC behaviour depends on.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import { render, act } from '@testing-library/react';
 import React, { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -130,7 +130,12 @@ function createFakeAudioTrack(): FakeAudioTrack {
 
 // Use a class so `instanceof RemoteTrackPublication` from the mock passes for
 // objects created via Object.create(prototype) when we extend it.
-import { RemoteTrackPublication as MockRTP } from 'livekit-client';
+import { RemoteTrackPublication } from 'livekit-client';
+
+// At runtime this is the bare mock class above (no ctor args, no accessors),
+// but TS sees the real livekit-client type — cast to a loose base so our fake
+// fields don't clash with the real class's accessors and constructor.
+const MockRTP = RemoteTrackPublication as unknown as new () => object;
 
 class FakeRemoteTrackPublication extends MockRTP {
   source: string;
@@ -140,7 +145,7 @@ class FakeRemoteTrackPublication extends MockRTP {
   subscriptionStatus: string;
   isMuted: boolean;
   track?: FakeAudioTrack;
-  setSubscribedSpy: ReturnType<typeof vi.fn>;
+  setSubscribedSpy: Mock<(subscribed: boolean) => void>;
 
   constructor(source: string, opts: { withTrack?: boolean; isMuted?: boolean } = {}) {
     super();

--- a/frontend/src/__tests__/socket-hub/handlers/messageHandlers.test.ts
+++ b/frontend/src/__tests__/socket-hub/handlers/messageHandlers.test.ts
@@ -33,7 +33,7 @@ function makeMessage(overrides: Record<string, unknown> = {}) {
 
 function makeInfiniteData(messages: ReturnType<typeof makeMessage>[]): InfiniteData<PaginatedMessagesResponseDto> {
   return {
-    pages: [{ messages: messages as never[], continuationToken: null }],
+    pages: [{ messages: messages as never[], continuationToken: undefined }],
     pageParams: [undefined],
   };
 }

--- a/frontend/src/__tests__/socket-hub/handlers/messageHandlers.test.ts
+++ b/frontend/src/__tests__/socket-hub/handlers/messageHandlers.test.ts
@@ -6,6 +6,8 @@ import {
   handleNewMessage,
   handleUpdateMessage,
   handleDeleteMessage,
+  handleMessageUnpinned,
+  handleThreadReplyCountUpdated,
   handleReadReceiptUpdated,
 } from '../../../socket-hub/handlers/messageHandlers';
 import { channelMessagesQueryKey } from '../../../utils/messageQueryKeys';
@@ -99,6 +101,55 @@ describe('messageHandlers', () => {
 
       const data = queryClient.getQueryData<InfiniteData<PaginatedMessagesResponseDto>>(queryKey);
       expect(data!.pages[0].messages).toHaveLength(0);
+    });
+  });
+
+  describe('handleMessageUnpinned', () => {
+    it('clears pin fields with explicit nulls (matching server DTO shape)', async () => {
+      const queryClient = new QueryClient();
+      const msg = makeMessage({
+        id: 'msg-1',
+        pinned: true,
+        pinnedBy: 'user-2',
+        pinnedAt: '2024-01-02T00:00:00Z',
+      });
+      const queryKey = channelMessagesQueryKey('ch-1');
+
+      queryClient.setQueryData(queryKey, makeInfiniteData([msg]));
+
+      await handleMessageUnpinned({ messageId: 'msg-1', channelId: 'ch-1', unpinnedBy: 'user-2' }, queryClient);
+
+      const data = queryClient.getQueryData<InfiniteData<PaginatedMessagesResponseDto>>(queryKey);
+      const updated = data!.pages[0].messages[0];
+      expect(updated.pinned).toBe(false);
+      expect(updated.pinnedBy).toBeNull();
+      expect(updated.pinnedAt).toBeNull();
+    });
+  });
+
+  describe('handleThreadReplyCountUpdated', () => {
+    it('preserves a null lastReplyAt instead of converting it to undefined', async () => {
+      const queryClient = new QueryClient();
+      const msg = makeMessage({ id: 'msg-1', replyCount: 1, lastReplyAt: '2024-01-02T00:00:00Z' });
+      const queryKey = channelMessagesQueryKey('ch-1');
+
+      queryClient.setQueryData(queryKey, makeInfiniteData([msg]));
+
+      await handleThreadReplyCountUpdated(
+        {
+          parentMessageId: 'msg-1',
+          replyCount: 0,
+          lastReplyAt: null,
+          channelId: 'ch-1',
+          directMessageGroupId: null,
+        },
+        queryClient,
+      );
+
+      const data = queryClient.getQueryData<InfiniteData<PaginatedMessagesResponseDto>>(queryKey);
+      const updated = data!.pages[0].messages[0];
+      expect(updated.replyCount).toBe(0);
+      expect(updated.lastReplyAt).toBeNull();
     });
   });
 

--- a/frontend/src/__tests__/socket-hub/handlers/notificationHandlers.test.ts
+++ b/frontend/src/__tests__/socket-hub/handlers/notificationHandlers.test.ts
@@ -363,12 +363,19 @@ describe('notificationHandlers', () => {
 
       const data = queryClient.getQueryData<NotificationListResponseDto>(notificationsKey);
       const notif = data!.notifications[0];
-      expect(notif.author).toEqual({ id: 'u-5', username: 'bob', avatarUrl: 'https://img.test/avatar.png' });
+      expect(notif.author).toEqual({
+        id: 'u-5',
+        username: 'bob',
+        displayName: null,
+        avatarUrl: 'https://img.test/avatar.png',
+      });
       expect(notif.message).toEqual({
         id: 'msg-10',
+        channelId: 'ch-1',
+        directMessageGroupId: null,
         spans: [
-          { type: 'MENTION', text: '@alice', userId: 'u-1' },
-          { type: 'PLAINTEXT', text: ' hey', userId: undefined },
+          { type: 'MENTION', text: '@alice', userId: 'u-1', specialKind: null, communityId: null, aliasId: null },
+          { type: 'PLAINTEXT', text: ' hey', userId: null, specialKind: null, communityId: null, aliasId: null },
         ],
       });
     });

--- a/frontend/src/__tests__/socket-hub/handlers/reconnectHandlers.test.ts
+++ b/frontend/src/__tests__/socket-hub/handlers/reconnectHandlers.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, type MockInstance } from 'vitest';
 import { QueryClient } from '@tanstack/react-query';
 import { handleReconnect } from '../../../socket-hub/handlers/reconnectHandlers';
 
 describe('handleReconnect', () => {
   let queryClient: QueryClient;
-  let invalidateSpy: ReturnType<typeof vi.spyOn>;
+  let invalidateSpy: MockInstance<QueryClient['invalidateQueries']>;
 
   beforeEach(() => {
     queryClient = new QueryClient();

--- a/frontend/src/__tests__/socket-hub/handlers/roleHandlers.test.ts
+++ b/frontend/src/__tests__/socket-hub/handlers/roleHandlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, type MockInstance } from 'vitest';
 import { QueryClient } from '@tanstack/react-query';
 import {
   handleRoleCreated,
@@ -10,7 +10,7 @@ import {
 
 describe('roleHandlers', () => {
   let queryClient: QueryClient;
-  let invalidateSpy: ReturnType<typeof vi.spyOn>;
+  let invalidateSpy: MockInstance<QueryClient['invalidateQueries']>;
 
   beforeEach(() => {
     queryClient = new QueryClient();

--- a/frontend/src/__tests__/socket-hub/handlers/threadHandlers.test.ts
+++ b/frontend/src/__tests__/socket-hub/handlers/threadHandlers.test.ts
@@ -26,7 +26,7 @@ describe('threadHandlers', () => {
       const key = getRepliesKey('parent-1');
       const existing: ThreadRepliesResponseDto = {
         replies: [makeReply('r1') as never],
-        continuationToken: null,
+        continuationToken: undefined,
       };
       queryClient.setQueryData(key, existing);
 

--- a/frontend/src/__tests__/socket-hub/handlers/voiceHandlers.test.ts
+++ b/frontend/src/__tests__/socket-hub/handlers/voiceHandlers.test.ts
@@ -23,7 +23,21 @@ import {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeVoiceUser(overrides: Partial<VoicePresenceUserDto> = {}): VoicePresenceUserDto {
+/**
+ * The websocket presence payloads carry live media state (mute/camera/screen)
+ * on top of the REST VoicePresenceUserDto, and the handlers store them in the
+ * cache as-is — model that with an extended test type.
+ */
+type TestVoiceUser = VoicePresenceUserDto & {
+  isMuted: boolean;
+  isCameraOn: boolean;
+  isScreenSharing: boolean;
+};
+
+type TestChannelPresence = Omit<ChannelVoicePresenceResponseDto, 'users'> & { users: TestVoiceUser[] };
+type TestDmPresence = Omit<DmVoicePresenceResponseDto, 'users'> & { users: TestVoiceUser[] };
+
+function makeVoiceUser(overrides: Partial<TestVoiceUser> = {}): TestVoiceUser {
   return {
     id: 'user-1',
     username: 'alice',
@@ -33,19 +47,19 @@ function makeVoiceUser(overrides: Partial<VoicePresenceUserDto> = {}): VoicePres
     isCameraOn: false,
     isScreenSharing: false,
     ...overrides,
-  } as VoicePresenceUserDto;
+  } as TestVoiceUser;
 }
 
 function makeChannelPresence(
-  users: VoicePresenceUserDto[],
-): ChannelVoicePresenceResponseDto {
-  return { users, count: users.length } as ChannelVoicePresenceResponseDto;
+  users: TestVoiceUser[],
+): TestChannelPresence {
+  return { users, count: users.length } as TestChannelPresence;
 }
 
 function makeDmPresence(
-  users: VoicePresenceUserDto[],
-): DmVoicePresenceResponseDto {
-  return { users, count: users.length } as DmVoicePresenceResponseDto;
+  users: TestVoiceUser[],
+): TestDmPresence {
+  return { users, count: users.length } as TestDmPresence;
 }
 
 // ---------------------------------------------------------------------------
@@ -68,7 +82,7 @@ describe('voiceHandlers — channel', () => {
       const user = makeVoiceUser({ id: 'user-1' });
       handleVoiceUserJoined({ channelId, user } as never, queryClient);
 
-      const data = queryClient.getQueryData<ChannelVoicePresenceResponseDto>(queryKey);
+      const data = queryClient.getQueryData<TestChannelPresence>(queryKey);
       expect(data!.users).toHaveLength(1);
       expect(data!.users[0].id).toBe('user-1');
       expect(data!.count).toBe(1);
@@ -81,7 +95,7 @@ describe('voiceHandlers — channel', () => {
 
       handleVoiceUserJoined({ channelId, user: existing } as never, queryClient);
 
-      const data = queryClient.getQueryData<ChannelVoicePresenceResponseDto>(queryKey);
+      const data = queryClient.getQueryData<TestChannelPresence>(queryKey);
       expect(data!.users).toHaveLength(1);
       expect(data!.count).toBe(1);
     });
@@ -101,7 +115,7 @@ describe('voiceHandlers — channel', () => {
 
       handleVoiceUserJoined({ channelId, user: makeVoiceUser({ id: 'user-2', username: 'bob' }) } as never, queryClient);
 
-      const data = queryClient.getQueryData<ChannelVoicePresenceResponseDto>(queryKey);
+      const data = queryClient.getQueryData<TestChannelPresence>(queryKey);
       expect(data!.users).toHaveLength(2);
       expect(data!.count).toBe(2);
     });
@@ -115,7 +129,7 @@ describe('voiceHandlers — channel', () => {
 
       handleVoiceUserLeft({ channelId, userId: 'user-1' } as never, queryClient);
 
-      const data = queryClient.getQueryData<ChannelVoicePresenceResponseDto>(queryKey);
+      const data = queryClient.getQueryData<TestChannelPresence>(queryKey);
       expect(data!.users).toHaveLength(0);
       expect(data!.count).toBe(0);
     });
@@ -127,7 +141,7 @@ describe('voiceHandlers — channel', () => {
 
       handleVoiceUserLeft({ channelId, userId: 'user-999' } as never, queryClient);
 
-      const data = queryClient.getQueryData<ChannelVoicePresenceResponseDto>(queryKey);
+      const data = queryClient.getQueryData<TestChannelPresence>(queryKey);
       expect(data!.users).toHaveLength(1);
       expect(data!.count).toBe(1);
     });
@@ -150,7 +164,7 @@ describe('voiceHandlers — channel', () => {
       const updatedUser = makeVoiceUser({ id: 'user-1', isMuted: true });
       handleVoiceUserUpdated({ channelId, user: updatedUser } as never, queryClient);
 
-      const data = queryClient.getQueryData<ChannelVoicePresenceResponseDto>(queryKey);
+      const data = queryClient.getQueryData<TestChannelPresence>(queryKey);
       expect(data!.users[0].isMuted).toBe(true);
     });
 
@@ -162,7 +176,7 @@ describe('voiceHandlers — channel', () => {
       const unknownUser = makeVoiceUser({ id: 'user-999', isMuted: true });
       handleVoiceUserUpdated({ channelId, user: unknownUser } as never, queryClient);
 
-      const data = queryClient.getQueryData<ChannelVoicePresenceResponseDto>(queryKey);
+      const data = queryClient.getQueryData<TestChannelPresence>(queryKey);
       expect(data!.users).toHaveLength(1);
       expect(data!.users[0].id).toBe('user-1');
     });
@@ -183,7 +197,7 @@ describe('voiceHandlers — channel', () => {
 
       handleVoiceUserUpdated({ channelId, user: makeVoiceUser({ id: 'user-1', isMuted: true }) } as never, queryClient);
 
-      const data = queryClient.getQueryData<ChannelVoicePresenceResponseDto>(queryKey);
+      const data = queryClient.getQueryData<TestChannelPresence>(queryKey);
       expect(data!.users).toHaveLength(2);
       expect(data!.users[0].isMuted).toBe(true);
       expect(data!.users[1].id).toBe('user-2');
@@ -222,7 +236,7 @@ describe('voiceHandlers — DM', () => {
       const user = makeVoiceUser({ id: 'user-1' });
       handleDmVoiceUserJoined({ dmGroupId, user } as never, queryClient);
 
-      const data = queryClient.getQueryData<DmVoicePresenceResponseDto>(queryKey);
+      const data = queryClient.getQueryData<TestDmPresence>(queryKey);
       expect(data!.users).toHaveLength(1);
       expect(data!.count).toBe(1);
     });
@@ -234,7 +248,7 @@ describe('voiceHandlers — DM', () => {
 
       handleDmVoiceUserJoined({ dmGroupId, user } as never, queryClient);
 
-      const data = queryClient.getQueryData<DmVoicePresenceResponseDto>(queryKey);
+      const data = queryClient.getQueryData<TestDmPresence>(queryKey);
       expect(data!.users).toHaveLength(1);
     });
 
@@ -255,7 +269,7 @@ describe('voiceHandlers — DM', () => {
 
       handleDmVoiceUserLeft({ dmGroupId, userId: 'user-1' } as never, queryClient);
 
-      const data = queryClient.getQueryData<DmVoicePresenceResponseDto>(queryKey);
+      const data = queryClient.getQueryData<TestDmPresence>(queryKey);
       expect(data!.users).toHaveLength(0);
       expect(data!.count).toBe(0);
     });
@@ -278,7 +292,7 @@ describe('voiceHandlers — DM', () => {
       const updated = makeVoiceUser({ id: 'user-1', isCameraOn: true });
       handleDmVoiceUserUpdated({ dmGroupId, user: updated } as never, queryClient);
 
-      const data = queryClient.getQueryData<DmVoicePresenceResponseDto>(queryKey);
+      const data = queryClient.getQueryData<TestDmPresence>(queryKey);
       expect(data!.users[0].isCameraOn).toBe(true);
     });
 
@@ -288,7 +302,7 @@ describe('voiceHandlers — DM', () => {
 
       handleDmVoiceUserUpdated({ dmGroupId, user: makeVoiceUser({ id: 'ghost' }) } as never, queryClient);
 
-      const data = queryClient.getQueryData<DmVoicePresenceResponseDto>(queryKey);
+      const data = queryClient.getQueryData<TestDmPresence>(queryKey);
       expect(data!.users).toHaveLength(0);
     });
 

--- a/frontend/src/__tests__/socket-hub/useSocketHub.test.ts
+++ b/frontend/src/__tests__/socket-hub/useSocketHub.test.ts
@@ -74,14 +74,14 @@ describe('useSocketHub', () => {
     // Verify every single ServerEvent has exactly one socket.on registration
     for (const event of allEvents) {
       const registrations = mockSocket.on.mock.calls.filter(
-        ([e]: [string]) => e === event,
+        ([e]) => e === event,
       );
       expect(registrations).toHaveLength(1);
     }
 
     // Verify we didn't register any extra events beyond ServerEvents + 'connect'
     const registeredEvents = new Set(
-      mockSocket.on.mock.calls.map(([e]: [string]) => e),
+      mockSocket.on.mock.calls.map(([e]) => e),
     );
     const expectedEvents = new Set([...allEvents, 'connect']);
     expect(registeredEvents).toEqual(expectedEvents);

--- a/frontend/src/__tests__/test-utils/factories.ts
+++ b/frontend/src/__tests__/test-utils/factories.ts
@@ -1,7 +1,9 @@
 import type { InfiniteData } from '@tanstack/react-query';
 import type { PaginatedMessagesResponseDto, ThreadRepliesResponseDto, EnrichedThreadReplyDto, FriendshipWithUsersDto, UserEntity } from '../../api-client/types.gen';
 import type { Message, Reaction } from '../../types/message.type';
-import type { DirectMessageGroup, DirectMessageGroupMember } from '../../types/direct-message.type';
+import type { DirectMessageGroup } from '../../types/direct-message.type';
+import type { DmGroupMemberDto } from '../../api-client/types.gen';
+import { ChannelType, type Channel } from '../../types/channel.type';
 
 let counter = 0;
 
@@ -125,46 +127,47 @@ export function createChannel(overrides: Partial<{
   id: string;
   name: string;
   communityId: string;
-  type: 'TEXT' | 'VOICE';
+  type: ChannelType | 'TEXT' | 'VOICE';
   isPrivate: boolean;
   createdAt: string;
   position: number;
-}> = {}) {
+  slowmodeSeconds: number;
+}> = {}): Channel {
   return {
     id: overrides.id ?? `channel-${++counter}`,
     name: overrides.name ?? 'general',
     communityId: overrides.communityId ?? 'community-1',
-    type: overrides.type ?? 'TEXT',
+    type: overrides.type === 'VOICE' ? 'VOICE' : 'TEXT',
     isPrivate: overrides.isPrivate ?? false,
     createdAt: overrides.createdAt ?? new Date().toISOString(),
     position: overrides.position ?? 0,
+    slowmodeSeconds: overrides.slowmodeSeconds ?? 0,
   };
 }
 
-export function createUser(overrides: Partial<{
-  id: string;
-  username: string;
-  displayName: string | null;
-  avatarUrl: string | null;
-  email: string;
-}> = {}) {
+export function createUser(overrides: Partial<UserEntity & { email: string }> = {}): UserEntity & { email: string } {
   const id = overrides.id ?? `user-${++counter}`;
   return {
     id,
     username: overrides.username ?? `user_${id}`,
     displayName: overrides.displayName ?? null,
     avatarUrl: overrides.avatarUrl ?? null,
+    bannerUrl: overrides.bannerUrl ?? null,
+    lastSeen: overrides.lastSeen ?? null,
+    bio: overrides.bio ?? null,
+    status: overrides.status ?? null,
+    role: overrides.role ?? 'USER',
     email: overrides.email ?? `${id}@test.com`,
   };
 }
 
-export function createDmGroupMember(overrides: Partial<DirectMessageGroupMember> = {}): DirectMessageGroupMember {
+export function createDmGroupMember(overrides: Partial<DmGroupMemberDto> = {}): DmGroupMemberDto {
   const memberId = overrides.id ?? `member-${++counter}`;
   const userId = overrides.userId ?? `user-${++counter}`;
   return {
     id: memberId,
     userId,
-    joinedAt: overrides.joinedAt ?? new Date(),
+    joinedAt: overrides.joinedAt ?? new Date().toISOString(),
     user: overrides.user ?? {
       id: userId,
       username: `user_${userId}`,
@@ -179,7 +182,7 @@ export function createDmGroup(overrides: Partial<DirectMessageGroup> = {}): Dire
     id: overrides.id ?? `dm-${++counter}`,
     name: overrides.name ?? null,
     isGroup: overrides.isGroup ?? false,
-    createdAt: overrides.createdAt ?? new Date(),
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
     members: overrides.members ?? [],
     lastMessage: overrides.lastMessage ?? null,
   };

--- a/frontend/src/__tests__/test-utils/mockSocket.ts
+++ b/frontend/src/__tests__/test-utils/mockSocket.ts
@@ -1,12 +1,12 @@
-import { vi } from 'vitest';
+import { vi, type Mock } from 'vitest';
 
 type Handler = (...args: unknown[]) => void;
 
 export interface MockSocket {
-  on: ReturnType<typeof vi.fn>;
-  off: ReturnType<typeof vi.fn>;
-  once: ReturnType<typeof vi.fn>;
-  emit: ReturnType<typeof vi.fn>;
+  on: Mock<(event: string, handler: Handler) => void>;
+  off: Mock<(event: string, handler: Handler) => void>;
+  once: Mock<(event: string, handler: Handler) => void>;
+  emit: Mock<(event: string, ...args: unknown[]) => void>;
   connected: boolean;
   /** Invoke all registered handlers for a given event name */
   simulateEvent: (event: string, ...args: unknown[]) => Promise<void>;
@@ -45,7 +45,7 @@ export function createMockSocket(): MockSocket {
     handlers.get(event)!.add(wrappedHandler);
   });
 
-  const emit = vi.fn();
+  const emit = vi.fn<(event: string, ...args: unknown[]) => void>();
 
   const simulateEvent = async (event: string, ...args: unknown[]) => {
     const eventHandlers = handlers.get(event);

--- a/frontend/src/__tests__/utils/env.test.ts
+++ b/frontend/src/__tests__/utils/env.test.ts
@@ -49,6 +49,7 @@ describe('getInstanceUrl', () => {
       id: 'server-1',
       name: 'My Server',
       url: 'https://my-semaphore-instance.com',
+      isActive: true,
     });
 
     expect(getInstanceUrl()).toBe('https://my-semaphore-instance.com');
@@ -67,6 +68,7 @@ describe('getInstanceUrl', () => {
       id: 'server-1',
       name: 'My Server',
       url: 'https://my-server.com',
+      isActive: true,
     });
 
     // Even if window.location.origin is file://, we should get the server URL

--- a/frontend/src/__tests__/utils/socketSingleton.test.ts
+++ b/frontend/src/__tests__/utils/socketSingleton.test.ts
@@ -16,7 +16,7 @@ const mockSocket = {
   connect: vi.fn(),
 };
 
-const mockIo = vi.fn(() => mockSocket);
+const mockIo = vi.fn((..._args: unknown[]) => mockSocket);
 
 vi.mock('socket.io-client', () => ({
   io: (...args: unknown[]) => mockIo(...args),

--- a/frontend/src/components/Common/UserSearchAutocomplete.tsx
+++ b/frontend/src/components/Common/UserSearchAutocomplete.tsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/material";
 import { useQuery } from "@tanstack/react-query";
 import { userControllerSearchUsersOptions, userControllerGetProfileOptions } from "../../api-client/@tanstack/react-query.gen";
+import type { UserControllerSearchUsersData } from "../../api-client/types.gen";
 import { useDebounce } from "../../hooks/useDebounce";
 import UserAvatar from "./UserAvatar";
 
@@ -68,7 +69,11 @@ const UserSearchAutocomplete: React.FC<UserSearchAutocompleteProps> = ({
   const debouncedQuery = useDebounce(inputValue.trim(), 300);
 
   const { data: usersData, isLoading } = useQuery({
-    ...userControllerSearchUsersOptions({ query: { q: debouncedQuery, limit: 25 } }),
+    // The generated spec marks `communityId` as required, but the backend
+    // controller treats it as an optional query param (instance-wide search).
+    ...userControllerSearchUsersOptions({
+      query: { q: debouncedQuery, limit: 25 } as UserControllerSearchUsersData['query'],
+    }),
     enabled: debouncedQuery.length >= 1,
   });
   const { data: currentUser } = useQuery(userControllerGetProfileOptions());
@@ -118,7 +123,7 @@ const UserSearchAutocomplete: React.FC<UserSearchAutocompleteProps> = ({
         }}
       />
     ),
-    renderOption: (props: React.HTMLAttributes<HTMLLIElement> & { key?: string }, user: UserOption) => {
+    renderOption: (props: React.HTMLAttributes<HTMLLIElement> & { key: React.Key }, user: UserOption) => {
       const { key: _key, ...restProps } = props;
       return (
         <Box component="li" key={user.id} {...restProps} sx={{ display: 'flex', alignItems: 'center' }}>

--- a/frontend/src/components/Community/AliasGroupManagement.tsx
+++ b/frontend/src/components/Community/AliasGroupManagement.tsx
@@ -93,14 +93,14 @@ const AliasGroupManagement: React.FC<AliasGroupManagementProps> = ({ communityId
 
     try {
       await deleteGroup({
-        path: { communityId, groupId: groupToDelete.id },
+        path: { groupId: groupToDelete.id },
       });
       setDeleteConfirmOpen(false);
       setGroupToDelete(null);
     } catch {
       // Error handled by RTK Query
     }
-  }, [groupToDelete, deleteGroup, communityId]);
+  }, [groupToDelete, deleteGroup]);
 
   const handleCancelEdit = useCallback(() => {
     setCreatingGroup(false);

--- a/frontend/src/components/Community/InviteManagement.tsx
+++ b/frontend/src/components/Community/InviteManagement.tsx
@@ -102,7 +102,7 @@ const InviteManagement: React.FC<InviteManagementProps> = ({ communityId }) => {
       const createInviteDto: CreateInviteDto = {
         communityIds: [communityId],
         maxUses: maxUses || undefined,
-        validUntil: validUntil ? new Date(validUntil) : undefined,
+        validUntil: validUntil ? new Date(validUntil).toISOString() : undefined,
       };
       
       await createInvite({ body: createInviteDto });

--- a/frontend/src/components/Community/MemberManagement.tsx
+++ b/frontend/src/components/Community/MemberManagement.tsx
@@ -21,6 +21,7 @@ import {
 } from "../../api-client/@tanstack/react-query.gen";
 import { useUserPermissions } from "../../features/roles/useUserPermissions";
 import { userControllerFindAllUsersOptions } from "../../api-client/@tanstack/react-query.gen";
+import type { UserControllerFindAllUsersData } from "../../api-client/types.gen";
 import UserAvatar from "../Common/UserAvatar";
 import RoleAssignmentDialog from "./RoleAssignmentDialog";
 import ConfirmDialog from "../Common/ConfirmDialog";
@@ -51,7 +52,13 @@ const MemberManagement: React.FC<MemberManagementProps> = ({ communityId }) => {
     data: usersData,
     isLoading: loadingUsers,
     error: usersError,
-  } = useQuery(userControllerFindAllUsersOptions({ query: { limit: usersPerPage } }));
+  } = useQuery(
+    userControllerFindAllUsersOptions({
+      // The generated spec marks `continuationToken` as required, but the backend
+      // controller treats it as an optional query param (first page when omitted).
+      query: { limit: usersPerPage } as UserControllerFindAllUsersData['query'],
+    }),
+  );
 
   const { mutateAsync: createMembership, isPending: addingMember } = useMutation({
     ...membershipControllerCreateMutation(),

--- a/frontend/src/components/Community/RoleEditor.tsx
+++ b/frontend/src/components/Community/RoleEditor.tsx
@@ -126,7 +126,7 @@ const RoleEditor: React.FC<RoleEditorProps> = ({
       <CardContent>
         <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
           <Typography variant="h6">
-            {isEditing ? `Edit Role: ${role.name}` : "Create New Role"}
+            {isEditing ? `Edit Role: ${role?.name}` : "Create New Role"}
           </Typography>
           <Box display="flex" gap={1}>
             <Button

--- a/frontend/src/components/Community/RoleManagement.tsx
+++ b/frontend/src/components/Community/RoleManagement.tsx
@@ -43,7 +43,7 @@ import {
   rolesControllerResetDefaultCommunityRolesMutation,
   rolesControllerReorderRolesMutation,
 } from "../../api-client/@tanstack/react-query.gen";
-import type { RoleDto } from "../../api-client/types.gen";
+import type { CreateRoleDto, RoleDto, UpdateRoleDto } from "../../api-client/types.gen";
 import { invalidateRoleQueries, invalidateAllRoleQueries } from "../../utils/queryInvalidation";
 import ConfirmDialog from "../Common/ConfirmDialog";
 import RoleEditor from "./RoleEditor";
@@ -135,7 +135,9 @@ const RoleManagement: React.FC<RoleManagementProps> = ({ communityId }) => {
         path: { communityId },
         body: {
           name: data.name!, // name is required for creating new roles
-          actions: data.actions,
+          // RoleEditor tracks actions as plain strings; the backend validates
+          // them against its RbacActions enum.
+          actions: data.actions as CreateRoleDto["actions"],
         },
       });
       setCreatingRole(false);
@@ -150,7 +152,12 @@ const RoleManagement: React.FC<RoleManagementProps> = ({ communityId }) => {
     try {
       await updateRole({
         path: { communityId, roleId: editingRole.id },
-        body: data,
+        body: {
+          name: data.name,
+          // RoleEditor tracks actions as plain strings; the backend validates
+          // them against its RbacActions enum.
+          actions: data.actions as UpdateRoleDto["actions"],
+        },
       });
       setEditingRole(null);
     } catch {

--- a/frontend/src/components/CommunityList/CommunityToggle.tsx
+++ b/frontend/src/components/CommunityList/CommunityToggle.tsx
@@ -14,15 +14,6 @@ import { useCanPerformAction } from "../../features/roles/useUserPermissions";
 import { RBAC_ACTIONS } from "../../constants/rbacActions";
 import { useReadReceipts } from "../../hooks/useReadReceipts";
 
-export interface Community {
-  id: string;
-  name: string;
-  avatar?: string | null;
-  banner?: string | null;
-  description?: string | null;
-  createdAt: Date;
-}
-
 interface CommunityToggleProps {
   isExpanded: boolean;
   appBarHeight: number;
@@ -195,7 +186,7 @@ const CommunityToggle: React.FC<CommunityToggleProps> = ({
         {isLoading && <Box color="grey.500">Loading...</Box>}
         {error && <Box color="error.main">Error loading</Box>}
         {communities && communities.length > 0
-          ? communities.map((community: Community) => (
+          ? communities.map((community) => (
               <CommunityListItem
                 key={community.id}
                 community={community}

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { Component, ErrorInfo, ReactNode } from 'react';
 import { Box, Typography, Button } from '@mui/material';
 import { Error as ErrorIcon } from '@mui/icons-material';
 import { logger } from '../utils/logger';

--- a/frontend/src/components/Friends/FriendRequestCard.tsx
+++ b/frontend/src/components/Friends/FriendRequestCard.tsx
@@ -13,7 +13,6 @@ import {
   Cancel as CancelIcon,
 } from "@mui/icons-material";
 import { Friendship } from "../../types/friend.type";
-import { User } from "../../types/auth.type";
 import UserAvatar from "../Common/UserAvatar";
 
 interface FriendRequestCardProps {
@@ -32,7 +31,7 @@ const FriendRequestCard: React.FC<FriendRequestCardProps> = ({
   onCancel,
 }) => {
   // Get the other user (sender for received, receiver for sent)
-  const otherUser: User | undefined =
+  const otherUser =
     type === "received"
       ? request.userA // Sender
       : request.userB; // Receiver

--- a/frontend/src/components/Message/MemberList.tsx
+++ b/frontend/src/components/Message/MemberList.tsx
@@ -219,7 +219,7 @@ const MemberList: React.FC<MemberListProps> = ({
   if (error) {
     return (
       <Box sx={{ width: 240, p: 2 }}>
-        <Alert severity="error" size="small">
+        <Alert severity="error">
           Failed to load members
         </Alert>
       </Box>

--- a/frontend/src/components/Message/MemberListContainer.tsx
+++ b/frontend/src/components/Message/MemberListContainer.tsx
@@ -116,7 +116,8 @@ const MemberListContainer: React.FC<MemberListContainerProps> = ({
           username: member.user.username,
           displayName: member.user.displayName,
           avatarUrl: member.user.avatarUrl,
-          status: member.user.status,
+          // The DM members endpoint does not return a status field
+          status: undefined,
         }));
     }
   }, [contextType, isPrivate, channelMembers, communityMembers, dmGroup]);

--- a/frontend/src/components/Message/MentionDropdown.tsx
+++ b/frontend/src/components/Message/MentionDropdown.tsx
@@ -27,7 +27,7 @@ const DropdownPaper = styled(Paper)(({ theme }) => ({
   zIndex: 2000,
   backgroundImage: `linear-gradient(145deg, ${alpha(theme.palette.background.paper, 0.95)}, ${alpha(theme.palette.background.paper, 0.85)})`,
   backdropFilter: 'blur(20px)',
-  borderRadius: theme.shape.borderRadius * 3,
+  borderRadius: Number(theme.shape.borderRadius) * 3,
   border: `1px solid ${alpha(theme.palette.divider, 0.12)}`,
   boxShadow: `
     0 8px 32px ${alpha(theme.palette.common.black, 0.12)},

--- a/frontend/src/components/Message/MessageSpan.tsx
+++ b/frontend/src/components/Message/MessageSpan.tsx
@@ -49,7 +49,7 @@ export const MessageSpan: React.FC<MessageSpanProps> = ({ span, index }) => {
     default: {
       // Split text into segments: plain text and URLs
       const urlPattern = /(https?:\/\/[^\s<>)"']*[^\s<>)"'.,!?;:])/g;
-      const parts = span.text.split(urlPattern);
+      const parts = (span.text ?? "").split(urlPattern);
 
       return (
         <span key={index}>

--- a/frontend/src/components/Message/useFileAttachments.ts
+++ b/frontend/src/components/Message/useFileAttachments.ts
@@ -14,7 +14,7 @@ import { formatFileSize } from "../../utils/format";
 export interface UseFileAttachmentsReturn {
   selectedFiles: File[];
   filePreviews: Map<number, string>;
-  fileInputRef: React.RefObject<HTMLInputElement>;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
   handleFileSelect: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleFileDrop: (files: File[]) => void;
   handleRemoveFile: (index: number) => void;

--- a/frontend/src/components/Message/useMentionHandling.ts
+++ b/frontend/src/components/Message/useMentionHandling.ts
@@ -20,7 +20,7 @@ export interface UseMentionHandlingReturn {
   cursorPosition: number;
   updateCursorPosition: () => void;
   handleInsertMention: (mention: MentionSuggestion, text: string, setText: (text: string) => void, closeMentions: () => void) => void;
-  setupCursorTracking: (inputRef: React.RefObject<HTMLInputElement>) => void;
+  setupCursorTracking: (inputRef: React.RefObject<HTMLInputElement | null>) => void;
 }
 
 /**
@@ -36,7 +36,7 @@ export function useMentionHandling(): UseMentionHandlingReturn {
     }
   }, []);
 
-  const setupCursorTracking = useCallback((inputRef: React.RefObject<HTMLInputElement>) => {
+  const setupCursorTracking = useCallback((inputRef: React.RefObject<HTMLInputElement | null>) => {
     inputRefForTracking.current = inputRef.current;
   }, []);
 

--- a/frontend/src/components/Message/useMessageActions.ts
+++ b/frontend/src/components/Message/useMessageActions.ts
@@ -125,11 +125,11 @@ export function useMessageActions(
     ...messagesControllerUpdateMutation(),
     onSuccess: (updatedMessage) => {
       // If we have original attachments metadata, enrich the response
-      let enrichedMessage = updatedMessage;
+      let enrichedMessage = updatedMessage as MessageType;
       if (message.attachments && Array.isArray(updatedMessage.attachments)) {
         const attachmentMap = new Map(message.attachments.map((att: FileMetadata) => [att.id, att]));
         enrichedMessage = {
-          ...updatedMessage,
+          ...(updatedMessage as MessageType),
           attachments: updatedMessage.attachments
             .map((idOrObj: string | FileMetadata) => {
               if (typeof idOrObj === 'object' && idOrObj.id) return idOrObj;
@@ -139,7 +139,7 @@ export function useMessageActions(
             .filter(Boolean) as MessageType['attachments'],
         };
       }
-      updateCache(queryClient, enrichedMessage as MessageType);
+      updateCache(queryClient, enrichedMessage);
     },
   });
 
@@ -153,14 +153,14 @@ export function useMessageActions(
   const { mutateAsync: addReactionApi } = useMutation({
     ...messagesControllerAddReactionMutation(),
     onSuccess: (updatedMessage) => {
-      updateReactionsInCache(queryClient, updatedMessage as MessageType);
+      updateReactionsInCache(queryClient, updatedMessage);
     },
   });
 
   const { mutateAsync: removeReactionApi } = useMutation({
     ...messagesControllerRemoveReactionMutation(),
     onSuccess: (updatedMessage) => {
-      updateReactionsInCache(queryClient, updatedMessage as MessageType);
+      updateReactionsInCache(queryClient, updatedMessage);
     },
   });
 
@@ -226,7 +226,16 @@ export function useMessageActions(
       await updateMessageApi({
         path: { id: message.id },
         body: {
-          spans: parsedSpans,
+          // The API DTO requires every span field to be present (null when
+          // unused); local Span uses optional fields instead.
+          spans: parsedSpans.map((span) => ({
+            type: span.type,
+            text: span.text ?? null,
+            userId: span.userId ?? null,
+            specialKind: span.specialKind ?? null,
+            communityId: span.communityId ?? null,
+            aliasId: span.aliasId ?? null,
+          })),
           attachments: editAttachments.map(att => att.id),
         },
       });
@@ -316,7 +325,7 @@ export function useMessageActions(
 
   const handlePin = useCallback(async () => {
     try {
-      await pinMessage({ path: { messageId: message.id } });
+      await pinMessage({ path: { messageId: message.id }, body: {} });
     } catch (error) {
       logger.error("Failed to pin message:", error);
     }
@@ -324,7 +333,7 @@ export function useMessageActions(
 
   const handleUnpin = useCallback(async () => {
     try {
-      await unpinMessage({ path: { messageId: message.id } });
+      await unpinMessage({ path: { messageId: message.id }, body: {} });
     } catch (error) {
       logger.error("Failed to unpin message:", error);
     }

--- a/frontend/src/components/Mobile/MobileAppBar.tsx
+++ b/frontend/src/components/Mobile/MobileAppBar.tsx
@@ -47,7 +47,7 @@ interface MobileAppBarProps {
   onMembersClick?: () => void;
   // Show more options button
   showMore?: boolean;
-  onMoreClick?: () => void;
+  onMoreClick?: (event: React.MouseEvent<HTMLElement>) => void;
 }
 
 const MobileAppBar: React.FC<MobileAppBarProps> = ({

--- a/frontend/src/components/Mobile/Panels/MobileProfilePanel.tsx
+++ b/frontend/src/components/Mobile/Panels/MobileProfilePanel.tsx
@@ -71,7 +71,7 @@ export const MobileProfilePanel: React.FC = () => {
     }
   };
 
-  const isAdmin = userData?.instanceRole === 'ADMIN';
+  const isAdmin = userData?.role === 'OWNER';
 
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -134,7 +134,7 @@ export const MobileProfilePanel: React.FC = () => {
                   <Typography variant="body2" color="text.secondary">
                     @{userData.username}
                   </Typography>
-                  {userData.instanceRole && (
+                  {userData.role === 'OWNER' && (
                     <Typography
                       variant="caption"
                       sx={{
@@ -147,7 +147,7 @@ export const MobileProfilePanel: React.FC = () => {
                         display: 'inline-block',
                       }}
                     >
-                      {userData.instanceRole}
+                      {userData.role}
                     </Typography>
                   )}
                 </Box>

--- a/frontend/src/components/Mobile/Screens/NotificationsScreen.tsx
+++ b/frontend/src/components/Mobile/Screens/NotificationsScreen.tsx
@@ -44,7 +44,7 @@ import { getMessagePreview, getNotificationTypeLabel, getTimeAgo } from '../../.
 /**
  * Get icon for notification type
  */
-const getNotificationIcon = (type: NotificationType) => {
+const getNotificationIcon = (type: Notification['type']) => {
   switch (type) {
     case NotificationType.USER_MENTION:
     case NotificationType.SPECIAL_MENTION:
@@ -141,7 +141,7 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
                 variant="body2"
                 color="text.secondary"
               >
-                {getNotificationTypeLabel(notification.type)}
+                {getNotificationTypeLabel(notification.type as NotificationType)}
               </Typography>
             </Box>
           }

--- a/frontend/src/components/Mobile/Tablet/TabletSidebar.tsx
+++ b/frontend/src/components/Mobile/Tablet/TabletSidebar.tsx
@@ -128,7 +128,7 @@ export const TabletSidebar: React.FC<TabletSidebarProps> = ({ communityId }) => 
         <ChannelCategoryList
           channels={channels}
           onChannelSelect={handleChannelClick}
-          selectedChannelId={state.channelId}
+          selectedChannelId={state.channelId ?? undefined}
           compact
           touchTargetHeight={TOUCH_TARGETS.MINIMUM}
         />

--- a/frontend/src/components/Mobile/common/MobileListItem.tsx
+++ b/frontend/src/components/Mobile/common/MobileListItem.tsx
@@ -58,7 +58,7 @@ export const MobileListItem: React.FC<MobileListItemProps> = ({
   dense = false,
 }) => {
   // Long press handling
-  const longPressTimer = React.useRef<NodeJS.Timeout | null>(null);
+  const longPressTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isLongPressing, setIsLongPressing] = React.useState(false);
 
   const handleTouchStart = () => {

--- a/frontend/src/components/Mobile/common/MobileSheet.tsx
+++ b/frontend/src/components/Mobile/common/MobileSheet.tsx
@@ -26,8 +26,6 @@ interface MobileSheetProps {
   maxHeight?: string | number;
   // Show close button in header
   showCloseButton?: boolean;
-  // Disable backdrop click to close
-  disableBackdropClick?: boolean;
 }
 
 /**
@@ -41,16 +39,9 @@ export const MobileSheet: React.FC<MobileSheetProps> = ({
   children,
   maxHeight = '85vh',
   showCloseButton = true,
-  disableBackdropClick = false,
 }) => {
   // iOS detection for swipe hints
   const iOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent);
-
-  const handleBackdropClick = () => {
-    if (!disableBackdropClick) {
-      onClose();
-    }
-  };
 
   return (
     <SwipeableDrawer
@@ -63,7 +54,6 @@ export const MobileSheet: React.FC<MobileSheetProps> = ({
       swipeAreaWidth={0} // Disable edge swipe to open (we control opening)
       ModalProps={{
         keepMounted: false,
-        onBackdropClick: handleBackdropClick,
       }}
       PaperProps={{
         sx: {

--- a/frontend/src/components/Moderation/ModerationLogsPanel.tsx
+++ b/frontend/src/components/Moderation/ModerationLogsPanel.tsx
@@ -33,9 +33,11 @@ import PushPinIcon from "@mui/icons-material/PushPin";
 import { alpha, useTheme } from "@mui/material/styles";
 import { useQuery } from "@tanstack/react-query";
 import { moderationControllerGetModerationLogsOptions } from "../../api-client/@tanstack/react-query.gen";
-import type { ModerationLogDto } from "../../api-client/types.gen";
+import type { ModerationControllerGetModerationLogsData, ModerationLogDto } from "../../api-client/types.gen";
 type ModerationAction = ModerationLogDto['action'];
-type ModerationLog = ModerationLogDto;
+// The response DTO does not declare targetMessageId, but the backend model
+// includes it and the service may return it.
+type ModerationLog = ModerationLogDto & { targetMessageId?: string | null };
 import { format } from "date-fns";
 
 interface ModerationLogsPanelProps {
@@ -64,11 +66,13 @@ const ModerationLogsPanel: React.FC<ModerationLogsPanelProps> = ({ communityId }
 
   const { data, isLoading, error } = useQuery(moderationControllerGetModerationLogsOptions({
     path: { communityId },
+    // The generated spec marks `action` as required, but the backend controller
+    // treats it as an optional query param (no filter when omitted).
     query: {
       limit: PAGE_SIZE,
       offset: (page - 1) * PAGE_SIZE,
       action: actionFilter || undefined,
-    },
+    } as ModerationControllerGetModerationLogsData['query'],
   }));
 
   const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0;
@@ -205,7 +209,7 @@ const ModerationLogsPanel: React.FC<ModerationLogsPanelProps> = ({ communityId }
                           }}
                         />
                         <Typography variant="caption" color="text.secondary">
-                          by {log.moderator?.displayName || log.moderator?.username || `${log.moderatorId.slice(0, 8)}...`}
+                          by {log.moderator?.displayName || log.moderator?.username || `${(log.moderatorId ?? "unknown").slice(0, 8)}...`}
                         </Typography>
                       </Box>
                     }

--- a/frontend/src/components/Moderation/PinnedMessagesPanel.tsx
+++ b/frontend/src/components/Moderation/PinnedMessagesPanel.tsx
@@ -61,7 +61,7 @@ const PinnedMessagesPanel: React.FC<PinnedMessagesPanelProps> = ({
 
   const handleUnpin = async (messageId: string) => {
     try {
-      await unpinMessage({ path: { messageId } });
+      await unpinMessage({ path: { messageId }, body: {} });
     } catch (err) {
       logger.error("Failed to unpin message:", err);
     }

--- a/frontend/src/components/Notifications/NotificationCenter.tsx
+++ b/frontend/src/components/Notifications/NotificationCenter.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
   IconButton,
   List,
+  ListItem,
   ListItemButton,
   ListItemText,
   ListItemAvatar,
@@ -159,18 +160,10 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({
             <List sx={{ p: 0 }}>
               {notifications.map((notification) => (
                 <React.Fragment key={notification.id}>
-                  <ListItemButton
-                    sx={{
-                      backgroundColor: notification.read
-                        ? 'transparent'
-                        : 'action.hover',
-                      '&:hover': {
-                        backgroundColor: notification.read
-                          ? 'action.hover'
-                          : 'action.selected',
-                      },
-                    }}
-                    onClick={() => handleNotificationClick(notification)}
+                  {/* secondaryAction is a ListItem prop (not ListItemButton),
+                      so the action buttons must live on a wrapping ListItem */}
+                  <ListItem
+                    disablePadding
                     secondaryAction={
                       <Box>
                         {!notification.read && (
@@ -194,9 +187,22 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({
                       </Box>
                     }
                   >
+                  <ListItemButton
+                    sx={{
+                      backgroundColor: notification.read
+                        ? 'transparent'
+                        : 'action.hover',
+                      '&:hover': {
+                        backgroundColor: notification.read
+                          ? 'action.hover'
+                          : 'action.selected',
+                      },
+                    }}
+                    onClick={() => handleNotificationClick(notification)}
+                  >
                     <ListItemAvatar>
                       <Avatar
-                        src={notification.author?.avatarUrl}
+                        src={notification.author?.avatarUrl ?? undefined}
                         alt={notification.author?.username}
                       />
                     </ListItemAvatar>
@@ -215,6 +221,7 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({
                       }}
                     />
                   </ListItemButton>
+                  </ListItem>
                   <Divider component="li" />
                 </React.Fragment>
               ))}

--- a/frontend/src/components/Profile/ClipLibrary.tsx
+++ b/frontend/src/components/Profile/ClipLibrary.tsx
@@ -317,7 +317,7 @@ export const ClipLibrary: React.FC<ClipLibraryProps> = ({ userId, isOwnProfile }
         <Skeleton variant="text" width={200} sx={{ mb: 3 }} />
         <Grid container spacing={2}>
           {[1, 2, 3].map((i) => (
-            <Grid item xs={12} sm={6} md={4} key={i}>
+            <Grid size={{ xs: 12, sm: 6, md: 4 }} key={i}>
               <ClipCardSkeleton />
             </Grid>
           ))}
@@ -360,7 +360,7 @@ export const ClipLibrary: React.FC<ClipLibraryProps> = ({ userId, isOwnProfile }
 
       <Grid container spacing={2}>
         {clips.map((clip) => (
-          <Grid item xs={12} sm={6} md={4} key={clip.id}>
+          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={clip.id}>
             <ClipCard
               clip={clip}
               isOwnProfile={isOwnProfile}

--- a/frontend/src/components/Profile/ProfileHeader.tsx
+++ b/frontend/src/components/Profile/ProfileHeader.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Avatar, Typography, Chip, styled } from "@mui/material";
 import { useAuthenticatedImage } from "../../hooks/useAuthenticatedImage";
-import type { User } from "../../types/auth.type";
+import type { UserEntity } from "../../api-client/types.gen";
 
 const BannerContainer = styled(Box)(({ theme }) => ({
   position: "relative",
@@ -31,7 +31,7 @@ const AvatarContainer = styled(Box)(() => ({
 }));
 
 interface ProfileHeaderProps {
-  user: User;
+  user: UserEntity;
 }
 
 const ProfileHeader: React.FC<ProfileHeaderProps> = ({ user }) => {

--- a/frontend/src/components/Settings/AudioVideoSettingsPanel.tsx
+++ b/frontend/src/components/Settings/AudioVideoSettingsPanel.tsx
@@ -31,7 +31,7 @@ import {
   VolumeUp,
   InfoOutlined,
 } from '@mui/icons-material';
-import { useDeviceSettings } from '../../hooks/useDeviceSettings';
+import { useDeviceSettings, type MediaDeviceInfo as DeviceInfo } from '../../hooks/useDeviceSettings';
 import { useDeviceTest, getDeviceLabel } from '../../hooks/useDeviceTest';
 import { useVoiceSettings, VoiceInputMode } from '../../hooks/useVoiceSettings';
 
@@ -160,7 +160,7 @@ const AudioVideoSettingsPanel: React.FC<AudioVideoSettingsPanelProps> = ({
     onDeviceChange?.('video', deviceId);
   };
 
-  const renderDeviceMenuItems = (devices: MediaDeviceInfo[], selectedId: string) => {
+  const renderDeviceMenuItems = (devices: DeviceInfo[], selectedId: string) => {
     if (devices.length === 0) {
       return <MenuItem value="">No devices found</MenuItem>;
     }

--- a/frontend/src/components/Settings/NotificationSettings.tsx
+++ b/frontend/src/components/Settings/NotificationSettings.tsx
@@ -102,11 +102,13 @@ export const NotificationSettings: React.FC = () => {
       setFormValues({
         desktopEnabled: settings.desktopEnabled,
         playSound: settings.playSound,
-        soundType: settings.soundType,
+        // GET response DTO types these as plain string; the update DTO narrows
+        // to the literal unions the backend actually stores
+        soundType: settings.soundType as UpdateNotificationSettingsDto['soundType'],
         doNotDisturb: settings.doNotDisturb,
         dndStartTime: settings.dndStartTime || '22:00',
         dndEndTime: settings.dndEndTime || '08:00',
-        defaultChannelLevel: settings.defaultChannelLevel,
+        defaultChannelLevel: settings.defaultChannelLevel as UpdateNotificationSettingsDto['defaultChannelLevel'],
         dmNotifications: settings.dmNotifications,
       });
     }
@@ -285,7 +287,7 @@ export const NotificationSettings: React.FC = () => {
                     mention: Sounds.mention,
                     dm: Sounds.directMessage,
                   };
-                  playSound(soundTypeMap[formValues.soundType] || Sounds.channelMessage);
+                  playSound(soundTypeMap[formValues.soundType ?? 'default'] || Sounds.channelMessage);
                 }}
               >
                 <PlayArrowIcon />

--- a/frontend/src/components/Thread/ThreadMessageInput.tsx
+++ b/frontend/src/components/Thread/ThreadMessageInput.tsx
@@ -49,11 +49,6 @@ export const ThreadMessageInput: React.FC<ThreadMessageInputProps> = ({
         {
           type: SpanType.PLAINTEXT,
           text: trimmedContent,
-          userId: null,
-          specialKind: null,
-          channelId: null,
-          communityId: null,
-          aliasId: null,
         },
       ],
       attachments: [],

--- a/frontend/src/components/Thread/ThreadReplyBadge.tsx
+++ b/frontend/src/components/Thread/ThreadReplyBadge.tsx
@@ -13,7 +13,7 @@ import { formatDistanceToNow } from "date-fns";
 
 interface ThreadReplyBadgeProps {
   replyCount: number;
-  lastReplyAt?: string;
+  lastReplyAt?: string | null;
   onClick: () => void;
 }
 

--- a/frontend/src/components/Voice/ScreenShareVolumeControl.tsx
+++ b/frontend/src/components/Voice/ScreenShareVolumeControl.tsx
@@ -116,7 +116,7 @@ const ScreenShareVolumeControl: React.FC<ScreenShareVolumeControlProps> = ({ par
       <Popover
         open={open}
         anchorEl={anchorEl}
-        onClose={() => handleClose()}
+        onClose={(e) => handleClose(e as React.SyntheticEvent)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
         transformOrigin={{ vertical: 'top', horizontal: 'center' }}
         onClick={(e) => e.stopPropagation()}

--- a/frontend/src/components/Voice/ScreenShareVolumeControl.tsx
+++ b/frontend/src/components/Voice/ScreenShareVolumeControl.tsx
@@ -8,6 +8,7 @@ import { Track, type RemoteParticipant } from 'livekit-client';
 import { SCREENSHARE_VOLUME_STORAGE_PREFIX } from '../../constants/voice';
 import { useVoice } from '../../contexts/VoiceContext';
 import { audioBoostManager, boostKey } from '../../features/voice/audioBoostManager';
+import { isBoostableAudioTrack } from '../../features/voice/isBoostableAudioTrack';
 
 function getStoredScreenShareVolume(userId: string): number | null {
   try {
@@ -55,7 +56,11 @@ const ScreenShareVolumeControl: React.FC<ScreenShareVolumeControlProps> = ({ par
   const applyVolumeToTracks = useCallback(
     (vol: number) => {
       participant.audioTrackPublications.forEach((pub) => {
-        if (pub.track && pub.source === Track.Source.ScreenShareAudio) {
+        if (
+          pub.track &&
+          pub.source === Track.Source.ScreenShareAudio &&
+          isBoostableAudioTrack(pub.track)
+        ) {
           audioBoostManager.applyVolume(
             pub.track,
             boostKey(participant.identity, pub.source),
@@ -111,7 +116,7 @@ const ScreenShareVolumeControl: React.FC<ScreenShareVolumeControlProps> = ({ par
       <Popover
         open={open}
         anchorEl={anchorEl}
-        onClose={handleClose}
+        onClose={() => handleClose()}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
         transformOrigin={{ vertical: 'top', horizontal: 'center' }}
         onClick={(e) => e.stopPropagation()}

--- a/frontend/src/components/Voice/ScreenSourcePicker.tsx
+++ b/frontend/src/components/Voice/ScreenSourcePicker.tsx
@@ -239,7 +239,7 @@ export const ScreenSourcePicker: React.FC<ScreenSourcePickerProps> = ({
                 </Box>
                 <Grid container spacing={2}>
                   {screens.map((source) => (
-                    <Grid item xs={12} sm={6} md={4} key={source.id}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }} key={source.id}>
                       <Paper
                         elevation={selectedSourceId === source.id ? 8 : 1}
                         sx={{
@@ -296,7 +296,7 @@ export const ScreenSourcePicker: React.FC<ScreenSourcePickerProps> = ({
                 </Box>
                 <Grid container spacing={2}>
                   {windows.map((source) => (
-                    <Grid item xs={12} sm={6} md={4} key={source.id}>
+                    <Grid size={{ xs: 12, sm: 6, md: 4 }} key={source.id}>
                       <Paper
                         elevation={selectedSourceId === source.id ? 8 : 1}
                         sx={{

--- a/frontend/src/components/Voice/VoiceBottomBar.tsx
+++ b/frontend/src/components/Voice/VoiceBottomBar.tsx
@@ -256,7 +256,7 @@ export const VoiceBottomBar: React.FC = () => {
                       ? "warning.main"
                       : (!isMicrophoneEnabled ? "error.main" : "transparent"),
                   color: isPTTKeyHeld
-                    ? theme.palette.semantic.status.positiveText
+                    ? theme.palette.getContrastText(theme.palette.semantic.status.positive)
                     : state.isServerMuted
                       ? "warning.contrastText"
                       : (!isMicrophoneEnabled ? "error.contrastText" : "text.primary"),

--- a/frontend/src/components/Voice/VoiceChannelUserList.tsx
+++ b/frontend/src/components/Voice/VoiceChannelUserList.tsx
@@ -169,6 +169,9 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
         avatarUrl: userInfos[i]?.avatarUrl ?? undefined,
         joinedAt: joinedAtCacheRef.current.get(p.identity) || new Date().toISOString(),
         isDeafened: p.isDeafened,
+        // LiveKit participant metadata doesn't carry server-mute state; the
+        // REST presence path is the source of truth for it
+        isServerMuted: false,
       }));
 
       setLivekitParticipants(participants);

--- a/frontend/src/components/Voice/VoiceUserContextMenu.tsx
+++ b/frontend/src/components/Voice/VoiceUserContextMenu.tsx
@@ -29,6 +29,7 @@ import { useNotification } from "../../contexts/NotificationContext";
 import type { VoicePresenceUserDto } from "../../api-client/types.gen";
 import { VOLUME_STORAGE_PREFIX } from "../../constants/voice";
 import { audioBoostManager, boostKey } from "../../features/voice/audioBoostManager";
+import { isBoostableAudioTrack } from "../../features/voice/isBoostableAudioTrack";
 import { logger } from "../../utils/logger";
 
 function getStoredVolume(userId: string): number | null {
@@ -112,7 +113,11 @@ const VoiceUserContextMenu: React.FC<VoiceUserContextMenuProps> = ({
       if (!participant || isLocalUser) return;
 
       participant.audioTrackPublications.forEach((pub) => {
-        if (pub.track && pub.source === Track.Source.Microphone) {
+        if (
+          pub.track &&
+          pub.source === Track.Source.Microphone &&
+          isBoostableAudioTrack(pub.track)
+        ) {
           audioBoostManager.applyVolume(pub.track, boostKey(user.id, pub.source), vol);
         }
       });

--- a/frontend/src/components/Voice/components/InlineUserAvatar.tsx
+++ b/frontend/src/components/Voice/components/InlineUserAvatar.tsx
@@ -5,7 +5,8 @@ import { useParticipantTracks } from "../../../hooks/useParticipantTracks";
 import UserAvatar from "../../Common/UserAvatar";
 
 interface InlineUserAvatarProps {
-  user: VoicePresenceUserDto;
+  /** WS presence payloads layer isVideoEnabled on top of the REST DTO */
+  user: VoicePresenceUserDto & { isVideoEnabled?: boolean };
   onContextMenu: (event: React.MouseEvent<HTMLElement>, user: VoicePresenceUserDto) => void;
   onClickUser: (userId: string) => void;
 }

--- a/frontend/src/constants/rbacActions.ts
+++ b/frontend/src/constants/rbacActions.ts
@@ -81,6 +81,15 @@ export const RBAC_ACTIONS = {
   VIEW_BAN_LIST: 'VIEW_BAN_LIST',
   VIEW_MODERATION_LOGS: 'VIEW_MODERATION_LOGS',
   MUTE_PARTICIPANT: 'MUTE_PARTICIPANT',
+
+  // Voice / Replay
+  CAPTURE_REPLAY: 'CAPTURE_REPLAY',
+
+  // Instance Administration
+  READ_INSTANCE_SETTINGS: 'READ_INSTANCE_SETTINGS',
+  UPDATE_INSTANCE_SETTINGS: 'UPDATE_INSTANCE_SETTINGS',
+  READ_INSTANCE_STATS: 'READ_INSTANCE_STATS',
+  MANAGE_USER_STORAGE: 'MANAGE_USER_STORAGE',
 } as const;
 
 export type RbacAction = typeof RBAC_ACTIONS[keyof typeof RBAC_ACTIONS];
@@ -175,6 +184,7 @@ export const ACTION_LABELS: Record<RbacAction, string> = {
   [RBAC_ACTIONS.JOIN_CHANNEL]: 'Join channels',
 
   // Community
+  [RBAC_ACTIONS.CREATE_COMMUNITY]: 'Create communities',
   [RBAC_ACTIONS.UPDATE_COMMUNITY]: 'Edit community',
   [RBAC_ACTIONS.DELETE_COMMUNITY]: 'Delete community',
   [RBAC_ACTIONS.READ_COMMUNITY]: 'View community',
@@ -232,4 +242,13 @@ export const ACTION_LABELS: Record<RbacAction, string> = {
   [RBAC_ACTIONS.VIEW_BAN_LIST]: 'View ban list',
   [RBAC_ACTIONS.VIEW_MODERATION_LOGS]: 'View moderation logs',
   [RBAC_ACTIONS.MUTE_PARTICIPANT]: 'Mute voice participants',
+
+  // Voice / Replay
+  [RBAC_ACTIONS.CAPTURE_REPLAY]: 'Capture voice replays',
+
+  // Instance Administration
+  [RBAC_ACTIONS.READ_INSTANCE_SETTINGS]: 'View instance settings',
+  [RBAC_ACTIONS.UPDATE_INSTANCE_SETTINGS]: 'Edit instance settings',
+  [RBAC_ACTIONS.READ_INSTANCE_STATS]: 'View instance stats',
+  [RBAC_ACTIONS.MANAGE_USER_STORAGE]: 'Manage user storage',
 };

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -5,7 +5,7 @@
  * Types and constants are in ../theme/constants.ts to comply with React Fast Refresh.
  */
 
-import React, { createContext, useContext, useState, useEffect, useMemo, useCallback, useRef, ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useMemo, useCallback, useRef, ReactNode } from 'react';
 import { logger } from '../utils/logger';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
 import { generateTheme } from '../theme/themeConfig';

--- a/frontend/src/features/voice/isBoostableAudioTrack.ts
+++ b/frontend/src/features/voice/isBoostableAudioTrack.ts
@@ -1,0 +1,16 @@
+import type { BoostableAudioTrack } from './audioBoostManager';
+
+/**
+ * Duck-types a track as a BoostableAudioTrack (i.e. a RemoteAudioTrack, which
+ * is the only RemoteTrack subtype with setVolume). Avoids `instanceof
+ * RemoteAudioTrack`, which can false-fail when livekit-client is loaded twice
+ * (HMR, dual bundles, test mocks).
+ *
+ * Lives in its own module (not audioBoostManager.ts) so tests that mock the
+ * boost manager don't accidentally stub the guard out.
+ */
+export function isBoostableAudioTrack(track: unknown): track is BoostableAudioTrack {
+  return (
+    !!track && typeof (track as BoostableAudioTrack).setVolume === 'function'
+  );
+}

--- a/frontend/src/features/voice/voiceActions.ts
+++ b/frontend/src/features/voice/voiceActions.ts
@@ -106,9 +106,7 @@ async function connectToLiveKitRoom(
   setRoom: (room: Room | null) => void
 ): Promise<Room> {
   logger.info('[Voice] Creating new LiveKit room instance');
-  const room = new Room({
-    autoSubscribe: false,
-  });
+  const room = new Room();
 
   // Register connection state monitoring before connecting so we catch
   // any events that fire during the connection handshake.
@@ -131,6 +129,13 @@ async function connectToLiveKitRoom(
 
   try {
     logger.info('[Voice] Connecting to LiveKit server:', url);
+    // NOTE: `autoSubscribe: false` used to be passed to the Room constructor,
+    // where livekit-client silently ignores it (it's a RoomConnectOptions
+    // field, i.e. connect()'s third argument). Every session has therefore
+    // always run with auto-subscribe ON and the manual subscription layer
+    // (useTrackSubscription) never active on the wire. Deliberately keeping
+    // that behavior here — actually disabling auto-subscribe is a wire-level
+    // change that needs its own E2E-validated PR.
     await room.connect(url, token);
     logger.info('[Voice] Connected to LiveKit room, state:', room.state);
     setRoom(room);
@@ -485,9 +490,11 @@ export async function toggleCameraUnified(deps: VoiceActionDeps) {
     const videoCaptureOptions: VideoCaptureOptions | undefined = newState
       ? {
           deviceId: selectedVideoInputId ? { ideal: selectedVideoInputId } : undefined,
+          // VideoResolution takes plain numbers; livekit-client converts them
+          // to ideal constraints when building getUserMedia constraints.
           resolution: {
-            width: { ideal: 1280 },
-            height: { ideal: 720 },
+            width: 1280,
+            height: 720,
           },
         }
       : undefined;

--- a/frontend/src/hooks/useBidirectionalScroll.ts
+++ b/frontend/src/hooks/useBidirectionalScroll.ts
@@ -111,7 +111,7 @@ export const useBidirectionalScroll = ({
   // Without adjustment, the viewport jumps. Shifting scrollTop by the height
   // delta keeps the user's current view stable.
   const prevScrollHeightRef = useRef(0);
-  const prevFirstMsgIdRef = useRef<string | undefined>();
+  const prevFirstMsgIdRef = useRef<string | undefined>(undefined);
   useLayoutEffect(() => {
     const container = scrollContainerRef.current;
     if (!container || messages.length === 0) return;

--- a/frontend/src/hooks/useDeafenEffect.ts
+++ b/frontend/src/hooks/useDeafenEffect.ts
@@ -4,6 +4,7 @@ import { useVoice } from '../contexts/VoiceContext';
 import { useRoom } from './useRoom';
 import { Track } from 'livekit-client';
 import { audioBoostManager, boostKey } from '../features/voice/audioBoostManager';
+import { isBoostableAudioTrack } from '../features/voice/isBoostableAudioTrack';
 import { getStoredVolumePercent } from '../features/voice/volumeStorage';
 
 function isBoostableAudioSource(source: Track.Source | string): boolean {
@@ -41,8 +42,9 @@ export const useDeafenEffect = () => {
     const muteAllRemoteAudio = () => {
       room.remoteParticipants.forEach((participant) => {
         participant.audioTrackPublications.forEach((publication) => {
-          if (publication.track && isBoostableAudioSource(publication.source)) {
-            publication.track.setVolume(0);
+          const { track } = publication;
+          if (track && isBoostableAudioTrack(track) && isBoostableAudioSource(publication.source)) {
+            track.setVolume(0);
           }
         });
       });
@@ -52,11 +54,12 @@ export const useDeafenEffect = () => {
     const restoreRemoteAudioVolumes = () => {
       room.remoteParticipants.forEach((participant) => {
         participant.audioTrackPublications.forEach((publication) => {
-          if (publication.track && isBoostableAudioSource(publication.source)) {
+          const { track } = publication;
+          if (track && isBoostableAudioTrack(track) && isBoostableAudioSource(publication.source)) {
             const volumePercent =
               getStoredVolumePercent(participant.identity, publication.source) ?? 100;
             audioBoostManager.applyVolume(
-              publication.track,
+              track,
               boostKey(participant.identity, publication.source),
               volumePercent,
             );

--- a/frontend/src/hooks/useDeviceTest.ts
+++ b/frontend/src/hooks/useDeviceTest.ts
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { logger } from '../utils/logger';
 import { computeVoiceLevel } from '../utils/audioLevel';
+import type { MediaDeviceInfo as DeviceInfo } from './useDeviceSettings';
 
 interface UseDeviceTestOptions {
   videoRef: React.RefObject<HTMLVideoElement | null>;
@@ -24,7 +25,7 @@ interface UseDeviceTestReturn {
  * Formats a device label for display. Falls back to a truncated device ID
  * when the browser has not yet been granted permission to read labels.
  */
-export function getDeviceLabel(device: MediaDeviceInfo): string {
+export function getDeviceLabel(device: DeviceInfo): string {
   if (!device.label || device.label === '') {
     return `${device.kind} (${device.deviceId.slice(0, 8)}...)`;
   }

--- a/frontend/src/hooks/useJumpToMessage.ts
+++ b/frontend/src/hooks/useJumpToMessage.ts
@@ -18,7 +18,7 @@ export const useJumpToMessage = (
   // Uses a seq counter so re-clicking the same message always triggers a new scroll.
   const [activeHighlight, setActiveHighlight] = useState<string | undefined>();
   const [highlightSeq, setHighlightSeq] = useState(0);
-  const flashTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const queryClient = useQueryClient();
 
   const mode = anchorMessageId ? "anchored" : "normal";

--- a/frontend/src/hooks/useMentionAutocomplete.ts
+++ b/frontend/src/hooks/useMentionAutocomplete.ts
@@ -20,7 +20,7 @@ export interface MentionAutocompleteState {
   suggestions: MentionSuggestion[];
   selectedIndex: number;
   query: string;
-  type: 'user' | 'special' | 'alias' | null;
+  type: 'user' | 'special' | 'channel' | 'alias' | null;
   isLoading: boolean;
 }
 

--- a/frontend/src/hooks/useMessageFileUpload.ts
+++ b/frontend/src/hooks/useMessageFileUpload.ts
@@ -8,7 +8,7 @@ import { useNotification } from "../contexts/NotificationContext";
 import { channelMessagesQueryKey, dmMessagesQueryKey } from "../utils/messageQueryKeys";
 import { updateMessageInInfinite } from "../utils/messageCacheUpdaters";
 import { logger } from "../utils/logger";
-import type { Message } from "../types/message.type";
+import type { Message, Span } from "../types/message.type";
 
 interface UseMessageFileUploadOptions {
   contextType: VoiceSessionType;
@@ -78,7 +78,7 @@ export const useMessageFileUpload = ({ contextType, contextId, authorId }: UseMe
     }
   });
 
-  const handleSendMessage = async (messageContent: string, spans: unknown[], files?: File[], replyToId?: string) => {
+  const handleSendMessage = async (_messageContent: string, spans: Span[], files?: File[], replyToId?: string) => {
     const msg = {
       ...(contextType === VoiceSessionType.Channel
         ? { channelId: contextId }

--- a/frontend/src/hooks/useRemoteVolumeEffect.ts
+++ b/frontend/src/hooks/useRemoteVolumeEffect.ts
@@ -8,6 +8,7 @@ import {
 import { useRoom } from './useRoom';
 import { useVoice } from '../contexts/VoiceContext';
 import { audioBoostManager, boostKey } from '../features/voice/audioBoostManager';
+import { isBoostableAudioTrack } from '../features/voice/isBoostableAudioTrack';
 import { getStoredVolumePercent } from '../features/voice/volumeStorage';
 import { logger } from '../utils/logger';
 
@@ -50,7 +51,8 @@ export const useRemoteVolumeEffect = () => {
       // Skip when deafened — useDeafenEffect manages volume in that case
       if (isDeafenedRef.current) return;
 
-      if (!publication.track) return;
+      const { track } = publication;
+      if (!track || !isBoostableAudioTrack(track)) return;
 
       // Default to 100% so a resubscribed track also clears any stale boost
       // wiring left from its previous incarnation.
@@ -58,7 +60,7 @@ export const useRemoteVolumeEffect = () => {
         getStoredVolumePercent(participant.identity, publication.source) ?? 100;
 
       audioBoostManager.applyVolume(
-        publication.track,
+        track,
         boostKey(participant.identity, publication.source),
         volumePercent,
       );

--- a/frontend/src/hooks/useSendMessage.ts
+++ b/frontend/src/hooks/useSendMessage.ts
@@ -72,12 +72,6 @@ export function useSendMessage(
         }
 
         const doSend = () => {
-          // Determine which event to emit based on context
-          const event =
-            contextType === VoiceSessionType.Channel
-              ? ClientEvents.SEND_MESSAGE
-              : ClientEvents.SEND_DM;
-
           let settled = false;
 
           // Add a timeout in case server doesn't respond
@@ -90,8 +84,7 @@ export function useSendMessage(
             });
           }, 10000); // 10 second timeout
 
-          // Emit with acknowledgment callback
-          socket.emit(event, payload, (messageId: string) => {
+          const ack = (messageId: string) => {
             if (settled) return;
             settled = true;
             clearTimeout(timeoutId);
@@ -99,7 +92,25 @@ export function useSendMessage(
               callback(messageId);
             }
             resolve({ success: true, messageId });
-          });
+          };
+
+          // Emit with acknowledgment callback. The context type determines the
+          // event and implies which context id the payload carries (callers
+          // build the payload for the same context they pass as contextType),
+          // hence the narrowing assertions.
+          if (contextType === VoiceSessionType.Channel) {
+            socket.emit(
+              ClientEvents.SEND_MESSAGE,
+              payload as NewMessagePayload & { channelId: string },
+              ack,
+            );
+          } else {
+            socket.emit(
+              ClientEvents.SEND_DM,
+              payload as NewMessagePayload & { directMessageGroupId: string },
+              ack,
+            );
+          }
         };
 
         if (!socket.connected) {

--- a/frontend/src/hooks/useSwipeGesture.ts
+++ b/frontend/src/hooks/useSwipeGesture.ts
@@ -218,7 +218,7 @@ export const useLongPress = (
     onPressEnd,
   } = options;
 
-  const timeout = useRef<NodeJS.Timeout>();
+  const timeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const isLongPressTriggered = useRef(false);
 
   const start = useCallback((_e: TouchEvent | React.MouseEvent) => {

--- a/frontend/src/hooks/useVideoUrl.ts
+++ b/frontend/src/hooks/useVideoUrl.ts
@@ -27,7 +27,7 @@ export function useVideoUrl(fileId: string | null): VideoUrlResult {
   const [signedUrl, setSignedUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const expiresAtRef = useRef<number>(0);
-  const refreshTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const fetchSignedUrl = useCallback(async () => {
     if (!fileId) return;

--- a/frontend/src/hooks/useVoiceEventLogDef.ts
+++ b/frontend/src/hooks/useVoiceEventLogDef.ts
@@ -40,7 +40,7 @@ export interface VoiceEventLogStore {
 export const VoiceEventLogContext = createContext<VoiceEventLogStore | null>(null);
 
 const NOOP_SUBSCRIBE = () => () => {};
-const EMPTY_EVENTS: VoiceEventEntry[] = Object.freeze([]) as VoiceEventEntry[];
+const EMPTY_EVENTS: VoiceEventEntry[] = Object.freeze([] as VoiceEventEntry[]) as VoiceEventEntry[];
 const emptySnapshot = () => EMPTY_EVENTS;
 
 /**

--- a/frontend/src/pages/AdminInvitePage.tsx
+++ b/frontend/src/pages/AdminInvitePage.tsx
@@ -145,7 +145,7 @@ const AdminInvitePage: React.FC = () => {
       const createInviteDto: CreateInviteDto = {
         communityIds: selectedCommunities.length > 0 ? selectedCommunities : [],
         maxUses: maxUses || undefined,
-        validUntil: validUntil ? new Date(validUntil) : undefined,
+        validUntil: validUntil ? new Date(validUntil).toISOString() : undefined,
       };
       
       const newInvite = await createInvite({ body: createInviteDto });
@@ -295,25 +295,25 @@ const AdminInvitePage: React.FC = () => {
 
       {/* Stats Cards */}
       <Grid container spacing={3} mb={4}>
-        <Grid item xs={12} sm={6} md={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
           <Paper sx={{ p: 2, textAlign: 'center' }}>
             <Typography variant="h4" color="primary">{stats.total}</Typography>
             <Typography variant="body2" color="text.secondary">Total Invites</Typography>
           </Paper>
         </Grid>
-        <Grid item xs={12} sm={6} md={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
           <Paper sx={{ p: 2, textAlign: 'center' }}>
             <Typography variant="h4" color="success.main">{stats.active}</Typography>
             <Typography variant="body2" color="text.secondary">Active Invites</Typography>
           </Paper>
         </Grid>
-        <Grid item xs={12} sm={6} md={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
           <Paper sx={{ p: 2, textAlign: 'center' }}>
             <Typography variant="h4" color="error.main">{stats.expired}</Typography>
             <Typography variant="body2" color="text.secondary">Expired</Typography>
           </Paper>
         </Grid>
-        <Grid item xs={12} sm={6} md={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
           <Paper sx={{ p: 2, textAlign: 'center' }}>
             <Typography variant="h4" color="info.main">{stats.totalUses}</Typography>
             <Typography variant="body2" color="text.secondary">Total Uses</Typography>

--- a/frontend/src/pages/FriendsPage.tsx
+++ b/frontend/src/pages/FriendsPage.tsx
@@ -24,7 +24,7 @@ const Container = styled(Paper)(({ theme }) => ({
   height: "calc(100% - 64px)",
   display: "flex",
   flexDirection: "column",
-  borderRadius: theme.shape.borderRadius * 2,
+  borderRadius: Number(theme.shape.borderRadius) * 2,
   overflow: "hidden",
 }));
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -89,7 +89,7 @@ const DesktopHomePage: React.FC = () => {
       const createInviteDto: CreateInviteDto = {
         communityIds: selectedCommunities,
         maxUses: 10,
-        validUntil: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
+        validUntil: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(), // 7 days
       };
 
       const newInvite = await createInvite({ body: createInviteDto });
@@ -243,7 +243,7 @@ const DesktopHomePage: React.FC = () => {
             }}
           >
             <Avatar
-              src={avatarUrl}
+              src={avatarUrl ?? undefined}
               alt={`${data.displayName}'s avatar`}
               sx={{
                 width: 80,

--- a/frontend/src/pages/admin/AdminCommunitiesPage.tsx
+++ b/frontend/src/pages/admin/AdminCommunitiesPage.tsx
@@ -33,7 +33,7 @@ import {
 } from "../../api-client/@tanstack/react-query.gen";
 import { invalidateCommunityQueries } from "../../utils/queryInvalidation";
 
-import type { CommunityStatsDetailDto as AdminCommunity } from "../../api-client/types.gen";
+import type { CommunityStatsDto as AdminCommunity } from "../../api-client/types.gen";
 
 const AdminCommunitiesPage: React.FC = () => {
   const navigate = useNavigate();

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -82,7 +82,7 @@ const StatCard: React.FC<StatCardProps> = ({ title, value, icon, color }) => (
             justifyContent: "center",
           }}
         >
-          {React.cloneElement(icon as React.ReactElement, {
+          {React.cloneElement(icon as React.ReactElement<{ sx?: object }>, {
             sx: { fontSize: 28, color },
           })}
         </Box>

--- a/frontend/src/pages/admin/AdminRolesPage.tsx
+++ b/frontend/src/pages/admin/AdminRolesPage.tsx
@@ -49,7 +49,9 @@ import ConfirmDialog from "../../components/Common/ConfirmDialog";
 import type { RoleDto as InstanceRole } from "../../api-client/types.gen";
 
 // All valid instance-level actions (must match backend)
-const INSTANCE_ACTIONS = [
+type InstanceAction = InstanceRole["actions"][number];
+
+const INSTANCE_ACTIONS: { key: InstanceAction; label: string; category: string }[] = [
   { key: "READ_INSTANCE_SETTINGS", label: "View Instance Settings", category: "Settings" },
   { key: "UPDATE_INSTANCE_SETTINGS", label: "Update Instance Settings", category: "Settings" },
   { key: "READ_INSTANCE_STATS", label: "View Instance Statistics", category: "Settings" },
@@ -68,7 +70,7 @@ const ACTION_CATEGORIES = ["Settings", "Storage", "Users", "Invites"];
 
 interface RoleFormData {
   name: string;
-  actions: string[];
+  actions: InstanceAction[];
 }
 
 const AdminRolesPage: React.FC = () => {
@@ -120,7 +122,7 @@ const AdminRolesPage: React.FC = () => {
     setFormData({ name: "", actions: [] });
   };
 
-  const handleActionToggle = (action: string) => {
+  const handleActionToggle = (action: InstanceAction) => {
     setFormData((prev) => ({
       ...prev,
       actions: prev.actions.includes(action)
@@ -296,7 +298,7 @@ const AdminRolesPage: React.FC = () => {
             fullWidth
             value={formData.name}
             onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
-            disabled={editingRole && isDefaultRole(editingRole)}
+            disabled={!!editingRole && isDefaultRole(editingRole)}
             sx={{ mb: 3 }}
           />
           <Typography variant="subtitle2" gutterBottom>

--- a/frontend/src/pages/debug/NotificationDebugPage.tsx
+++ b/frontend/src/pages/debug/NotificationDebugPage.tsx
@@ -35,6 +35,7 @@ import DeleteSweepIcon from '@mui/icons-material/DeleteSweep';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import SendIcon from '@mui/icons-material/Send';
 import { useQuery } from '@tanstack/react-query';
+import type { DebugSubscriptionsResponseDto } from '../../api-client/types.gen';
 import { userControllerGetProfileOptions } from '../../api-client/@tanstack/react-query.gen';
 import { useNotificationPermission } from '../../hooks/useNotificationPermission';
 import { usePushNotifications } from '../../hooks/usePushNotifications';
@@ -104,11 +105,8 @@ const NotificationDebugPage: React.FC = () => {
     },
   });
 
-  const [subscriptionsData, setSubscriptionsData] = React.useState<{
-    subscriptions: Array<{ id: string; endpoint: string; userAgent?: string; createdAt: string }>;
-    count: number;
-    pushEnabled: boolean;
-  } | null>(null);
+  const [subscriptionsData, setSubscriptionsData] =
+    React.useState<DebugSubscriptionsResponseDto | null>(null);
   const [isLoadingSubscriptions, setIsLoadingSubscriptions] = React.useState(false);
 
   // Add a result to the log

--- a/frontend/src/socket-hub/handlers/communityHandlers.ts
+++ b/frontend/src/socket-hub/handlers/communityHandlers.ts
@@ -16,7 +16,7 @@ export const handleMemberAddedToCommunity: SocketEventHandler<typeof ServerEvent
 // =============================================================================
 
 export const handleChannelsReordered: SocketEventHandler<typeof ServerEvents.CHANNELS_REORDERED> = (
-  payload,
+  _payload,
   queryClient: QueryClient,
 ) => {
   queryClient.invalidateQueries({

--- a/frontend/src/socket-hub/handlers/messageHandlers.ts
+++ b/frontend/src/socket-hub/handlers/messageHandlers.ts
@@ -244,8 +244,8 @@ export const handleMessageUnpinned: SocketEventHandler<typeof ServerEvents.MESSA
     return updateMessageInInfinite(old as never, {
       ...msg,
       pinned: false,
-      pinnedBy: undefined,
-      pinnedAt: undefined,
+      pinnedBy: null,
+      pinnedAt: null,
     });
   });
   queryClient.invalidateQueries({
@@ -267,7 +267,7 @@ export const handleThreadReplyCountUpdated: SocketEventHandler<typeof ServerEven
     return updateMessageInInfinite(old as never, {
       ...msg,
       replyCount,
-      lastReplyAt: lastReplyAt ?? undefined,
+      lastReplyAt,
     });
   });
 };

--- a/frontend/src/socket-hub/handlers/messageHandlers.ts
+++ b/frontend/src/socket-hub/handlers/messageHandlers.ts
@@ -36,7 +36,10 @@ import type { ServerEvents } from '@semaphore-chat/shared';
 // deletes, or new messages. This is acceptable since anchored mode is transient
 // (seconds), and the user gets fresh data on return to normal mode.
 
-export const handleNewMessage: SocketEventHandler<typeof ServerEvents.NEW_MESSAGE> = async (
+// Registered for both NEW_MESSAGE and NEW_DM (they share the same payload shape).
+export const handleNewMessage: SocketEventHandler<
+  typeof ServerEvents.NEW_MESSAGE | typeof ServerEvents.NEW_DM
+> = async (
   { message }: NewMessagePayload,
   queryClient: QueryClient,
 ) => {
@@ -109,11 +112,11 @@ export const handleDeleteMessage: SocketEventHandler<typeof ServerEvents.DELETE_
     deleteMessageFromInfinite(old as never, messageId),
   );
 
-  // Remove thread replies cache if this was a thread parent
-  const threadQueryKey = threadsControllerGetRepliesQueryKey({
-    path: { parentMessageId: messageId },
+  // Remove thread replies cache if this was a thread parent.
+  // Partial key (no query params) so all paginated variants are removed.
+  queryClient.removeQueries({
+    queryKey: [{ _id: 'threadsControllerGetReplies', path: { parentMessageId: messageId } }],
   });
-  queryClient.removeQueries({ queryKey: threadQueryKey });
 };
 
 export const handleReactionAdded: SocketEventHandler<typeof ServerEvents.REACTION_ADDED> = async (
@@ -241,8 +244,8 @@ export const handleMessageUnpinned: SocketEventHandler<typeof ServerEvents.MESSA
     return updateMessageInInfinite(old as never, {
       ...msg,
       pinned: false,
-      pinnedBy: null,
-      pinnedAt: null,
+      pinnedBy: undefined,
+      pinnedAt: undefined,
     });
   });
   queryClient.invalidateQueries({
@@ -264,7 +267,7 @@ export const handleThreadReplyCountUpdated: SocketEventHandler<typeof ServerEven
     return updateMessageInInfinite(old as never, {
       ...msg,
       replyCount,
-      lastReplyAt,
+      lastReplyAt: lastReplyAt ?? undefined,
     });
   });
 };

--- a/frontend/src/socket-hub/handlers/notificationHandlers.ts
+++ b/frontend/src/socket-hub/handlers/notificationHandlers.ts
@@ -10,6 +10,7 @@ import type {
   UnreadCountResponseDto,
   UnreadCountDto,
   NotificationDto,
+  SpanDto,
 } from '../../api-client';
 import { NotificationType } from '../../types/notification.type';
 import type { SocketEventHandler } from './types';
@@ -36,16 +37,24 @@ export const handleNewNotification: SocketEventHandler<typeof ServerEvents.NEW_N
       ? {
           id: payload.author.id || '',
           username: payload.author.username,
+          displayName: null,
           avatarUrl: payload.author.avatarUrl ?? null,
         }
       : undefined,
     message: payload.message
       ? {
           id: payload.message.id || '',
+          channelId: payload.channelId ?? null,
+          directMessageGroupId: payload.directMessageGroupId ?? null,
           spans: payload.message.spans.map((s) => ({
-            type: s.type,
-            text: s.text,
-            userId: s.userId,
+            // The WS payload types span.type as a plain string; the values come
+            // from the same backend enum the SpanDto union is generated from.
+            type: s.type as SpanDto['type'],
+            text: s.text ?? null,
+            userId: s.userId ?? null,
+            specialKind: s.specialKind ?? null,
+            communityId: null,
+            aliasId: null,
           })),
         }
       : undefined,

--- a/frontend/src/socket-hub/handlers/voiceHandlers.ts
+++ b/frontend/src/socket-hub/handlers/voiceHandlers.ts
@@ -1,5 +1,5 @@
 import type { QueryClient } from '@tanstack/react-query';
-import type { ServerEvents } from '@semaphore-chat/shared';
+import type { ServerEvents, VoicePresenceUser } from '@semaphore-chat/shared';
 import {
   voicePresenceControllerGetChannelPresenceQueryKey,
   dmVoicePresenceControllerGetDmPresenceQueryKey,
@@ -13,19 +13,35 @@ function invalidateVoiceQueries(queryClient: QueryClient) {
   queryClient.invalidateQueries({ queryKey: [{ _id: 'dmVoicePresenceControllerGetDmPresence' }] });
 }
 
+/**
+ * Normalizes the WebSocket presence-user payload into the REST DTO shape used
+ * in the presence query caches. Over the wire joinedAt is always a serialized
+ * ISO string and the flags are always present, so this is a type-level
+ * normalization with no observable runtime change.
+ */
+function toPresenceUserDto(user: VoicePresenceUser): VoicePresenceUserDto {
+  return {
+    ...user,
+    joinedAt: user.joinedAt instanceof Date ? user.joinedAt.toISOString() : user.joinedAt,
+    isDeafened: user.isDeafened ?? false,
+    isServerMuted: user.isServerMuted ?? false,
+  };
+}
+
 export const handleVoiceUserJoined: SocketEventHandler<typeof ServerEvents.VOICE_CHANNEL_USER_JOINED> = (
-  data: { channelId: string; user: VoicePresenceUserDto },
+  data,
   queryClient: QueryClient,
 ) => {
   const queryKey = voicePresenceControllerGetChannelPresenceQueryKey({ path: { channelId: data.channelId } });
   const existing = queryClient.getQueryData<ChannelVoicePresenceResponseDto>(queryKey);
 
   if (existing) {
+    const user = toPresenceUserDto(data.user);
     queryClient.setQueryData<ChannelVoicePresenceResponseDto>(queryKey, (draft) => {
       if (!draft) return draft;
-      const existingIndex = draft.users.findIndex((u) => u.id === data.user.id);
+      const existingIndex = draft.users.findIndex((u) => u.id === user.id);
       if (existingIndex === -1) {
-        const newUsers = [...draft.users, data.user];
+        const newUsers = [...draft.users, user];
         return { ...draft, users: newUsers, count: newUsers.length };
       }
       return draft;
@@ -54,19 +70,20 @@ export const handleVoiceUserLeft: SocketEventHandler<typeof ServerEvents.VOICE_C
 };
 
 export const handleVoiceUserUpdated: SocketEventHandler<typeof ServerEvents.VOICE_CHANNEL_USER_UPDATED> = (
-  data: { channelId: string; user: VoicePresenceUserDto },
+  data,
   queryClient: QueryClient,
 ) => {
   const queryKey = voicePresenceControllerGetChannelPresenceQueryKey({ path: { channelId: data.channelId } });
   const existing = queryClient.getQueryData<ChannelVoicePresenceResponseDto>(queryKey);
 
   if (existing) {
+    const user = toPresenceUserDto(data.user);
     queryClient.setQueryData<ChannelVoicePresenceResponseDto>(queryKey, (draft) => {
       if (!draft) return draft;
-      const index = draft.users.findIndex((u) => u.id === data.user.id);
+      const index = draft.users.findIndex((u) => u.id === user.id);
       if (index !== -1) {
         const newUsers = [...draft.users];
-        newUsers[index] = data.user;
+        newUsers[index] = user;
         return { ...draft, users: newUsers };
       }
       return draft;
@@ -88,18 +105,19 @@ export const handleDmVoiceCallStarted: SocketEventHandler<typeof ServerEvents.DM
 };
 
 export const handleDmVoiceUserJoined: SocketEventHandler<typeof ServerEvents.DM_VOICE_USER_JOINED> = (
-  data: { dmGroupId: string; user: VoicePresenceUserDto },
+  data,
   queryClient: QueryClient,
 ) => {
   const queryKey = dmVoicePresenceControllerGetDmPresenceQueryKey({ path: { dmGroupId: data.dmGroupId } });
   const existing = queryClient.getQueryData<DmVoicePresenceResponseDto>(queryKey);
 
   if (existing) {
+    const user = toPresenceUserDto(data.user);
     queryClient.setQueryData<DmVoicePresenceResponseDto>(queryKey, (draft) => {
       if (!draft) return draft;
-      const existingIndex = draft.users.findIndex((u) => u.id === data.user.id);
+      const existingIndex = draft.users.findIndex((u) => u.id === user.id);
       if (existingIndex === -1) {
-        const newUsers = [...draft.users, data.user];
+        const newUsers = [...draft.users, user];
         return { ...draft, users: newUsers, count: newUsers.length };
       }
       return draft;
@@ -128,19 +146,20 @@ export const handleDmVoiceUserLeft: SocketEventHandler<typeof ServerEvents.DM_VO
 };
 
 export const handleDmVoiceUserUpdated: SocketEventHandler<typeof ServerEvents.DM_VOICE_USER_UPDATED> = (
-  data: { dmGroupId: string; user: VoicePresenceUserDto },
+  data,
   queryClient: QueryClient,
 ) => {
   const queryKey = dmVoicePresenceControllerGetDmPresenceQueryKey({ path: { dmGroupId: data.dmGroupId } });
   const existing = queryClient.getQueryData<DmVoicePresenceResponseDto>(queryKey);
 
   if (existing) {
+    const user = toPresenceUserDto(data.user);
     queryClient.setQueryData<DmVoicePresenceResponseDto>(queryKey, (draft) => {
       if (!draft) return draft;
-      const index = draft.users.findIndex((u) => u.id === data.user.id);
+      const index = draft.users.findIndex((u) => u.id === user.id);
       if (index !== -1) {
         const newUsers = [...draft.users];
-        newUsers[index] = data.user;
+        newUsers[index] = user;
         return { ...draft, users: newUsers };
       }
       return draft;

--- a/frontend/src/socket-hub/useSocketHub.ts
+++ b/frontend/src/socket-hub/useSocketHub.ts
@@ -72,7 +72,7 @@ export function useSocketHub(eventBus: EventBus) {
   useEffect(() => {
     if (!socket) return;
 
-    const listeners: Array<[string, (...args: unknown[]) => void]> = [];
+    const unsubscribers: Array<() => void> = [];
 
     for (const event of ALL_SERVER_EVENTS) {
       const listener = async (payload: ServerEventPayloads[typeof event]) => {
@@ -95,13 +95,13 @@ export function useSocketHub(eventBus: EventBus) {
         eventBus.emit(event, payload);
       };
 
-      socket.on(event as string, listener as never);
-      listeners.push([event as string, listener as never]);
+      socket.on(event, listener);
+      unsubscribers.push(() => socket.off(event, listener));
     }
 
     return () => {
-      for (const [event, listener] of listeners) {
-        socket.off(event as string, listener as never);
+      for (const unsubscribe of unsubscribers) {
+        unsubscribe();
       }
     };
   }, [socket, queryClient, eventBus]);

--- a/frontend/src/sw-custom.ts
+++ b/frontend/src/sw-custom.ts
@@ -76,7 +76,9 @@ self.addEventListener('push', (event: PushEvent) => {
     return;
   }
 
-  const options: NotificationOptions = {
+  // `vibrate` is a non-standard (but widely supported) notification option
+  // missing from the TS lib's NotificationOptions.
+  const options: NotificationOptions & { vibrate: number[] } = {
     body: data.body,
     icon: data.icon || '/pwa-192x192.png',
     badge: data.badge || '/pwa-192x192.png',

--- a/frontend/src/types/channel.type.ts
+++ b/frontend/src/types/channel.type.ts
@@ -1,1 +1,4 @@
-export { ChannelType, type Channel } from '@semaphore-chat/shared';
+export { ChannelType } from '@semaphore-chat/shared';
+// The API client's generated ChannelDto is the source of truth for channel
+// objects returned by the backend (string-literal `type`, string dates).
+export type { ChannelDto as Channel } from '../api-client/types.gen';

--- a/frontend/src/types/community.type.ts
+++ b/frontend/src/types/community.type.ts
@@ -1,8 +1,3 @@
-export interface Community {
-  id: string;
-  name: string;
-  avatar?: string | null;
-  banner?: string | null;
-  description?: string | null;
-  createdAt: Date;
-}
+// The API client's generated CommunityResponseDto is the source of truth for
+// community objects returned by the backend.
+export type { CommunityResponseDto as Community } from '../api-client/types.gen';

--- a/frontend/src/types/direct-message.type.ts
+++ b/frontend/src/types/direct-message.type.ts
@@ -1,35 +1,3 @@
-export interface DirectMessageGroup {
-  id: string;
-  name?: string | null;
-  isGroup: boolean;
-  createdAt: Date;
-  members: DirectMessageGroupMember[];
-  lastMessage?: {
-    id: string;
-    authorId: string;
-    spans: Array<{ type: string; text?: string; [key: string]: unknown }>;
-    sentAt: Date;
-  } | null;
-}
-
-export interface DirectMessageGroupMember {
-  id: string;
-  userId: string;
-  joinedAt: Date;
-  user: {
-    id: string;
-    username: string;
-    displayName?: string | null;
-    avatarUrl?: string | null;
-  };
-}
-
-export interface CreateDmGroupDto {
-  userIds: string[];
-  name?: string;
-  isGroup?: boolean;
-}
-
-export interface AddMembersDto {
-  userIds: string[];
-}
+// The API client's generated DmGroupResponseDto is the source of truth for DM
+// group objects returned by the backend (string dates, generated member DTOs).
+export type { DmGroupResponseDto as DirectMessageGroup } from '../api-client/types.gen';

--- a/frontend/src/types/friend.type.ts
+++ b/frontend/src/types/friend.type.ts
@@ -1,21 +1,12 @@
-import { User } from './auth.type';
+// The API client's generated friendship DTOs are the source of truth.
+export type {
+  FriendshipWithUsersDto as Friendship,
+  PendingRequestsDto as PendingRequests,
+} from '../api-client/types.gen';
 
-export type FriendshipStatus = 'PENDING' | 'ACCEPTED' | 'BLOCKED';
+import type { FriendshipWithUsersDto } from '../api-client/types.gen';
 
-export interface Friendship {
-  id: string;
-  userAId: string;
-  userBId: string;
-  status: FriendshipStatus;
-  createdAt: string;
-  userA?: User;
-  userB?: User;
-}
-
-export interface PendingRequests {
-  sent: Friendship[];
-  received: Friendship[];
-}
+export type FriendshipStatus = FriendshipWithUsersDto['status'];
 
 export interface FriendshipStatusResponse {
   status: FriendshipStatus | null;

--- a/frontend/src/types/invite.type.ts
+++ b/frontend/src/types/invite.type.ts
@@ -1,21 +1,7 @@
-import { User } from './auth.type';
-
-export interface InstanceInvite {
-  id: string;
-  code: string;
-  createdById?: string;
-  createdBy?: User;
-  defaultCommunities: Array<{ id: string; inviteId: string; communityId: string }>;
-  maxUses?: number;
-  uses: number;
-  validUntil?: Date;
-  createdAt: Date;
-  usages: Array<{ id: string; inviteId: string; userId: string; usedAt: Date }>;
-  disabled: boolean;
-}
-
-export interface CreateInviteDto {
-  maxUses?: number;
-  validUntil?: Date;
-  communityIds: string[];
-}
+// The API client's generated invite DTOs are the source of truth.
+// `InstanceInvite` is kept as a legacy alias for `InviteResponseDto`.
+export type {
+  CreateInviteDto,
+  InviteResponseDto,
+  InviteResponseDto as InstanceInvite,
+} from '../api-client/types.gen';

--- a/frontend/src/types/notification.type.ts
+++ b/frontend/src/types/notification.type.ts
@@ -5,13 +5,16 @@
  */
 
 import { NotificationType } from '@semaphore-chat/shared';
+import type { NotificationDto } from '../api-client/types.gen';
 
 export { NotificationType, type NewNotificationPayload, type NotificationReadPayload } from '@semaphore-chat/shared';
 
 export interface Notification {
   id: string;
   userId: string;
-  type: NotificationType;
+  // Accepts both the shared enum and the generated API client's literal union
+  // so NotificationDto values are assignable to Notification.
+  type: NotificationType | NotificationDto['type'];
   messageId: string | null;
   channelId: string | null;
   directMessageGroupId: string | null;
@@ -25,17 +28,18 @@ export interface Notification {
   author?: {
     id: string;
     username: string;
-    avatarUrl?: string;
+    displayName?: string | null;
+    avatarUrl?: string | null;
   };
   message?: {
     id: string;
     spans: Array<{
       type: string;
-      text?: string;
-      userId?: string;
-      specialKind?: string;
+      text?: string | null;
+      userId?: string | null;
+      specialKind?: string | null;
     }>;
-  };
+  } | null;
 }
 
 export interface UserNotificationSettings {

--- a/frontend/src/utils/tokenService.ts
+++ b/frontend/src/utils/tokenService.ts
@@ -174,6 +174,12 @@ export async function storeElectronRefreshToken(token: string): Promise<void> {
   localStorage.setItem("refreshToken", token);
 }
 
+/** Shape of the /auth/refresh response. Web responses omit refreshToken (cookie-based). */
+interface RefreshResponseBody {
+  accessToken: string;
+  refreshToken?: string;
+}
+
 async function performRefresh(): Promise<string | null> {
   const isElectronApp = isElectron();
 
@@ -187,13 +193,13 @@ async function performRefresh(): Promise<string | null> {
       }
 
       // For Electron, send refresh token in body
-      refreshResponse = await axios.post<{
-        accessToken: string;
-        refreshToken?: string;
-      }>(getApiUrl("/auth/refresh"), { refreshToken });
+      refreshResponse = await axios.post<RefreshResponseBody>(
+        getApiUrl("/auth/refresh"),
+        { refreshToken }
+      );
     } else {
       // For web clients, use cookie-based refresh
-      refreshResponse = await axios.post<{ accessToken: string }>(
+      refreshResponse = await axios.post<RefreshResponseBody>(
         getApiUrl("/auth/refresh"),
         {},
         { withCredentials: true }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -22,6 +22,9 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
 
+    /* Vitest runs with globals: true (vitest.config.ts) */
+    "types": ["vitest/globals"],
+
     "paths": {
       "@semaphore-chat/shared": ["../shared/src"],
       "@semaphore-chat/shared/*": ["../shared/src/*"]

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -139,7 +139,11 @@ for i in {1..60}; do
   fi
 done
 
-# Step 2: Seed the database
+# Step 2: Migrate + seed the database (volumes are fresh after `down -v`,
+# so the schema must be applied before seeding — same order as CI)
+echo -e "${BLUE}🗄️  Running database migrations...${NC}"
+docker-compose -f docker-compose.e2e.yml exec -T backend-test pnpm run prisma:migrate
+
 echo -e "${BLUE}🌱 Seeding test database...${NC}"
 docker-compose -f docker-compose.e2e.yml exec -T backend-test npx ts-node prisma/seed-e2e.ts || {
   echo -e "${YELLOW}⚠️  Seed script not found, creating test user via API...${NC}"

--- a/shared/src/type-maps/socket-io-types.ts
+++ b/shared/src/type-maps/socket-io-types.ts
@@ -5,111 +5,17 @@
  */
 
 import { ClientEvents } from '../events/client-events.enum';
-import { ServerEvents } from '../events/server-events.enum';
 import { Span, FileMetadata } from '../types/message.types';
-import {
-  AckPayload,
-  ErrorPayload,
-  NewMessagePayload,
-  UpdateMessagePayload,
-  DeleteMessagePayload,
-  ReactionAddedPayload,
-  ReactionRemovedPayload,
-  ReadReceiptUpdatedPayload,
-  NewNotificationPayload,
-  NotificationReadPayload,
-  UserOnlinePayload,
-  UserOfflinePayload,
-  UserTypingPayload,
-  VoiceChannelUserJoinedPayload,
-  VoiceChannelUserLeftPayload,
-  VoiceChannelUserUpdatedPayload,
-  DmVoiceCallStartedPayload,
-  DmVoiceUserJoinedPayload,
-  DmVoiceUserLeftPayload,
-  DmVoiceUserUpdatedPayload,
-  ReplayBufferStoppedPayload,
-  ReplayBufferFailedPayload,
-  ChannelsReorderedPayload,
-  UserBannedPayload,
-  UserKickedPayload,
-  UserTimedOutPayload,
-  TimeoutRemovedPayload,
-  MessagePinnedPayload,
-  MessageUnpinnedPayload,
-  NewThreadReplyPayload,
-  UpdateThreadReplyPayload,
-  DeleteThreadReplyPayload,
-  ThreadReplyCountUpdatedPayload,
-  MemberAddedToCommunityPayload,
-} from '../payloads/websocket-payloads';
+import { ServerEventPayloads } from '../payloads/websocket-payloads';
 
 /**
  * Server-to-Client WebSocket event types.
+ *
+ * Derived from {@link ServerEventPayloads} so the socket typing always covers
+ * every server event (the previous hand-maintained map drifted out of sync).
  */
 export type ServerToClientEvents = {
-  // Messaging: Channels
-  [ServerEvents.NEW_MESSAGE]: (data: NewMessagePayload) => void;
-  [ServerEvents.UPDATE_MESSAGE]: (data: UpdateMessagePayload) => void;
-  [ServerEvents.DELETE_MESSAGE]: (data: DeleteMessagePayload) => void;
-
-  // Message Reactions
-  [ServerEvents.REACTION_ADDED]: (data: ReactionAddedPayload) => void;
-  [ServerEvents.REACTION_REMOVED]: (data: ReactionRemovedPayload) => void;
-
-  // Read Receipts
-  [ServerEvents.READ_RECEIPT_UPDATED]: (data: ReadReceiptUpdatedPayload) => void;
-
-  // Messaging: Direct Messages
-  [ServerEvents.NEW_DM]: (data: NewMessagePayload) => void;
-
-  // Mentions & Notifications
-  [ServerEvents.NEW_NOTIFICATION]: (data: NewNotificationPayload) => void;
-  [ServerEvents.NOTIFICATION_READ]: (data: NotificationReadPayload) => void;
-
-  // Presence & Typing
-  [ServerEvents.USER_ONLINE]: (data: UserOnlinePayload) => void;
-  [ServerEvents.USER_OFFLINE]: (data: UserOfflinePayload) => void;
-  [ServerEvents.USER_TYPING]: (data: UserTypingPayload) => void;
-
-  // Voice Channels
-  [ServerEvents.VOICE_CHANNEL_USER_JOINED]: (data: VoiceChannelUserJoinedPayload) => void;
-  [ServerEvents.VOICE_CHANNEL_USER_LEFT]: (data: VoiceChannelUserLeftPayload) => void;
-  [ServerEvents.VOICE_CHANNEL_USER_UPDATED]: (data: VoiceChannelUserUpdatedPayload) => void;
-
-  // DM Voice Calls
-  [ServerEvents.DM_VOICE_CALL_STARTED]: (data: DmVoiceCallStartedPayload) => void;
-  [ServerEvents.DM_VOICE_USER_JOINED]: (data: DmVoiceUserJoinedPayload) => void;
-  [ServerEvents.DM_VOICE_USER_LEFT]: (data: DmVoiceUserLeftPayload) => void;
-  [ServerEvents.DM_VOICE_USER_UPDATED]: (data: DmVoiceUserUpdatedPayload) => void;
-
-  // Replay Buffer (Screen Recording)
-  [ServerEvents.REPLAY_BUFFER_STOPPED]: (data: ReplayBufferStoppedPayload) => void;
-  [ServerEvents.REPLAY_BUFFER_FAILED]: (data: ReplayBufferFailedPayload) => void;
-
-  // Threads
-  [ServerEvents.NEW_THREAD_REPLY]: (data: NewThreadReplyPayload) => void;
-  [ServerEvents.UPDATE_THREAD_REPLY]: (data: UpdateThreadReplyPayload) => void;
-  [ServerEvents.DELETE_THREAD_REPLY]: (data: DeleteThreadReplyPayload) => void;
-  [ServerEvents.THREAD_REPLY_COUNT_UPDATED]: (data: ThreadReplyCountUpdatedPayload) => void;
-
-  // Channel Management
-  [ServerEvents.CHANNELS_REORDERED]: (data: ChannelsReorderedPayload) => void;
-
-  // Moderation Events
-  [ServerEvents.USER_BANNED]: (data: UserBannedPayload) => void;
-  [ServerEvents.USER_KICKED]: (data: UserKickedPayload) => void;
-  [ServerEvents.USER_TIMED_OUT]: (data: UserTimedOutPayload) => void;
-  [ServerEvents.TIMEOUT_REMOVED]: (data: TimeoutRemovedPayload) => void;
-  [ServerEvents.MESSAGE_PINNED]: (data: MessagePinnedPayload) => void;
-  [ServerEvents.MESSAGE_UNPINNED]: (data: MessageUnpinnedPayload) => void;
-
-  // Community Membership
-  [ServerEvents.MEMBER_ADDED_TO_COMMUNITY]: (data: MemberAddedToCommunityPayload) => void;
-
-  // Acknowledgments & Errors
-  [ServerEvents.ACK]: (data: AckPayload) => void;
-  [ServerEvents.ERROR]: (data: ErrorPayload) => void;
+  [E in keyof ServerEventPayloads]: (data: ServerEventPayloads[E]) => void;
 };
 
 /**

--- a/shared/src/types/message.types.ts
+++ b/shared/src/types/message.types.ts
@@ -52,14 +52,14 @@ export interface Message {
   sentAt: string;
   editedAt?: string;
   deletedAt?: string;
-  // Pinning fields
+  // Pinning fields (server DTOs send explicit null when unset)
   pinned?: boolean;
-  pinnedAt?: string;
-  pinnedBy?: string;
+  pinnedAt?: string | null;
+  pinnedBy?: string | null;
   // Threading fields
   parentMessageId?: string;
   replyCount?: number;
-  lastReplyAt?: string;
+  lastReplyAt?: string | null;
   // Inline reply (quote) fields
   replyToId?: string | null;
   replyTo?: {


### PR DESCRIPTION
Fixes #356. Also fixes the E2E Tests workflow, red on every main push since #355 merged.

## Part 1 — frontend type-check was a no-op (#356)

Both CI workflows called bare `tsc --noEmit` against the solution-style root tsconfig, which type-checks **nothing** and always exits 0. They now run `pnpm run type-check` (`tsc -b`). Turning the real check on surfaced 349 accumulated errors; this PR takes them to **zero** with runtime behavior preserved:

- **Config**: `tsconfig.app.json` declares `vitest/globals` (76 errors were just missing test globals — vitest runs `globals: true`).
- **Type drift at the root**: `src/types/*` hand-copies of API shapes (channel, community, DM, friend, invite, notification) re-pointed to the generated `api-client` DTOs as source of truth; `ServerToClientEvents` in `shared/` is now derived from `ServerEventPayloads` instead of a drifted hand-written map.
- **Tests**: factories/mocks completed to match real types (`createChannel`, `createUser`, `createDmGroup`, `mockSocket`, `VoiceState` fixtures); vitest 4 `Mock` generics typed precisely. No assertions changed.
- **App code**: precise prop/event/DTO types, React 19 `useRef` args, MUI overloads; `DebugPushSubscriptionDto` declared the `id`/`userAgent` fields the endpoint already returns (spec + SDK regenerated).

### ⚠️ Notable find: `autoSubscribe: false` has never worked

The type-check exposed that `autoSubscribe: false` was passed to the `Room` **constructor**, where livekit-client silently ignores it (it's a `connect()` option). Every voice session has always run with auto-subscribe ON; the manual subscription layer (`useTrackSubscription`) has never been active on the wire — including during the PR #344 stability investigation that reasoned about it.

**This PR deliberately keeps current behavior** (dead option removed, explanatory comment added). Actually enabling `autoSubscribe: false` is a wire-level change to every voice session and should be its own PR validated with the voice E2E harness. Follow-up tracked in #365.

Two micro-fixes that do change behavior, both bugs: VoiceBottomBar's PTT-held label used `palette...positiveText` which doesn't exist (undefined at runtime) → now `getContrastText(positive)`; WS cache writes in notification/message handlers now populate fields their DTOs require (null defaults matching server shapes).

## Part 2 — E2E workflow red on every main push since June 6

All 14 failures in the latest main run were `voice/` specs; all 18 non-voice tests passed. Root cause: the push/PR e2e job runs `playwright test` with no project filter, which includes the `voice` project — but only the nightly-gated `voice-e2e` job starts the real LiveKit server those specs need. The specs also leaked into the `chromium` project (its `testIgnore` only excluded `auth.spec.ts`), so they ran twice and failed twice, burning ~15 min of retries per push.

- `playwright.config.ts`: chromium project ignores `voice/`
- `e2e-tests.yml`: e2e job selects `--project=chromium --project=auth-tests` explicitly
- `scripts/run-e2e.sh`: run migrations before seeding (local runner broke on fresh volumes; CI already migrated)

## Verification

- `tsc -b --force`: **0 errors** (was 349)
- Frontend unit suite: 1271/1274, the 3 failures are the documented WSL flaky-timeout baseline (all pass in isolation); backend: 2142/2142
- Lint: 0 errors both sides (warnings at the pre-existing 20 baseline)
- E2E locally against the dockerized stack: chromium+auth-tests green; `--list` confirms zero voice specs in the selected projects; voice specs remain intact under the `voice` project for the nightly job

🤖 Generated with [Claude Code](https://claude.com/claude-code)
