### PR TITLE
fix(replay): user-friendly status and error messages (#285)

### DIFF
--- a/backend/src/livekit/ffmpeg.service.spec.ts
+++ b/backend/src/livekit/ffmpeg.service.spec.ts
@@ -92,7 +92,7 @@ describe('FfmpegService', () => {
 
     it('should throw error when no segments provided', async () => {
       await expect(service.concatenateSegments([], outputPath)).rejects.toThrow(
-        'No segments provided for concatenation',
+        'No replay video is available to process.',
       );
     });
 
@@ -346,7 +346,9 @@ describe('FfmpegService', () => {
 
       await expect(
         service.getVideoDuration('/path/to/missing.mp4'),
-      ).rejects.toThrow('FFprobe failed: File not found');
+      ).rejects.toThrow(
+        'Could not process the replay video. Please try again.',
+      );
     });
   });
 

--- a/backend/src/livekit/ffmpeg.service.ts
+++ b/backend/src/livekit/ffmpeg.service.ts
@@ -58,7 +58,7 @@ export class FfmpegService {
     },
   ): Promise<void> {
     if (segmentPaths.length === 0) {
-      throw new BadRequestException('No segments provided for concatenation');
+      throw new BadRequestException('No replay video is available to process.');
     }
 
     const tempDir = `/tmp/replay-concat-${uuidv4()}`;
@@ -304,7 +304,7 @@ export class FfmpegService {
         `Failed to probe video duration: ${getErrorMessage(err)}`,
       );
       throw new InternalServerErrorException(
-        `FFprobe failed: ${getErrorMessage(err)}`,
+        'Could not process the replay video. Please try again.',
       );
     }
   }

--- a/backend/src/livekit/livekit-replay.service.ts
+++ b/backend/src/livekit/livekit-replay.service.ts
@@ -259,7 +259,9 @@ export class LivekitReplayService {
       this.logger.error(
         `Failed to start egress for user ${userId}: ${getErrorMessage(error)}`,
       );
-      throw new BadRequestException('Failed to start replay buffer egress');
+      throw new BadRequestException(
+        'Could not start the replay recorder. Please try screen sharing again.',
+      );
     }
   }
 
@@ -306,7 +308,9 @@ export class LivekitReplayService {
 
     if (!session) {
       this.logger.warn(`No active session found for user ${userId}`);
-      throw new NotFoundException('No active replay buffer session found');
+      throw new NotFoundException(
+        'No active replay found. Start screen sharing to record a replay.',
+      );
     }
 
     try {
@@ -324,7 +328,9 @@ export class LivekitReplayService {
         this.logger.error(
           `Failed to stop egress ${session.egressId}: ${errorMsg}`,
         );
-        throw new BadRequestException('Failed to stop replay buffer egress');
+        throw new BadRequestException(
+          'Could not stop the replay recorder. Please try again.',
+        );
       }
     }
 
@@ -652,7 +658,7 @@ export class LivekitReplayService {
 
     if (!session) {
       throw new NotFoundException(
-        'No active replay buffer session found. Start screen sharing first.',
+        'No active replay found. Start screen sharing first.',
       );
     }
 
@@ -671,7 +677,7 @@ export class LivekitReplayService {
 
     if (allSegments.length === 0) {
       throw new BadRequestException(
-        'No segments available in replay buffer. Start screen sharing and wait for the buffer to accumulate.',
+        'Your replay is still warming up. Keep sharing your screen for a few seconds, then try again.',
       );
     }
 
@@ -730,7 +736,7 @@ export class LivekitReplayService {
 
     if (!session) {
       throw new NotFoundException(
-        'No active replay buffer session found. Start screen sharing first.',
+        'No active replay found. Start screen sharing first.',
       );
     }
 
@@ -745,7 +751,7 @@ export class LivekitReplayService {
 
     if (allSegments.length === 0) {
       throw new BadRequestException(
-        'No segments available in replay buffer. Start screen sharing and wait for the buffer to accumulate.',
+        'Your replay is still warming up. Keep sharing your screen for a few seconds, then try again.',
       );
     }
 
@@ -772,7 +778,7 @@ export class LivekitReplayService {
 
       if (clampedStart >= clampedEnd) {
         throw new BadRequestException(
-          'Requested range has no available segments. The buffer may have been cleaned up.',
+          'That part of the replay is no longer available. Try a more recent time range.',
         );
       }
 
@@ -913,14 +919,14 @@ export class LivekitReplayService {
         where: { id: dto.targetChannelId },
       });
       if (!channel) {
-        throw new NotFoundException('Target channel not found');
+        throw new NotFoundException('That channel could not be found.');
       }
       const membership = await this.databaseService.membership.findFirst({
         where: { userId, communityId: channel.communityId },
       });
       if (!membership) {
         throw new ForbiddenException(
-          "You are not a member of the target channel's community",
+          "You don't have permission to post in that channel.",
         );
       }
       // Private channels require explicit channel membership
@@ -931,7 +937,7 @@ export class LivekitReplayService {
           });
         if (!channelMembership) {
           throw new ForbiddenException(
-            'You do not have access to this private channel',
+            "You don't have permission to post in that channel.",
           );
         }
       }
@@ -944,7 +950,7 @@ export class LivekitReplayService {
         });
       if (!dmMember) {
         throw new ForbiddenException(
-          'You are not a member of the target DM group',
+          "You don't have permission to post in that conversation.",
         );
       }
     }
@@ -1148,7 +1154,9 @@ export class LivekitReplayService {
     });
 
     if (!session) {
-      throw new NotFoundException('No active replay buffer session found.');
+      throw new NotFoundException(
+        'No active replay found. Start screen sharing first.',
+      );
     }
 
     // Resolve relative segment path to full path
@@ -1160,7 +1168,7 @@ export class LivekitReplayService {
 
     if (completeSegments.length === 0) {
       throw new BadRequestException(
-        'No complete segments available in buffer yet. Please wait a moment.',
+        'Your replay is still warming up. Please wait a few seconds and try again.',
       );
     }
 

--- a/backend/src/livekit/replay-segments.service.spec.ts
+++ b/backend/src/livekit/replay-segments.service.spec.ts
@@ -268,13 +268,13 @@ describe('ReplaySegmentsService', () => {
     it('should reject filenames with path traversal attempts', async () => {
       await expect(
         service.getSegmentPath(userId, '../../../etc/passwd'),
-      ).rejects.toThrow('Invalid segment filename.');
+      ).rejects.toThrow('That replay segment is not valid.');
     });
 
     it('should reject filenames with invalid format', async () => {
       await expect(
         service.getSegmentPath(userId, 'segment.mp4'),
-      ).rejects.toThrow('Invalid segment filename.');
+      ).rejects.toThrow('That replay segment is not valid.');
     });
 
     it('should throw NotFoundException when no active session', async () => {
@@ -282,7 +282,7 @@ describe('ReplaySegmentsService', () => {
 
       await expect(
         service.getSegmentPath(userId, 'segment_00001.ts'),
-      ).rejects.toThrow('No active replay buffer session found.');
+      ).rejects.toThrow('No active replay found. Start screen sharing first.');
     });
 
     it('should throw NotFoundException when segment file does not exist', async () => {
@@ -290,7 +290,7 @@ describe('ReplaySegmentsService', () => {
 
       await expect(
         service.getSegmentPath(userId, 'segment_00001.ts'),
-      ).rejects.toThrow('Segment segment_00001.ts not found.');
+      ).rejects.toThrow('That part of the replay is no longer available.');
     });
 
     it('should return resolved segment path', async () => {

--- a/backend/src/livekit/replay-segments.service.ts
+++ b/backend/src/livekit/replay-segments.service.ts
@@ -389,7 +389,9 @@ export class ReplaySegmentsService {
     });
 
     if (!session) {
-      throw new NotFoundException('No active replay buffer session found.');
+      throw new NotFoundException(
+        'No active replay found. Start screen sharing first.',
+      );
     }
 
     // Validate segment filename format to prevent path traversal
@@ -398,7 +400,8 @@ export class ReplaySegmentsService {
       segmentFile.includes('..') ||
       segmentFile.includes('/')
     ) {
-      throw new BadRequestException('Invalid segment filename.');
+      this.logger.warn(`Rejected invalid segment filename: ${segmentFile}`);
+      throw new BadRequestException('That replay segment is not valid.');
     }
 
     // Resolve relative session path to full path, then join with segment filename
@@ -410,7 +413,10 @@ export class ReplaySegmentsService {
     // Verify file exists
     const exists = await this.storageService.fileExists(segmentPath);
     if (!exists) {
-      throw new NotFoundException(`Segment ${segmentFile} not found.`);
+      this.logger.warn(`Segment file not found on disk: ${segmentFile}`);
+      throw new NotFoundException(
+        'That part of the replay is no longer available.',
+      );
     }
 
     return segmentPath;

--- a/frontend/src/components/Voice/TrimPreview.tsx
+++ b/frontend/src/components/Voice/TrimPreview.tsx
@@ -173,14 +173,9 @@ export const TrimPreview: React.FC<TrimPreviewProps> = ({ onRangeChange }) => {
           });
         }
         if (data.fatal) {
-          let errorMessage = `Failed to load video preview: ${data.type}`;
-          if (data.details) {
-            errorMessage += ` (${data.details})`;
-          }
-          if (data.response?.code) {
-            errorMessage += ` - HTTP ${data.response.code}`;
-          }
-          setError(errorMessage);
+          // Full technical detail (type/details/HTTP code) is in the
+          // logger.error calls above; show the user a plain message
+          setError('Could not load the video preview. Please try again.');
           setIsLoading(false);
         }
       });
@@ -223,11 +218,11 @@ export const TrimPreview: React.FC<TrimPreviewProps> = ({ onRangeChange }) => {
       };
       video.addEventListener('loadedmetadata', handleLoadedMetadata);
       video.addEventListener('error', () => {
-        setError('Failed to load video preview');
+        setError('Could not load the video preview. Please try again.');
         setIsLoading(false);
       });
     } else {
-      setError('HLS playback is not supported in this browser');
+      setError('Video preview is not supported in this browser.');
       setIsLoading(false);
     }
   }, [sessionInfo?.hasActiveSession, isInitialized, retryKey]);
@@ -408,7 +403,7 @@ export const TrimPreview: React.FC<TrimPreviewProps> = ({ onRangeChange }) => {
   if (!sessionInfo?.hasActiveSession) {
     return (
       <Alert severity="warning" sx={{ mt: 2 }}>
-        No active replay buffer. Start screen sharing to enable custom trimming.
+        No replay yet. Start screen sharing to record a replay.
       </Alert>
     );
   }
@@ -416,7 +411,7 @@ export const TrimPreview: React.FC<TrimPreviewProps> = ({ onRangeChange }) => {
   if (maxDuration === 0) {
     return (
       <Alert severity="info" sx={{ mt: 2 }}>
-        Waiting for buffer to accumulate segments...
+        Getting your replay ready — keep sharing your screen for a few seconds.
       </Alert>
     );
   }


### PR DESCRIPTION
## Summary
Replay-related backend exception messages are shown to users verbatim in the error snackbar (`getErrorMessage` reads `error.data.message`), and several were developer-speak. This rewords them at the source:

| Before | After |
|---|---|
| Waiting for buffer to accumulate segments... | Getting your replay ready — keep sharing your screen for a few seconds. |
| No segments available in replay buffer. Start screen sharing and wait for the buffer to accumulate. | Your replay is still warming up. Keep sharing your screen for a few seconds, then try again. |
| Failed to start replay buffer egress | Could not start the replay recorder. Please try screen sharing again. |
| No active replay buffer session found. Start screen sharing first. | No active replay found. Start screen sharing first. |
| Segment xyz.ts not found. | That part of the replay is no longer available. |
| FFprobe failed: \<raw error\> | Could not process the replay video. Please try again. |
| Failed to load video preview: networkError (fragLoadError) - HTTP 404 | Could not load the video preview. Please try again. |
| HLS playback is not supported in this browser | Video preview is not supported in this browser. |

…plus the membership/permission variants ("You don't have permission to post in that channel/conversation.").

## Notes
- Exception **classes and status codes are unchanged** — only `message` strings
- Technical detail removed from user-facing messages is preserved (or newly added) in `this.logger` output, including the HLS.js error type/details that used to leak into the UI
- The LiveKit SDK error match in `stopReplayBuffer` ("egress does not exist") is untouched — that's their string, not ours
- No DTO/controller shape changes, so no OpenAPI regen needed

## Testing
- `ffmpeg.service.spec`, `replay-segments.service.spec`, `livekit-replay.service.spec`: 85/85 pass with updated string assertions
- Backend + frontend lint clean (TrimPreview's `exhaustive-deps` warning is pre-existing on main)

Fixes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQrcNdL1tCnTNfbqxKsecu