### PR TITLE
fix(messages): stop chat videos replaying in the background when the signed URL refreshes

### DIFF
--- a/frontend/src/__tests__/components/VideoPreview.test.tsx
+++ b/frontend/src/__tests__/components/VideoPreview.test.tsx
@@ -1,4 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  afterAll,
+} from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
 import { generateTheme } from '../../theme/themeConfig';
@@ -33,7 +41,12 @@ vi.mock('../../hooks/useVideoUrl', () => ({
 
 // jsdom does not implement HTMLMediaElement.play — stub it as a resolved promise
 const playMock = vi.fn(() => Promise.resolve());
+const originalPlay = window.HTMLMediaElement.prototype.play;
 window.HTMLMediaElement.prototype.play = playMock;
+
+afterAll(() => {
+  window.HTMLMediaElement.prototype.play = originalPlay;
+});
 
 const theme = generateTheme('dark', 'blue', 'balanced');
 
@@ -59,6 +72,11 @@ describe('VideoPreview', () => {
       value: 'visible',
       configurable: true,
     });
+  });
+
+  afterEach(() => {
+    // Remove the own property so jsdom's prototype getter takes over again
+    Reflect.deleteProperty(document, 'visibilityState');
   });
 
   it('should render play button overlay', () => {

--- a/frontend/src/__tests__/components/VideoPreview.test.tsx
+++ b/frontend/src/__tests__/components/VideoPreview.test.tsx
@@ -14,14 +14,26 @@ vi.mock('../../contexts/AvatarCacheContext', () => ({
   })),
 }));
 
-// Mock the useVideoUrl hook
+// Mock the useVideoUrl hook (urlOverride lets tests simulate a signed-URL refresh)
+const videoUrlMock = vi.hoisted(() => ({ urlOverride: null as string | null }));
+
 vi.mock('../../hooks/useVideoUrl', () => ({
   useVideoUrl: vi.fn((fileId: string | null) =>
     fileId
-      ? { url: `http://localhost:3000/api/file/${fileId}`, isLoading: false, refresh: vi.fn() }
+      ? {
+          url:
+            videoUrlMock.urlOverride ??
+            `http://localhost:3000/api/file/${fileId}`,
+          isLoading: false,
+          refresh: vi.fn(),
+        }
       : { url: null, isLoading: false, refresh: vi.fn() },
   ),
 }));
+
+// jsdom does not implement HTMLMediaElement.play — stub it as a resolved promise
+const playMock = vi.fn(() => Promise.resolve());
+window.HTMLMediaElement.prototype.play = playMock;
 
 const theme = generateTheme('dark', 'blue', 'balanced');
 
@@ -42,6 +54,11 @@ describe('VideoPreview', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetchThumbnail.mockResolvedValue('blob:thumbnail-url');
+    videoUrlMock.urlOverride = null;
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    });
   });
 
   it('should render play button overlay', () => {
@@ -93,7 +110,25 @@ describe('VideoPreview', () => {
     const video = document.querySelector('video');
     expect(video).not.toBeNull();
     expect(video?.src).toContain('/api/file/video-123');
-    expect(video?.autoplay).toBe(true);
+  });
+
+  it('should not have the autoplay attribute on the video element', () => {
+    renderWithTheme(<VideoPreview metadata={baseMetadata} />);
+
+    fireEvent.click(screen.getByTestId('PlayArrowIcon'));
+
+    const video = document.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video?.hasAttribute('autoplay')).toBe(false);
+    expect(video?.autoplay).toBe(false);
+  });
+
+  it('should call play() exactly once when the user clicks play', () => {
+    renderWithTheme(<VideoPreview metadata={baseMetadata} />);
+
+    fireEvent.click(screen.getByTestId('PlayArrowIcon'));
+
+    expect(playMock).toHaveBeenCalledTimes(1);
   });
 
   it('should format small file sizes correctly', () => {
@@ -182,10 +217,82 @@ describe('VideoPreview', () => {
 
       fireEvent.click(screen.getByTestId('PlayArrowIcon'));
 
+      // src is set imperatively (no src prop), so assert the DOM property
       const video = document.querySelector('video');
       expect(video?.src).toBe(
         'http://localhost:3000/api/file/video-123',
       );
+    });
+  });
+
+  describe('signed URL refresh', () => {
+    function renderPlaying() {
+      const result = renderWithTheme(<VideoPreview metadata={baseMetadata} />);
+      fireEvent.click(screen.getByTestId('PlayArrowIcon'));
+      const video = document.querySelector('video') as HTMLVideoElement;
+      expect(video).not.toBeNull();
+      expect(playMock).toHaveBeenCalledTimes(1);
+      return { ...result, video };
+    }
+
+    function refreshUrl(
+      rerender: (ui: React.ReactElement) => void,
+      url = 'http://localhost:3000/api/file/video-123?sig=refreshed',
+    ) {
+      videoUrlMock.urlOverride = url;
+      rerender(
+        <ThemeProvider theme={theme}>
+          <VideoPreview metadata={baseMetadata} />
+        </ThemeProvider>,
+      );
+    }
+
+    it('should not replay when the URL refreshes while paused, and restores currentTime', () => {
+      const { rerender, video } = renderPlaying();
+
+      // jsdom default: video.paused === true
+      video.currentTime = 42;
+
+      refreshUrl(rerender);
+      expect(video.src).toContain('sig=refreshed');
+
+      fireEvent(video, new Event('loadedmetadata'));
+
+      expect(playMock).toHaveBeenCalledTimes(1); // no additional play()
+      expect(video.currentTime).toBe(42);
+    });
+
+    it('should not resume playback after a URL refresh when the document is hidden', () => {
+      const { rerender, video } = renderPlaying();
+
+      Object.defineProperty(video, 'paused', {
+        value: false,
+        configurable: true,
+      });
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'hidden',
+        configurable: true,
+      });
+
+      refreshUrl(rerender);
+      fireEvent(video, new Event('loadedmetadata'));
+
+      expect(playMock).toHaveBeenCalledTimes(1); // only the initial user-gesture play
+    });
+
+    it('should resume playback after a URL refresh when the document is visible', () => {
+      const { rerender, video } = renderPlaying();
+
+      Object.defineProperty(video, 'paused', {
+        value: false,
+        configurable: true,
+      });
+      // visibilityState is 'visible' (set in beforeEach)
+
+      refreshUrl(rerender);
+      fireEvent(video, new Event('loadedmetadata'));
+
+      expect(playMock).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/frontend/src/components/Message/VideoPreview.tsx
+++ b/frontend/src/components/Message/VideoPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   Box,
   Card,
@@ -93,6 +93,36 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({ metadata }) => {
   const [thumbnailLoading, setThumbnailLoading] = useState(false);
   const fileCache = useFileCache();
   const { url: videoUrl } = useVideoUrl(state === "playing" ? metadata.id : null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const hasLoadedRef = useRef(false);
+
+  // Manage the video src imperatively so that signed-URL refreshes (Electron)
+  // don't trigger a React-driven src swap + autoPlay, which would audibly
+  // replay the clip while the app is backgrounded.
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || !videoUrl) return;
+
+    if (!hasLoadedRef.current) {
+      hasLoadedRef.current = true;
+      video.src = videoUrl;
+      video.play().catch(() => {}); // user just clicked Play — gesture-backed
+      return;
+    }
+
+    // Signed-URL refresh: swap src without audible restarts
+    const wasPlaying = !video.paused && !video.ended;
+    const resumeTime = video.currentTime;
+    video.src = videoUrl;
+    const onLoaded = () => {
+      if (resumeTime > 0) video.currentTime = resumeTime;
+      if (wasPlaying && document.visibilityState === "visible") {
+        video.play().catch(() => {});
+      }
+    };
+    video.addEventListener("loadedmetadata", onLoaded, { once: true });
+    return () => video.removeEventListener("loadedmetadata", onLoaded);
+  }, [videoUrl]);
 
   // Fetch thumbnail on mount if available
   useEffect(() => {
@@ -128,7 +158,7 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({ metadata }) => {
     return (
       <VideoCard>
         {videoUrl ? (
-          <StyledVideo src={videoUrl} controls autoPlay crossOrigin="use-credentials" />
+          <StyledVideo ref={videoRef} controls crossOrigin="use-credentials" />
         ) : (
           <GenericPlaceholder>
             <CircularProgress size={32} />


### PR DESCRIPTION
## Problem

A video clip played in chat (e.g. a screen-share replay) can spontaneously start playing again **hours later while the app is backgrounded** (Electron).

## Root cause

Once played, `VideoPreview` stays mounted indefinitely (the message list isn't virtualized) rendering `<video src={videoUrl} controls autoPlay>`. On Electron, `useVideoUrl` refreshes the HMAC-signed URL ~5 minutes before expiry on a `setTimeout` loop — forever. Each refresh changes the `src` prop on the still-mounted element, which makes the browser reload the media, and `autoPlay` starts playback again. `setTimeout` doesn't care that the window is hidden. (Web uses a stable cookie-auth URL and was never affected.)

## Fix

Removed `autoPlay` and the `src` prop; `src` is now managed imperatively:

- First URL (user just clicked play — gesture-backed): set `src`, call `play()` once.
- Subsequent URLs (signed-URL refreshes): capture `paused`/`currentTime` **before** the swap, set the new `src`, restore position on `loadedmetadata`, and resume only if it was actually playing **and** the document is visible.

`useVideoUrl`'s refresh timer is intentionally unchanged — it keeps seeking working after token expiry; the swap is just silent now. `ClipLibrary` (no autoPlay) and `ImageLightbox` (unmounts on close) need no changes.

## Known trade-off

If someone is deliberately listening to a clip with the window hidden when a refresh lands (~5min before token expiry), playback pauses rather than resuming — flagged by review as inherent to the visibility guard. Clips are short; the alternative is the original bug.

## Verification

- `VideoPreview.test.tsx`: new tests for no-autoplay attribute, single `play()` on click, refresh-while-paused (no replay, position restored), refresh-while-playing hidden vs visible; all pass.
- Two independent adversarial reviews — no must-fix findings (both flagged only the documented trade-off above).

Part of the undocumented-bug batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
