### PR TITLE
fix(voice): scale placeholder avatar to tile height so it is not clipped in filmstrip tiles

### DIFF
--- a/frontend/src/__tests__/components/VideoTile.test.tsx
+++ b/frontend/src/__tests__/components/VideoTile.test.tsx
@@ -5,7 +5,9 @@ import VideoTile from '../../components/Voice/VideoTile';
 import type { VideoTileProps } from '../../components/Voice/VideoTile';
 
 vi.mock('../../components/Common/UserAvatar', () => ({
-  default: () => <div data-testid="avatar" />,
+  default: ({ size }: { size?: string }) => (
+    <div data-testid="avatar" data-size={size} />
+  ),
 }));
 
 vi.mock('../../components/Voice/ScreenShareVolumeControl', () => ({
@@ -131,5 +133,24 @@ describe('VideoTile', () => {
     await user.click(screen.getByText('Click to watch'));
 
     expect(onWatch).toHaveBeenCalledOnce();
+  });
+
+  it('placeholder tile renders name, caption, and a fluid avatar (not fixed xlarge)', () => {
+    renderTile({
+      isPlaceholder: true,
+      placeholderType: 'camera',
+      isLocal: true,
+      onWatch: vi.fn(),
+    });
+
+    expect(screen.getByText('RemoteUser')).toBeInTheDocument();
+    expect(screen.getByText('Click to show')).toBeInTheDocument();
+    expect(screen.getByTestId('avatar')).toHaveAttribute('data-size', 'fluid');
+  });
+
+  it('no-video tile renders a fluid avatar', () => {
+    renderTile({});
+
+    expect(screen.getByTestId('avatar')).toHaveAttribute('data-size', 'fluid');
   });
 });

--- a/frontend/src/components/Common/UserAvatar.tsx
+++ b/frontend/src/components/Common/UserAvatar.tsx
@@ -5,9 +5,9 @@ import UserStatusIndicator from "../Message/UserStatusIndicator";
 import { useUserProfile } from "../../contexts/UserProfileContext";
 import { useUser } from "../../hooks/useUser";
 
-type AvatarSize = "small" | "medium" | "large" | "xlarge";
+type AvatarSize = "small" | "medium" | "large" | "xlarge" | "fluid";
 
-const sizeMap: Record<AvatarSize, number> = {
+const sizeMap: Record<Exclude<AvatarSize, "fluid">, number> = {
   small: 32,
   medium: 40,
   large: 48,
@@ -32,7 +32,8 @@ const UserAvatar: React.FC<UserAvatarProps> = ({
   isOnline = false,
   clickable = false,
 }) => {
-  const avatarSize = sizeMap[size];
+  // "fluid" fills the parent container instead of using a fixed pixel size
+  const avatarSize = size === "fluid" ? "100%" : sizeMap[size];
   const { data: user } = useUser(userId);
   const { blobUrl, isLoading } = useAuthenticatedImage(user?.avatarUrl);
   const { openProfile } = useUserProfile();

--- a/frontend/src/components/Voice/VideoTile.tsx
+++ b/frontend/src/components/Voice/VideoTile.tsx
@@ -140,9 +140,11 @@ const VideoTile: React.FC<VideoTileProps> = ({
             gap: 1,
           }}
         >
-          <UserAvatar userId={participant.identity} displayName={participant.name} size="xlarge" />
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <Typography variant="caption" sx={{ color: 'grey.300', fontWeight: 'bold' }}>
+          <Box sx={{ height: 'min(120px, 45%)', aspectRatio: '1 / 1', flexShrink: 1, minHeight: 32 }}>
+            <UserAvatar userId={participant.identity} displayName={participant.name} size="fluid" />
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, maxWidth: '100%' }}>
+            <Typography variant="caption" noWrap sx={{ color: 'grey.300', fontWeight: 'bold', maxWidth: '90%' }}>
               {displayName}
             </Typography>
             {placeholderType === 'screen' ? (
@@ -210,7 +212,9 @@ const VideoTile: React.FC<VideoTileProps> = ({
             backgroundColor: 'grey.800',
           }}
         >
-          <UserAvatar userId={participant.identity} displayName={participant.name} size="xlarge" />
+          <Box sx={{ height: 'min(120px, 60%)', aspectRatio: '1 / 1', flexShrink: 1, minHeight: 32 }}>
+            <UserAvatar userId={participant.identity} displayName={participant.name} size="fluid" />
+          </Box>
         </Box>
       )}
 

--- a/frontend/src/components/Voice/VideoTile.tsx
+++ b/frontend/src/components/Voice/VideoTile.tsx
@@ -143,8 +143,8 @@ const VideoTile: React.FC<VideoTileProps> = ({
           <Box sx={{ height: 'min(120px, 45%)', aspectRatio: '1 / 1', flexShrink: 1, minHeight: 32 }}>
             <UserAvatar userId={participant.identity} displayName={participant.name} size="fluid" />
           </Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, maxWidth: '100%' }}>
-            <Typography variant="caption" noWrap sx={{ color: 'grey.300', fontWeight: 'bold', maxWidth: '90%' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, maxWidth: '100%', minWidth: 0 }}>
+            <Typography variant="caption" noWrap sx={{ color: 'grey.300', fontWeight: 'bold', minWidth: 0 }}>
               {displayName}
             </Typography>
             {placeholderType === 'screen' ? (


### PR DESCRIPTION
## Problem

Turning off your own camera while screen sharing leaves a placeholder tile in the 150px-tall sidebar filmstrip whose user avatar is clipped at the top.

## Root cause

The placeholder tile stacks a **fixed 120px** `xlarge` `UserAvatar` + name row + "Click to show" caption + gaps (~170px total) inside a 150px tile whose Card has `overflow: hidden`. The centered column clips top and bottom; the avatar is the top-most item, so its top is what gets cut off.

## Fix

- `UserAvatar` gains a `"fluid"` size that renders at 100% of its parent (Avatar and loading Skeleton both).
- `VideoTile` wraps the placeholder avatar in a `min(120px, 45%)`-height box with `aspectRatio: 1/1` (no-video branch: `min(120px, 60%)`). A 150px filmstrip tile now gets a ~67px avatar with room for name + caption; large grid tiles still cap at 120px, visually unchanged. Long display names truncate (`noWrap`) instead of wrapping.
- No `tileSize` prop plumbing — CSS `min()` self-adapts to any tile height.

## Verification

- `VideoTile.test.tsx`: 2 new structural tests (placeholder renders name + caption + fluid avatar; no-video renders fluid avatar); 7/7 pass.
- Two independent adversarial reviews — zero findings; reviewers verified all 24 other `UserAvatar` consumers use unchanged pixel sizes and all three `VideoTiles` layouts provide definite heights.

Part of the undocumented-bug batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
