### PR TITLE
fix(voice): apply stored volume after audio track attach so muted streams stay silent on reopen

### DIFF
--- a/frontend/src/__tests__/components/AudioRenderer.test.tsx
+++ b/frontend/src/__tests__/components/AudioRenderer.test.tsx
@@ -6,12 +6,21 @@ import { AudioRenderer } from '../../components/Voice/AudioRenderer';
 type Handler = (...args: unknown[]) => void;
 let roomEventHandlers: Map<string, Set<Handler>>;
 
+// --- Mock audioBoostManager (real boostKey shape, spied applyVolume) ---
+const { applyVolumeMock } = vi.hoisted(() => ({ applyVolumeMock: vi.fn() }));
+
+vi.mock('../../features/voice/audioBoostManager', () => ({
+  audioBoostManager: { applyVolume: applyVolumeMock },
+  boostKey: (identity: string, source: string) => `${identity}:${source}`,
+}));
+
 // --- Mock track / participant factories ---
+// Tracks include setVolume so isBoostableAudioTrack treats them as RemoteAudioTracks.
 function createMockPublication(source: string, hasTrack = true) {
   return {
     source,
     trackSid: `sid-${source}-${Math.random()}`,
-    track: hasTrack ? { attach: vi.fn(), detach: vi.fn() } : undefined,
+    track: hasTrack ? { attach: vi.fn(), detach: vi.fn(), setVolume: vi.fn() } : undefined,
   };
 }
 
@@ -86,6 +95,7 @@ vi.mock('../../contexts/VoiceContext', () => ({
 describe('AudioRenderer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     buildMockRoom();
     mockWatchingScreenShares = new Set<string>();
   });
@@ -184,5 +194,61 @@ describe('AudioRenderer', () => {
     const { container } = render(<AudioRenderer />);
     const audioElements = container.querySelectorAll('audio');
     expect(audioElements.length).toBe(0);
+  });
+
+  describe('stored volume application after attach', () => {
+    it('applies a stored volume of 0 (muted mic) after the track is attached', () => {
+      // Stored as 0-2.0 float in localStorage; 0 means the user muted this stream
+      localStorage.setItem('voiceUserVolume:user-1', '0');
+      const micPub = createMockPublication('microphone');
+      const participant = createMockRemoteParticipant('user-1', [micPub]);
+      mockRoom!.remoteParticipants.set('user-1', participant);
+
+      render(<AudioRenderer />);
+
+      expect(applyVolumeMock).toHaveBeenCalledWith(micPub.track, 'user-1:microphone', 0);
+      // Must run AFTER attach: RemoteAudioTrack.attach only re-applies truthy
+      // volumes, so a pre-attach setVolume(0) never reaches the element.
+      const attachOrder = micPub.track!.attach.mock.invocationCallOrder[0];
+      const applyOrder = applyVolumeMock.mock.invocationCallOrder[0];
+      expect(applyOrder).toBeGreaterThan(attachOrder);
+    });
+
+    it('applies a stored volume of 0 for screen share audio when watching', () => {
+      mockWatchingScreenShares = new Set(['user-1']);
+      localStorage.setItem('voiceScreenShareVolume:user-1', '0');
+      const screenAudioPub = createMockPublication('screen_share_audio');
+      const participant = createMockRemoteParticipant('user-1', [screenAudioPub]);
+      mockRoom!.remoteParticipants.set('user-1', participant);
+
+      render(<AudioRenderer />);
+
+      expect(applyVolumeMock).toHaveBeenCalledWith(
+        screenAudioPub.track,
+        'user-1:screen_share_audio',
+        0,
+      );
+    });
+
+    it('defaults to 100% when no volume is stored', () => {
+      const micPub = createMockPublication('microphone');
+      const participant = createMockRemoteParticipant('user-1', [micPub]);
+      mockRoom!.remoteParticipants.set('user-1', participant);
+
+      render(<AudioRenderer />);
+
+      expect(applyVolumeMock).toHaveBeenCalledWith(micPub.track, 'user-1:microphone', 100);
+    });
+
+    it('applies a stored boosted volume (150%)', () => {
+      localStorage.setItem('voiceUserVolume:user-1', '1.5');
+      const micPub = createMockPublication('microphone');
+      const participant = createMockRemoteParticipant('user-1', [micPub]);
+      mockRoom!.remoteParticipants.set('user-1', participant);
+
+      render(<AudioRenderer />);
+
+      expect(applyVolumeMock).toHaveBeenCalledWith(micPub.track, 'user-1:microphone', 150);
+    });
   });
 });

--- a/frontend/src/components/Voice/AudioRenderer.tsx
+++ b/frontend/src/components/Voice/AudioRenderer.tsx
@@ -2,6 +2,9 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { RemoteParticipant, RemoteTrackPublication, Track, AudioTrack, RoomEvent } from 'livekit-client';
 import { useRoom } from '../../hooks/useRoom';
 import { useVoice } from '../../contexts/VoiceContext';
+import { audioBoostManager, boostKey } from '../../features/voice/audioBoostManager';
+import { isBoostableAudioTrack } from '../../features/voice/isBoostableAudioTrack';
+import { getStoredVolumePercent } from '../../features/voice/volumeStorage';
 import { logger } from '../../utils/logger';
 
 /**
@@ -33,12 +36,28 @@ const ParticipantAudio: React.FC<ParticipantAudioProps> = ({ participant, audioP
     logger.info('[AudioRenderer] Attaching audio track for:', participant.identity, 'trackSid:', audioPublication.trackSid);
     track.attach(audioElement);
 
+    // Re-apply the stored per-user volume AFTER attach. useRemoteVolumeEffect
+    // applies it on TrackSubscribed, which fires before this element exists —
+    // and RemoteAudioTrack.attach() only re-applies a previously set volume
+    // when it is truthy ("if (this.elementVolume)"), so a stored volume of 0
+    // (muted stream) never reaches the element and it plays at full volume.
+    // applyVolume is idempotent and internally respects the deafened state.
+    if (isBoostableAudioTrack(track)) {
+      const volumePercent =
+        getStoredVolumePercent(participant.identity, audioPublication.source) ?? 100;
+      audioBoostManager.applyVolume(
+        track,
+        boostKey(participant.identity, audioPublication.source),
+        volumePercent,
+      );
+    }
+
     return () => {
       // Detach the audio track when unmounting or track changes
       logger.info('[AudioRenderer] Detaching audio track for:', participant.identity);
       track.detach(audioElement);
     };
-  }, [audioPublication, audioPublication.track, participant.identity]);
+  }, [audioPublication, audioPublication.track, audioPublication.source, participant.identity]);
 
   return (
     <audio
@@ -46,7 +65,9 @@ const ParticipantAudio: React.FC<ParticipantAudioProps> = ({ participant, audioP
       autoPlay
       playsInline
       // Not muted - we want to hear remote audio
-      // Volume control is handled by useDeafenEffect hook via track.setVolume()
+      // Volume control: the stored per-user volume is applied right after
+      // track.attach() above (so falsy 0 survives attach), and live changes
+      // are owned by useRemoteVolumeEffect/useDeafenEffect via applyVolume.
     />
   );
 };


### PR DESCRIPTION
## Problem

Reopening a screen share (or rejoining voice) that you previously muted shows the volume control as muted — but the audio plays at **full volume** until you wiggle the slider and re-mute.

## Root cause

Mute is stored as volume `0` in localStorage. On `RoomEvent.TrackSubscribed`, `useRemoteVolumeEffect` applies the stored volume synchronously — but at that instant `AudioRenderer` hasn't attached an `<audio>` element yet (its React state update is still pending). livekit-client's `RemoteAudioTrack.setVolume(0)` therefore just records `elementVolume = 0` against zero attached elements, and when `attach()` runs later it only re-applies the stored volume `if (this.elementVolume)` — a **falsy-zero guard**. Stored `0` never reaches the element, which keeps its default `volume = 1.0`. Non-zero volumes survive because they're truthy — which is exactly why only the muted case leaked.

## Fix

`ParticipantAudio` (in `AudioRenderer.tsx`) now re-applies the stored per-user volume via `audioBoostManager.applyVolume(...)` immediately after `track.attach(audioElement)` — same synchronous effect, so there is no audible window. `useRemoteVolumeEffect` stays the persistent owner for live slider changes; `applyVolume` is idempotent so the double application is harmless.

- Deafen interplay is safe: `applyVolume` internally applies `deafened ? 0 : v`, and `useDeafenEffect` sets the deafen flag before muting — mounting while deafened cannot un-deafen.
- Bonus: this also closes a latent sibling race for **boosted** (>100%) tracks, whose element volume `0` was likewise not re-applied by `attach()` — previously the raw element could play at 1.0 alongside the WebAudio gain node.

## Verification

- 4 new tests in `AudioRenderer.test.tsx` (stored 0 for mic with attach-ordering assertion, stored 0 for screen-share audio while watching, default 100, boosted 150); 13/13 pass.
- Two independent adversarial reviews (correctness + regression lens) — zero findings; the correctness reviewer verified the falsy-zero guard against livekit-client's actual source.

Part of the undocumented-bug batch (voice indicators, message selection, tile avatar, background replay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
