### PR TITLE
feat(messages): enable right-click context menu on web (#299)

### DIFF
--- a/frontend/src/__tests__/components/MessageComponent.contextMenu.test.tsx
+++ b/frontend/src/__tests__/components/MessageComponent.contextMenu.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import MessageComponent from '../../components/Message/MessageComponent';
+import { createMessage } from '../test-utils/factories';
+import { SpanType } from '../../types/message.type';
+
+// Mock platform detection — web, to prove the context menu works outside Electron
+vi.mock('../../utils/platform', () => ({
+  isElectron: vi.fn(() => false),
+  isWeb: vi.fn(() => true),
+}));
+
+vi.mock('../../utils/clipboard', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: { id: 'user-1', username: 'alice' } }),
+}));
+
+vi.mock('../../contexts/UserProfileContext', () => ({
+  useUserProfile: () => ({ openProfile: vi.fn() }),
+}));
+
+// UserAvatar requires FileCacheProvider; stub it out
+vi.mock('../../components/Common/UserAvatar', () => ({
+  default: () => <div data-testid="avatar" />,
+}));
+
+const mockPermissions = {
+  canEdit: true,
+  canDelete: true,
+  canPin: true,
+  canReact: true,
+  isOwnMessage: true,
+};
+vi.mock('../../hooks/useMessagePermissions', () => ({
+  useMessagePermissions: () => mockPermissions,
+}));
+
+const mockActions = {
+  isEditing: false,
+  editText: '',
+  editAttachments: [],
+  stagedForDelete: false,
+  isDeleting: false,
+  setEditText: vi.fn(),
+  handleEditClick: vi.fn(),
+  handleEditSave: vi.fn(),
+  handleEditCancel: vi.fn(),
+  handleRemoveAttachment: vi.fn(),
+  handleDeleteClick: vi.fn(),
+  handleConfirmDelete: vi.fn(),
+  handleCancelDelete: vi.fn(),
+  handleConfirmThreadDelete: vi.fn(),
+  handleCancelThreadDelete: vi.fn(),
+  showThreadDeleteConfirm: false,
+  handleReactionClick: vi.fn(),
+  handleEmojiSelect: vi.fn(),
+  handlePin: vi.fn(),
+  handleUnpin: vi.fn(),
+};
+vi.mock('../../components/Message/useMessageActions', () => ({
+  useMessageActions: () => mockActions,
+}));
+
+function renderMessage() {
+  const message = createMessage({
+    spans: [{ type: SpanType.PLAINTEXT, text: 'Right-click me' }],
+  });
+  return {
+    message,
+    ...renderWithProviders(<MessageComponent message={message} />),
+  };
+}
+
+describe('MessageComponent context menu (web)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens the custom context menu on right-click and prevents the native menu', () => {
+    renderMessage();
+
+    const messageText = screen.getByText('Right-click me');
+    const notPrevented = fireEvent.contextMenu(messageText, {
+      clientX: 120,
+      clientY: 240,
+    });
+
+    // fireEvent returns false when preventDefault was called
+    expect(notPrevented).toBe(false);
+    expect(screen.getByText('Copy Message Content')).toBeInTheDocument();
+    expect(screen.getByText('Edit Message')).toBeInTheDocument();
+    expect(screen.getByText('Delete Message')).toBeInTheDocument();
+  });
+
+  it('closes the context menu on Escape', async () => {
+    renderMessage();
+
+    fireEvent.contextMenu(screen.getByText('Right-click me'));
+    const menu = await screen.findByRole('menu');
+
+    fireEvent.keyDown(menu, { key: 'Escape' });
+    await waitFor(() =>
+      expect(screen.queryByText('Copy Message Content')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('invokes the edit action from the context menu', async () => {
+    const { user } = renderMessage();
+
+    fireEvent.contextMenu(screen.getByText('Right-click me'));
+    await user.click(screen.getByText('Edit Message'));
+
+    expect(mockActions.handleEditClick).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/MessageContextMenu.test.tsx
+++ b/frontend/src/__tests__/components/MessageContextMenu.test.tsx
@@ -7,10 +7,10 @@ import MessageContextMenu, {
 import { createMessage } from '../test-utils/factories';
 import { SpanType } from '../../types/message.type';
 
-// Mock platform detection — Electron by default
+// Mock platform detection — web by default (the menu is platform-agnostic)
 vi.mock('../../utils/platform', () => ({
-  isElectron: vi.fn(() => true),
-  isWeb: vi.fn(() => false),
+  isElectron: vi.fn(() => false),
+  isWeb: vi.fn(() => true),
 }));
 
 // Mock clipboard utility

--- a/frontend/src/__tests__/components/MessageContextMenu.test.tsx
+++ b/frontend/src/__tests__/components/MessageContextMenu.test.tsx
@@ -7,12 +7,6 @@ import MessageContextMenu, {
 import { createMessage } from '../test-utils/factories';
 import { SpanType } from '../../types/message.type';
 
-// Mock platform detection — web by default (the menu is platform-agnostic)
-vi.mock('../../utils/platform', () => ({
-  isElectron: vi.fn(() => false),
-  isWeb: vi.fn(() => true),
-}));
-
 // Mock clipboard utility
 vi.mock('../../utils/clipboard', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(undefined),

--- a/frontend/src/components/Message/MessageComponent.tsx
+++ b/frontend/src/components/Message/MessageComponent.tsx
@@ -29,7 +29,6 @@ import QuotePreview from "./QuotePreview";
 import { useUserProfile } from "../../contexts/UserProfileContext";
 import { SeenByTooltip } from "./SeenByTooltip";
 import { VoiceSessionType } from "../../contexts/VoiceContext";
-import { isElectron } from "../../utils/platform";
 import MessageContextMenu from "./MessageContextMenu";
 import { EmojiPickerPopover } from "./EmojiPicker";
 
@@ -109,12 +108,11 @@ function MessageComponentInner({
     handleUnpin,
   } = useMessageActions(message, currentUser?.id);
 
-  // Context menu state (Electron only)
+  // Context menu state
   const [contextMenuPosition, setContextMenuPosition] = useState<{ top: number; left: number } | null>(null);
   const [emojiPickerPosition, setEmojiPickerPosition] = useState<{ top: number; left: number } | null>(null);
 
   const handleContextMenu = useCallback((event: React.MouseEvent) => {
-    if (!isElectron()) return; // Allow native browser context menu on web
     event.preventDefault();
     setContextMenuPosition({ top: event.clientY, left: event.clientX });
   }, []);
@@ -271,38 +269,34 @@ function MessageComponentInner({
         onConfirm={handleConfirmThreadDelete}
         onCancel={handleCancelThreadDelete}
       />
-      {isElectron() && (
-        <>
-          <MessageContextMenu
-            anchorPosition={contextMenuPosition}
-            open={Boolean(contextMenuPosition)}
-            onClose={handleCloseContextMenu}
-            message={message}
-            canEdit={canEdit}
-            canDelete={canDelete}
-            canPin={canPin}
-            canReact={canReact}
-            canThread={canThread}
-            isPinned={isPinned}
-            onEdit={handleEditClick}
-            onDelete={handleDeleteClick}
-            onPin={handlePin}
-            onUnpin={handleUnpin}
-            onReplyInThread={handleOpenThread}
-            onQuoteReply={onQuoteReply && !message.deletedAt ? () => onQuoteReply(message) : undefined}
-            onAddReaction={handleAddReaction}
-          />
-          <EmojiPickerPopover
-            open={Boolean(emojiPickerPosition)}
-            anchorPosition={emojiPickerPosition}
-            onClose={() => setEmojiPickerPosition(null)}
-            onEmojiSelect={(emoji) => {
-              handleEmojiSelect(emoji);
-              setEmojiPickerPosition(null);
-            }}
-          />
-        </>
-      )}
+      <MessageContextMenu
+        anchorPosition={contextMenuPosition}
+        open={Boolean(contextMenuPosition)}
+        onClose={handleCloseContextMenu}
+        message={message}
+        canEdit={canEdit}
+        canDelete={canDelete}
+        canPin={canPin}
+        canReact={canReact}
+        canThread={canThread}
+        isPinned={isPinned}
+        onEdit={handleEditClick}
+        onDelete={handleDeleteClick}
+        onPin={handlePin}
+        onUnpin={handleUnpin}
+        onReplyInThread={handleOpenThread}
+        onQuoteReply={onQuoteReply && !message.deletedAt ? () => onQuoteReply(message) : undefined}
+        onAddReaction={handleAddReaction}
+      />
+      <EmojiPickerPopover
+        open={Boolean(emojiPickerPosition)}
+        anchorPosition={emojiPickerPosition}
+        onClose={() => setEmojiPickerPosition(null)}
+        onEmojiSelect={(emoji) => {
+          handleEmojiSelect(emoji);
+          setEmojiPickerPosition(null);
+        }}
+      />
     </Container>
   );
 }

--- a/frontend/src/components/Message/MessageContextMenu.tsx
+++ b/frontend/src/components/Message/MessageContextMenu.tsx
@@ -1,9 +1,8 @@
 /**
  * MessageContextMenu
  *
- * Right-click context menu for messages in the Electron app.
+ * Right-click context menu for messages (web and Electron).
  * Provides quick access to message actions: reply, react, pin, edit, delete, copy.
- * On web, the native browser context menu is preserved (this component is not rendered).
  */
 
 import React, { useCallback } from 'react';


### PR DESCRIPTION
## Summary
- Removes the `isElectron()` gate so the existing `MessageContextMenu` (reply, reply in thread, react, pin/unpin, edit, delete, copy) opens on right-click in web browsers, not just the Electron app
- Same permission gating as the hover toolbar (`useMessagePermissions`) — no new permission logic
- Updated the `MessageContextMenu` tests to run with the web platform mock (proving the menu is platform-agnostic) and added an integration test that right-clicks a rendered `MessageComponent`

## Design note
The custom menu always replaces the native browser context menu on messages (Discord-style). "Copy Message Content" covers the dominant native-menu use case; text selections can still be copied with Ctrl+C since opening the menu doesn't clear the selection.

## Testing
- `MessageComponent.contextMenu.test.tsx` (new): menu opens on right-click with `preventDefault`, closes on Escape, actions dispatch
- `MessageContextMenu.test.tsx`: all 17 tests pass with `isElectron: false`
- `MessageContainer.test.tsx`, `MessageToolbar.test.tsx`: unaffected, pass
- Lint clean; type-check has only the known pre-existing stale-SDK error in `ResetPasswordDialog` (CI regenerates the client first)

Fixes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQrcNdL1tCnTNfbqxKsecu