### PR TITLE
feat(voice): auto-open video panel when a screen share starts (#71)

### DIFF
--- a/frontend/src/__tests__/hooks/useScreenShare.test.ts
+++ b/frontend/src/__tests__/hooks/useScreenShare.test.ts
@@ -11,10 +11,14 @@ vi.mock('../../api-client/client.gen', async (importOriginal) => {
 });
 
 const mockToggleScreenShare = vi.fn().mockResolvedValue(undefined);
+const mockSetShowVideoTiles = vi.fn();
 vi.mock('../../hooks/useVoiceConnection', () => ({
   useVoiceConnection: vi.fn(() => ({
     state: { isConnected: true },
-    actions: { toggleScreenShare: mockToggleScreenShare },
+    actions: {
+      toggleScreenShare: mockToggleScreenShare,
+      setShowVideoTiles: mockSetShowVideoTiles,
+    },
   })),
 }));
 
@@ -148,5 +152,26 @@ describe('useScreenShare', () => {
     rerender();
 
     expect(mockClearScreenShareConfig).toHaveBeenCalled();
+  });
+
+  it('opens the video panel when own screen share starts', () => {
+    const { rerender } = renderUseScreenShare();
+    expect(mockSetShowVideoTiles).not.toHaveBeenCalled();
+
+    // Simulate sharing starting
+    mockIsScreenShareEnabled = true;
+    rerender();
+
+    expect(mockSetShowVideoTiles).toHaveBeenCalledWith(true);
+  });
+
+  it('does not open the video panel when sharing stops', () => {
+    mockIsScreenShareEnabled = true;
+    const { rerender } = renderUseScreenShare();
+
+    mockIsScreenShareEnabled = false;
+    rerender();
+
+    expect(mockSetShowVideoTiles).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/hooks/useTrackSubscription.test.ts
+++ b/frontend/src/__tests__/hooks/useTrackSubscription.test.ts
@@ -97,6 +97,7 @@ vi.mock('../../contexts/VoiceContext', () => ({
     StopWatchingCamera2: 'STOP_WATCHING_CAMERA',
     WatchScreenShare: 'WATCH_SCREEN_SHARE',
     StopWatchingScreenShare2: 'STOP_WATCHING_SCREEN_SHARE',
+    SetShowVideoTiles: 'SET_SHOW_VIDEO_TILES',
   },
 }));
 
@@ -191,6 +192,41 @@ describe('useTrackSubscription', () => {
       });
 
       expect(screenPub.setSubscribed).not.toHaveBeenCalled();
+    });
+
+    it('opens the video panel when a screen share is published', () => {
+      renderHook(() => useTrackSubscription());
+
+      const screenPub = createMockPublication('screen_share');
+      const participant = createMockParticipant('user-1', [screenPub]);
+
+      act(() => {
+        emitRoomEvent('trackPublished', screenPub, participant);
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_SHOW_VIDEO_TILES',
+        payload: true,
+      });
+    });
+
+    it('does not open the video panel for mic, camera, or screen share audio publishes', () => {
+      renderHook(() => useTrackSubscription());
+
+      const micPub = createMockPublication('microphone');
+      const camPub = createMockPublication('camera');
+      const screenAudioPub = createMockPublication('screen_share_audio');
+      const participant = createMockParticipant('user-1', [micPub, camPub, screenAudioPub]);
+
+      act(() => {
+        emitRoomEvent('trackPublished', micPub, participant);
+        emitRoomEvent('trackPublished', camPub, participant);
+        emitRoomEvent('trackPublished', screenAudioPub, participant);
+      });
+
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'SET_SHOW_VIDEO_TILES' }),
+      );
     });
 
     it('unsubscribes previously-subscribed opt-in tracks on re-publish', () => {

--- a/frontend/src/hooks/useScreenShare.ts
+++ b/frontend/src/hooks/useScreenShare.ts
@@ -122,6 +122,20 @@ export const useScreenShare = (): UseScreenShareReturn => {
     }
   }, [isScreenShareEnabled]);
 
+  /**
+   * Open the video panel when our own screen share starts, so the sharer
+   * sees what they are broadcasting (remote viewers get the same via
+   * useTrackSubscription's TrackPublished handler)
+   */
+  const { setShowVideoTiles } = actions;
+  const prevScreenShareEnabledRef = useRef(isScreenShareEnabled);
+  useEffect(() => {
+    if (isScreenShareEnabled && !prevScreenShareEnabledRef.current) {
+      setShowVideoTiles(true);
+    }
+    prevScreenShareEnabledRef.current = isScreenShareEnabled;
+  }, [isScreenShareEnabled, setShowVideoTiles]);
+
   return {
     isScreenSharing: isScreenShareEnabled,
     showSourcePicker,

--- a/frontend/src/hooks/useTrackSubscription.ts
+++ b/frontend/src/hooks/useTrackSubscription.ts
@@ -158,6 +158,12 @@ export function useTrackSubscription(): TrackSubscriptionActions {
         subscribePublication(publication, `published-mic:${participant.identity}`);
       } else if (isOptInSource(publication.source)) {
         unsubscribePublication(publication, `published:${participant.identity}`);
+        // Surface new screen shares: open the video panel so the viewer sees
+        // the "Click to watch" tile (watching remains opt-in per subscription policy)
+        if (publication.source === Track.Source.ScreenShare) {
+          logger.info('[TrackSubscription] Screen share published, opening video panel', participant.identity);
+          dispatch({ type: VoiceActionType.SetShowVideoTiles, payload: true });
+        }
       }
     };
 


### PR DESCRIPTION
## Summary
- **Remote shares**: when a participant publishes a screen share track, `useTrackSubscription`'s `TrackPublished` handler now dispatches `SetShowVideoTiles: true`, so viewers get the video panel with the existing "Click to watch" placeholder tile
- **No auto-subscribe**: watching remains opt-in — the selective track subscription policy from #367 is untouched, so this costs no video bandwidth until the user clicks to watch
- **Local sharer**: `useScreenShare` opens the panel on the `isScreenShareEnabled` false→true transition, so the sharer sees what they're broadcasting regardless of which UI entry point started the share

## Known limitation
Joining a call where someone is *already* sharing doesn't auto-open the panel — `TrackPublished` only fires for new publishes. The per-user share icons in the voice user list still cover that case.

## Testing
- `useTrackSubscription.test.ts`: screen share publish dispatches `SET_SHOW_VIDEO_TILES`; mic/camera/screen-share-audio publishes don't; all existing subscription-policy tests pass
- `useScreenShare.test.ts`: panel opens on share start, not on stop
- Lint clean

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQrcNdL1tCnTNfbqxKsecu