### PR TITLE
fix(voice): voice-activity gate no longer re-enables muted mic; speaking indicators reflect real transmission

### DIFF
--- a/frontend/src/__tests__/hooks/useSpeakingDetection.test.ts
+++ b/frontend/src/__tests__/hooks/useSpeakingDetection.test.ts
@@ -51,9 +51,15 @@ const participantHandlers = new Map<string, Set<Handler>>();
 const roomHandlers = new Map<string, Set<Handler>>();
 
 const mockAnalysisTrack = { enabled: true, stop: vi.fn() };
+// Like the real MediaStreamTrack.clone(), the clone inherits `enabled`
+// from the source track at clone time.
+const cloneImpl = () => {
+  mockAnalysisTrack.enabled = mockMediaStreamTrack.enabled;
+  return mockAnalysisTrack;
+};
 const mockMediaStreamTrack = {
   enabled: true,
-  clone: vi.fn(() => mockAnalysisTrack),
+  clone: vi.fn(cloneImpl),
 };
 
 const mockMicPublication = {
@@ -130,7 +136,7 @@ describe('useSpeakingDetection', () => {
     rafCallbacks = [];
     audioLevel = 0;
     mockMediaStreamTrack.enabled = true;
-    mockMediaStreamTrack.clone.mockReturnValue(mockAnalysisTrack);
+    mockMediaStreamTrack.clone.mockImplementation(cloneImpl);
     mockAnalysisTrack.enabled = true;
     mockAnalysisTrack.stop.mockClear();
     currentRoom = makeRoom();
@@ -487,6 +493,105 @@ describe('useSpeakingDetection', () => {
 
     expect(result.current.isSpeaking('user-1')).toBe(false);
     expect(mockMediaStreamTrack.enabled).toBe(false);
+  });
+
+  it('keeps track disabled and speaking false when muted from a gate-closed state, even with loud audio', () => {
+    const { result } = renderSpeaking();
+
+    // Build gate-closed state: silence past the 300ms hold-open,
+    // so the GATE wrote enabled=false (gateDisabledTrackRef=true).
+    audioLevel = 0;
+    act(() => tickRAF(1));
+    act(() => {
+      vi.advanceTimersByTime(350);
+      tickRAF(1);
+    });
+    expect(mockMediaStreamTrack.enabled).toBe(false);
+
+    // User mutes while the gate has the track closed
+    mockMicPublication.isMuted = true;
+    act(() => {
+      participantHandlers.get('trackMuted')?.forEach(h => h(mockMicPublication));
+    });
+
+    // Loud audio while muted must NOT reopen the gate or the indicator
+    audioLevel = 50;
+    act(() => {
+      vi.advanceTimersByTime(200);
+      tickRAF(5);
+    });
+
+    expect(mockMediaStreamTrack.enabled).toBe(false);
+    expect(result.current.isSpeaking('user-1')).toBe(false);
+  });
+
+  it('force-enables the analysis clone when the source track is disabled (restart while muted)', () => {
+    // Muted mic: published track is disabled when analysis starts
+    mockMediaStreamTrack.enabled = false;
+    mockMicPublication.isMuted = true;
+
+    renderSpeaking();
+
+    // clone() inherits enabled=false from the source; the hook must force it
+    // back on so the analyser keeps reading real audio.
+    expect(mockMediaStreamTrack.clone).toHaveBeenCalled();
+    expect(mockAnalysisTrack.enabled).toBe(true);
+    // The published track itself must stay disabled (mute wins)
+    expect(mockMediaStreamTrack.enabled).toBe(false);
+  });
+
+  it('restarts analysis on trackUnmuted (fresh clone and analyser)', () => {
+    renderSpeaking();
+    expect(mockMediaStreamTrack.clone).toHaveBeenCalledTimes(1);
+
+    mockMicPublication.isMuted = true;
+    mockMediaStreamTrack.enabled = false;
+    act(() => {
+      participantHandlers.get('trackMuted')?.forEach(h => h(mockMicPublication));
+    });
+
+    mockMicPublication.isMuted = false;
+    mockMediaStreamTrack.enabled = true;
+    act(() => {
+      participantHandlers.get('trackUnmuted')?.forEach(h => h(mockMicPublication));
+    });
+
+    // Old session torn down, fresh clone created for the new analyser
+    expect(mockAnalysisTrack.stop).toHaveBeenCalled();
+    expect(mockAudioContextClose).toHaveBeenCalled();
+    expect(mockMediaStreamTrack.clone).toHaveBeenCalledTimes(2);
+  });
+
+  it('recovers speaking after analysis restarts while muted (device switch) and user unmutes', () => {
+    const { result } = renderSpeaking();
+
+    // Mute
+    mockMicPublication.isMuted = true;
+    mockMediaStreamTrack.enabled = false;
+    act(() => {
+      participantHandlers.get('trackMuted')?.forEach(h => h(mockMicPublication));
+    });
+
+    // Device switch while muted restarts analysis; the new clone would
+    // inherit enabled=false without the fix
+    act(() => {
+      roomHandlers.get('activeDeviceChanged')?.forEach(h => h('audioinput'));
+    });
+    act(() => vi.advanceTimersByTime(250));
+    expect(mockAnalysisTrack.enabled).toBe(true);
+
+    // Unmute: LiveKit re-enables the track and fires trackUnmuted
+    mockMicPublication.isMuted = false;
+    mockMediaStreamTrack.enabled = true;
+    act(() => {
+      participantHandlers.get('trackUnmuted')?.forEach(h => h(mockMicPublication));
+    });
+
+    // Loud audio: indicator and gate must both recover
+    audioLevel = 50;
+    act(() => tickRAF(1));
+    expect(result.current.isSpeaking('user-1')).toBe(true);
+    expect(mockMediaStreamTrack.enabled).toBe(true);
   });
 
   it('ignores trackMuted/trackUnmuted for non-microphone publications', () => {

--- a/frontend/src/__tests__/hooks/useSpeakingDetection.test.ts
+++ b/frontend/src/__tests__/hooks/useSpeakingDetection.test.ts
@@ -56,11 +56,15 @@ const mockMediaStreamTrack = {
   clone: vi.fn(() => mockAnalysisTrack),
 };
 
+const mockMicPublication = {
+  source: 'microphone',
+  isMuted: false,
+  track: { mediaStreamTrack: mockMediaStreamTrack },
+};
+
 const mockLocalParticipant = {
   identity: 'user-1',
-  getTrackPublication: vi.fn().mockReturnValue({
-    track: { mediaStreamTrack: mockMediaStreamTrack },
-  }),
+  getTrackPublication: vi.fn().mockReturnValue(mockMicPublication),
   on: vi.fn((event: string, handler: Handler) => {
     if (!participantHandlers.has(event)) participantHandlers.set(event, new Set());
     participantHandlers.get(event)!.add(handler);
@@ -136,9 +140,8 @@ describe('useSpeakingDetection', () => {
         voiceActivityThreshold: 25,
       },
     };
-    mockLocalParticipant.getTrackPublication.mockReturnValue({
-      track: { mediaStreamTrack: mockMediaStreamTrack },
-    });
+    mockMicPublication.isMuted = false;
+    mockLocalParticipant.getTrackPublication.mockReturnValue(mockMicPublication);
   });
 
   afterEach(() => {
@@ -359,6 +362,157 @@ describe('useSpeakingDetection', () => {
 
     // Should NOT re-enable — we didn't disable it, so we shouldn't touch it
     expect(mockMediaStreamTrack.enabled).toBe(false);
+  });
+
+  // ------------------------------------------------------------------
+  // Mute wins over the VA gate
+  // ------------------------------------------------------------------
+
+  it('never re-enables the track while the mic publication is muted, even with loud audio', () => {
+    const { result } = renderSpeaking();
+
+    // Simulate LiveKit mute: publication muted, track disabled
+    mockMicPublication.isMuted = true;
+    mockMediaStreamTrack.enabled = false;
+
+    // Loud audio on the analysis clone — gate must NOT open
+    audioLevel = 50;
+    act(() => {
+      vi.advanceTimersByTime(200);
+      tickRAF(5);
+    });
+
+    expect(mockMediaStreamTrack.enabled).toBe(false);
+    expect(result.current.isSpeaking('user-1')).toBe(false);
+  });
+
+  it('flips speaking false immediately on trackMuted and recovers on trackUnmuted', () => {
+    const { result } = renderSpeaking();
+
+    // Start speaking
+    audioLevel = 50;
+    act(() => tickRAF(1));
+    expect(result.current.isSpeaking('user-1')).toBe(true);
+
+    // Mute: LiveKit disables the track and fires trackMuted
+    mockMicPublication.isMuted = true;
+    mockMediaStreamTrack.enabled = false;
+    act(() => {
+      participantHandlers.get('trackMuted')?.forEach(h => h(mockMicPublication));
+    });
+
+    // Indicator drops immediately, no tick needed
+    expect(result.current.isSpeaking('user-1')).toBe(false);
+
+    // Ticks while muted must not re-enable the track or the indicator
+    act(() => {
+      vi.advanceTimersByTime(200);
+      tickRAF(5);
+    });
+    expect(mockMediaStreamTrack.enabled).toBe(false);
+    expect(result.current.isSpeaking('user-1')).toBe(false);
+
+    // Unmute: LiveKit re-enables the track and fires trackUnmuted
+    mockMicPublication.isMuted = false;
+    mockMediaStreamTrack.enabled = true;
+    act(() => {
+      participantHandlers.get('trackUnmuted')?.forEach(h => h(mockMicPublication));
+    });
+
+    // Still loud — speaking and transmitting again
+    act(() => tickRAF(1));
+    expect(result.current.isSpeaking('user-1')).toBe(true);
+    expect(mockMediaStreamTrack.enabled).toBe(true);
+  });
+
+  it('closes the gate quickly after unmute when the user is silent', () => {
+    const { result } = renderSpeaking();
+
+    // Mute then unmute while silent
+    mockMicPublication.isMuted = true;
+    mockMediaStreamTrack.enabled = false;
+    act(() => {
+      participantHandlers.get('trackMuted')?.forEach(h => h(mockMicPublication));
+    });
+
+    mockMicPublication.isMuted = false;
+    mockMediaStreamTrack.enabled = true;
+    act(() => {
+      participantHandlers.get('trackUnmuted')?.forEach(h => h(mockMicPublication));
+    });
+
+    // Silent: next tick should close the gate (hold-open expired via reset)
+    audioLevel = 0;
+    act(() => tickRAF(1));
+    expect(mockMediaStreamTrack.enabled).toBe(false);
+    expect(result.current.isSpeaking('user-1')).toBe(false);
+  });
+
+  it('does NOT re-enable the track on unmount when gate closed it and user then muted', () => {
+    const { unmount } = renderSpeaking();
+
+    // Gate closes the track (silence past hold-open)
+    audioLevel = 0;
+    act(() => tickRAF(1));
+    act(() => {
+      vi.advanceTimersByTime(350);
+      tickRAF(1);
+    });
+    expect(mockMediaStreamTrack.enabled).toBe(false);
+
+    // User mutes before any further tick runs
+    mockMicPublication.isMuted = true;
+
+    unmount();
+
+    // Cleanup must not "restore" enabled=true over an active mute
+    expect(mockMediaStreamTrack.enabled).toBe(false);
+  });
+
+  it('keeps speaking false in push_to_talk mode while muted, even with loud audio', () => {
+    storedSettings = {
+      semaphore_voice_settings: {
+        inputMode: 'push_to_talk',
+        voiceActivityThreshold: 25,
+      },
+    };
+
+    const { result } = renderSpeaking();
+
+    mockMicPublication.isMuted = true;
+    mockMediaStreamTrack.enabled = false;
+
+    audioLevel = 50;
+    act(() => tickRAF(5));
+
+    expect(result.current.isSpeaking('user-1')).toBe(false);
+    expect(mockMediaStreamTrack.enabled).toBe(false);
+  });
+
+  it('ignores trackMuted/trackUnmuted for non-microphone publications', () => {
+    const { result } = renderSpeaking();
+
+    audioLevel = 50;
+    act(() => tickRAF(1));
+    expect(result.current.isSpeaking('user-1')).toBe(true);
+
+    const cameraPub = { source: 'camera', isMuted: true };
+    act(() => {
+      participantHandlers.get('trackMuted')?.forEach(h => h(cameraPub));
+    });
+
+    // Mic gate state untouched — still speaking
+    expect(result.current.isSpeaking('user-1')).toBe(true);
+    act(() => tickRAF(1));
+    expect(mockMediaStreamTrack.enabled).toBe(true);
+  });
+
+  it('deregisters trackMuted/trackUnmuted listeners on unmount', () => {
+    const { unmount } = renderSpeaking();
+    unmount();
+
+    expect(mockLocalParticipant.off).toHaveBeenCalledWith('trackMuted', expect.any(Function));
+    expect(mockLocalParticipant.off).toHaveBeenCalledWith('trackUnmuted', expect.any(Function));
   });
 
   // ------------------------------------------------------------------

--- a/frontend/src/hooks/useSpeakingDetection.ts
+++ b/frontend/src/hooks/useSpeakingDetection.ts
@@ -57,6 +57,7 @@ export const useSpeakingDetection = () => {
   const localTrackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const analysisTrackRef = useRef<MediaStreamTrack | null>(null);
   const analysisTrackIsCloneRef = useRef(false);
+  const analysisSessionRef = useRef(0); // invalidates stale rAF loops across restarts
 
   // Gate state refs (used for both indicator and audio gating)
   const gateOpenRef = useRef(true);
@@ -142,6 +143,11 @@ export const useSpeakingDetection = () => {
       const mediaStreamTrack = micPub?.track?.mediaStreamTrack;
       if (!mediaStreamTrack) return;
 
+      // Session token: a restart can be synchronous (stop + start in the same
+      // task), so a previous session's pending rAF callback would otherwise
+      // see localAnalysisActiveRef=true again and keep a stale loop running.
+      const session = ++analysisSessionRef.current;
+
       // Build an AnalyserNode from the mic track
       try {
         const ctx = new AudioContext();
@@ -155,6 +161,11 @@ export const useSpeakingDetection = () => {
         let analysisTrack: MediaStreamTrack;
         try {
           analysisTrack = mediaStreamTrack.clone();
+          // clone() inherits `enabled` from the source, so a clone taken from
+          // a muted (enabled=false) mic would read as silence forever. Force
+          // it on — the clone only feeds the local AnalyserNode; its audio
+          // goes nowhere.
+          analysisTrack.enabled = true;
           analysisTrackIsCloneRef.current = true;
         } catch {
           // Fallback: use the original (pre-fix behavior)
@@ -295,6 +306,7 @@ export const useSpeakingDetection = () => {
         // analysis loop keeps running when the tab/window is backgrounded.
         const fallbackToRaf = () => {
           const rafTick = () => {
+            if (analysisSessionRef.current !== session) return; // stale session
             tick();
             if (localAnalysisActiveRef.current) {
               requestAnimationFrame(rafTick);
@@ -413,8 +425,15 @@ export const useSpeakingDetection = () => {
     };
     const handleTrackUnmuted = (pub: TrackPublication) => {
       if (pub.source !== Track.Source.Microphone) return;
-      // Reopen the gate; next tick closes it again unless the user is
-      // actually speaking (lastAboveThreshold=0 makes hold-open expire).
+      // Restart analysis so it picks up the fresh MediaStreamTrack that
+      // LiveKit may swap in on unmute (e.g. a device switch performed while
+      // muted defers the real track restart to unmute, and no further track
+      // event fires after that restartTrack). stop/start reuse the existing
+      // cleanup discipline, so this is idempotent and leak-free.
+      stopLocalAnalysis();
+      startLocalAnalysis();
+      // Re-arm the gate: open now, but the next tick closes it again unless
+      // the user is actually speaking (lastAboveThreshold=0 expires hold-open).
       gateOpenRef.current = true;
       lastAboveThresholdRef.current = 0;
     };

--- a/frontend/src/hooks/useSpeakingDetection.ts
+++ b/frontend/src/hooks/useSpeakingDetection.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useRoom } from "./useRoom";
 import { Participant, Track } from "livekit-client";
+import type { TrackPublication } from "livekit-client";
 import { getCachedItem } from "../utils/storage";
 import { computeVoiceLevel } from "../utils/audioLevel";
 
@@ -37,6 +38,8 @@ interface ParsedSettings {
  * - **Hysteresis**: close threshold is 5 points below open threshold
  * - **Min close time**: 100ms minimum before re-opening
  * - **Cleanup**: re-enables `mediaStreamTrack.enabled` only if gate disabled it
+ * - **Mute wins**: while the mic publication is muted the gate never touches
+ *   `track.enabled` and the local indicator is forced off
  *
  * @example
  * const { speakingMap, isSpeaking } = useSpeakingDetection();
@@ -189,6 +192,22 @@ export const useSpeakingDetection = () => {
             return; // skip this tick, resume is async
           }
 
+          // Mute wins: while the mic publication is muted, never touch
+          // track.enabled (LiveKit's mute owns enabled=false) and force the
+          // local speaking indicator off. Skips both VA-gate and PTT branches.
+          const currentMicPub = local.getTrackPublication(Track.Source.Microphone);
+          if (currentMicPub?.isMuted) {
+            gateOpenRef.current = false;
+            gateDisabledTrackRef.current = false;
+            setSpeakingMap((prev) => {
+              if (prev.get(local.identity) === false) return prev;
+              const newMap = new Map(prev);
+              newMap.set(local.identity, false);
+              return newMap;
+            });
+            return;
+          }
+
           // Periodically re-read settings from localStorage (not every tick)
           frameCountRef.current++;
           if (frameCountRef.current >= SETTINGS_READ_INTERVAL) {
@@ -222,7 +241,7 @@ export const useSpeakingDetection = () => {
                   gateDisabledTrackRef.current = true;
                   lastGateCloseRef.current = now;
                   // Re-acquire track ref to avoid stale closure after LiveKit track replacement
-                  const currentTrackOff = local.getTrackPublication(Track.Source.Microphone)?.track?.mediaStreamTrack;
+                  const currentTrackOff = currentMicPub?.track?.mediaStreamTrack;
                   if (currentTrackOff) currentTrackOff.enabled = false;
                   setSpeakingMap((prev) => {
                     if (prev.get(local.identity) === false) return prev;
@@ -241,7 +260,7 @@ export const useSpeakingDetection = () => {
                   gateDisabledTrackRef.current = false;
                   lastAboveThresholdRef.current = now;
                   // Re-acquire track ref to avoid stale closure after LiveKit track replacement
-                  const currentTrackOn = local.getTrackPublication(Track.Source.Microphone)?.track?.mediaStreamTrack;
+                  const currentTrackOn = currentMicPub?.track?.mediaStreamTrack;
                   if (currentTrackOn) currentTrackOn.enabled = true;
                   setSpeakingMap((prev) => {
                     if (prev.get(local.identity) === true) return prev;
@@ -257,7 +276,7 @@ export const useSpeakingDetection = () => {
             // Only undo gate-caused disables; never touch track.enabled otherwise
             // (PTT/manual mute control it via LiveKit's publish/unpublish)
             if (gateDisabledTrackRef.current) {
-              const currentTrackRestore = local.getTrackPublication(Track.Source.Microphone)?.track?.mediaStreamTrack;
+              const currentTrackRestore = currentMicPub?.track?.mediaStreamTrack;
               if (currentTrackRestore) currentTrackRestore.enabled = true;
               gateDisabledTrackRef.current = false;
               gateOpenRef.current = true;
@@ -343,12 +362,14 @@ export const useSpeakingDetection = () => {
       analysisTrackIsCloneRef.current = false;
 
       // Only re-enable track if OUR gate disabled it — don't override
-      // explicit user mute/deafen/PTT state
+      // explicit user mute/deafen/PTT state (mute wins over the gate)
       if (gateDisabledTrackRef.current) {
         const micPub = local.getTrackPublication(Track.Source.Microphone);
-        const track = micPub?.track?.mediaStreamTrack;
-        if (track) {
-          track.enabled = true;
+        if (!micPub?.isMuted) {
+          const track = micPub?.track?.mediaStreamTrack;
+          if (track) {
+            track.enabled = true;
+          }
         }
         gateDisabledTrackRef.current = false;
       }
@@ -375,6 +396,30 @@ export const useSpeakingDetection = () => {
 
     local.on("localTrackPublished", handleLocalTrackPublished);
     local.on("localTrackUnpublished", handleLocalTrackUnpublished);
+
+    // Mute/unmute: LiveKit implements mute as mediaStreamTrack.enabled=false
+    // with the publication still live. The gate must never fight that —
+    // never write track.enabled from these handlers.
+    const handleTrackMuted = (pub: TrackPublication) => {
+      if (pub.source !== Track.Source.Microphone) return;
+      gateDisabledTrackRef.current = false; // LiveKit's mute owns enabled=false now
+      gateOpenRef.current = false;
+      setSpeakingMap((prev) => {
+        if (prev.get(local.identity) === false) return prev;
+        const newMap = new Map(prev);
+        newMap.set(local.identity, false);
+        return newMap;
+      });
+    };
+    const handleTrackUnmuted = (pub: TrackPublication) => {
+      if (pub.source !== Track.Source.Microphone) return;
+      // Reopen the gate; next tick closes it again unless the user is
+      // actually speaking (lastAboveThreshold=0 makes hold-open expire).
+      gateOpenRef.current = true;
+      lastAboveThresholdRef.current = 0;
+    };
+    local.on("trackMuted", handleTrackMuted);
+    local.on("trackUnmuted", handleTrackUnmuted);
 
     const handleActiveDeviceChanged = (kind: MediaDeviceKind) => {
       if (kind === 'audioinput') {
@@ -405,6 +450,8 @@ export const useSpeakingDetection = () => {
       stopLocalAnalysis();
       local.off("localTrackPublished", handleLocalTrackPublished);
       local.off("localTrackUnpublished", handleLocalTrackUnpublished);
+      local.off("trackMuted", handleTrackMuted);
+      local.off("trackUnmuted", handleTrackUnmuted);
     };
   }, [room, readSettings]);
 


### PR DESCRIPTION
## Problem

Voice activity indicators were "gating on volume but not actually stopping sound": a muted user who kept talking **still transmitted audio** and still showed a green speaking ring to everyone else.

## Root cause

`useSpeakingDetection` analyses a **clone** of the mic track (so it can meter input regardless of publish state) and, in voice-activity mode, gates transmission by writing `track.enabled` on the real published track. LiveKit implements mute the same way — `setMicrophoneEnabled(false)` sets `mediaStreamTrack.enabled = false` and fires `trackMuted`, which this hook never listened for. So after muting, the gate would detect speech on the (still-live) clone and set `enabled = true` on the published track — **literally un-muting the user** while LiveKit still reported `isMuted: true`. The SFU then saw audio energy and broadcast `isSpeakingChanged` to everyone. The cleanup path had the same hole (`stopLocalAnalysis` unconditionally restored `enabled = true`).

## Fix

**Mute now wins, everywhere:**
- `tick()` resolves the mic publication once per tick; if muted it forces the local indicator off, closes the gate, and returns before the VA-gate **and** PTT branches — the gate can never write `track.enabled` over a mute.
- `trackMuted`/`trackUnmuted` listeners (mic-source filtered): mute kills the indicator immediately; unmute restarts the analysis loop and re-arms the gate closed-until-speech (Discord-like — no ambient burst on unmute).
- `stopLocalAnalysis` only restores `enabled = true` if the gate disabled it **and** the publication isn't muted.
- The analysis clone is force-enabled after `clone()` (clones inherit `enabled=false` from a muted source; the clone feeds only the local analyser). Combined with the restart-on-unmute, this closes a hole adversarial review found where analysis restarting while muted (device switch, camera toggle, remount) would leave a permanently-silent clone → user stuck muted after unmute.

Producer indicator = actual transmission (not muted AND gate open / PTT held). Consumer indicators keep using LiveKit's server-side `isSpeakingChanged`, which becomes truthful once the leak is gone.

## Review notes / accepted trade-offs

- ~30ms (one tick) of ambient audio can pass on unmute before the gate closes — inherent to tick-based gating.
- Settings changed while muted apply within ~2s of unmute (existing refresh cadence).
- Follow-ups worth separate issues (pre-existing, out of scope): PTT keydown bypasses server-mute; switching PTT→VA mid-call leaves you muted until manual unmute (previously "worked" only via this leak); the hook is mounted 3× concurrently — consolidation into a shared context planned alongside video-tile speaking rings.

## Verification

- 33 hook tests (11 new) incl. the canonical regression: gate-closed → mute → loud audio → `enabled` stays false; clone inheritance modeled in the mock; device-switch-while-muted recovery. 66 tests green across the three affected files.
- Two adversarial reviews (correctness verified event names/mute mechanics against livekit-client 2.16.1 source; regression review walked PTT/server-mute/deafen/device-switch consumers). The one must-fix finding (dead clone) is fixed in the second commit.

Part of the undocumented-bug batch (#373–#375).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
