### PR TITLE
fix(messages): chronological DOM order so cross-message text selection works

### DIFF
--- a/frontend/src/__tests__/components/MessageContainer.test.tsx
+++ b/frontend/src/__tests__/components/MessageContainer.test.tsx
@@ -42,6 +42,36 @@ class MockIntersectionObserver {
   disconnect() { this._instance.disconnect(); }
 }
 
+// ── Mock ResizeObserver ────────────────────────────────────────────────
+type MockResizeInstance = {
+  callback: ResizeObserverCallback;
+  elements: Set<Element>;
+  trigger: (targets: Element[]) => void;
+};
+
+let mockResizeInstances: MockResizeInstance[] = [];
+
+class MockResizeObserver {
+  _instance: MockResizeInstance;
+  constructor(callback: ResizeObserverCallback) {
+    const instance: MockResizeInstance = {
+      callback,
+      elements: new Set(),
+      trigger: (targets: Element[]) => {
+        callback(
+          targets.map((target) => ({ target }) as ResizeObserverEntry),
+          this as unknown as ResizeObserver,
+        );
+      },
+    };
+    this._instance = instance;
+    mockResizeInstances.push(instance);
+  }
+  observe(el: Element) { this._instance.elements.add(el); }
+  unobserve(el: Element) { this._instance.elements.delete(el); }
+  disconnect() { this._instance.elements.clear(); }
+}
+
 // ── Mock child components ──────────────────────────────────────────────
 vi.mock('../../components/Message/MessageComponent', () => ({
   default: ({ message, isSearchHighlight, contextType }: { message: { id: string; spans: unknown[] }; isSearchHighlight?: boolean; contextType?: string }) => (
@@ -117,11 +147,33 @@ function findObserverFor(testFn: (instance: MockObserverInstance) => boolean) {
   return mockObserverInstances.find(testFn);
 }
 
+/** Get the most recent ResizeObserver instance that observes a given element */
+function findResizeObserverFor(el: Element) {
+  return [...mockResizeInstances].reverse().find((inst) => inst.elements.has(el));
+}
+
+/** Build a partial DOMRect for getBoundingClientRect mocks */
+function makeRect({ top = 0, height = 0 }: { top?: number; height?: number }) {
+  return {
+    top,
+    height,
+    bottom: top + height,
+    left: 0,
+    right: 0,
+    width: 0,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
 // ── Setup / Teardown ───────────────────────────────────────────────────
 beforeEach(() => {
   resetFactoryCounter();
   mockObserverInstances = [];
+  mockResizeInstances = [];
   vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  vi.stubGlobal('ResizeObserver', MockResizeObserver);
   mockGetLastReadMessageId.mockReturnValue(undefined);
   mockGetUnreadCount.mockReturnValue(0);
 });
@@ -227,6 +279,21 @@ describe('MessageContainer', () => {
         'message-msg-middle',
         'message-msg-newest',
       ]);
+    });
+
+    it('bottom-packs sparse content: first child of the scroll container has marginTop auto', () => {
+      // Replaces column-reverse's bottom packing: when messages don't fill
+      // the viewport, the auto top margin on the first child absorbs the free
+      // space so content sits at the visual bottom. (justifyContent: flex-end
+      // is NOT an acceptable substitute — it breaks scrolling in some engines.)
+      const messages = [createMessage({ id: 'msg-1' })];
+
+      renderWithProviders(
+        <MessageContainer {...defaultProps} messages={messages} />,
+      );
+
+      const container = getScrollContainer();
+      expect(container.firstElementChild).toHaveStyle({ marginTop: 'auto' });
     });
 
     it('always renders message input outside the scroll container', () => {
@@ -486,6 +553,131 @@ describe('MessageContainer', () => {
 
       // scrollTop shifted by the 300px height delta → viewport stays put
       expect(container.scrollTop).toBe(800);
+    });
+
+    it('does not yank to bottom when a newer page arrives while pinned in anchored mode', () => {
+      const m1 = createMessage({ id: 'msg-1' });
+      const m2 = createMessage({ id: 'msg-2' });
+      const { rerender } = renderWithProviders(
+        <MessageContainer
+          {...defaultProps}
+          messages={[m2, m1]}
+          mode="anchored"
+          hasNewer={true}
+        />,
+      );
+
+      const container = getScrollContainer();
+      mockScrollGeometry(container, {
+        scrollTop: 600,
+        scrollHeight: 1000,
+        clientHeight: 400,
+      });
+      // distance from bottom = 0 → pinnedToBottomRef becomes true
+      fireEvent.scroll(container);
+
+      // The bottom-pin ResizeObserver must not observe the container in
+      // anchored mode: it is recreated on message changes and its initial
+      // callbacks fire with stale pinned=true, which would teleport the user.
+      expect(
+        mockResizeInstances.some((inst) => inst.elements.has(container)),
+      ).toBe(false);
+
+      // A newer page lands: a newer newest message appends below the viewport
+      const m3 = createMessage({ id: 'msg-3' });
+      rerender(
+        <MessageContainer
+          {...defaultProps}
+          messages={[m3, m2, m1]}
+          mode="anchored"
+          hasNewer={true}
+        />,
+      );
+
+      // Viewport must stay put — NOT be forced to scrollHeight
+      expect(container.scrollTop).toBe(600);
+    });
+
+    it('compensates scrollTop when content above the viewport grows while unpinned', () => {
+      const m1 = createMessage({ id: 'msg-1' });
+      const m2 = createMessage({ id: 'msg-2' });
+      renderWithProviders(
+        <MessageContainer {...defaultProps} messages={[m2, m1]} />,
+      );
+
+      const container = getScrollContainer();
+      mockScrollGeometry(container, {
+        scrollTop: 100,
+        scrollHeight: 1000,
+        clientHeight: 400,
+      });
+      // distance from bottom = 500 → not pinned (reading history)
+      fireEvent.scroll(container);
+      vi.spyOn(container, 'getBoundingClientRect').mockReturnValue(
+        makeRect({ top: 0, height: 400 }),
+      );
+
+      // msg-1 sits above the viewport (top edge above the container's top)
+      const el = document.querySelector('[data-message-id="msg-1"]') as HTMLElement;
+      const rectSpy = vi
+        .spyOn(el, 'getBoundingClientRect')
+        .mockReturnValue(makeRect({ top: -250, height: 200 }));
+
+      const growthObserver = findResizeObserverFor(el);
+      expect(growthObserver).toBeDefined();
+
+      // First callback only records the baseline height — no compensation
+      act(() => {
+        growthObserver!.trigger([el]);
+      });
+      expect(container.scrollTop).toBe(100);
+
+      // Media finishes loading: the element grows by 300px above the viewport
+      rectSpy.mockReturnValue(makeRect({ top: -250, height: 500 }));
+      act(() => {
+        growthObserver!.trigger([el]);
+      });
+      expect(container.scrollTop).toBe(400);
+    });
+
+    it('skips above-viewport growth compensation while pinned to the bottom', () => {
+      const m1 = createMessage({ id: 'msg-1' });
+      const m2 = createMessage({ id: 'msg-2' });
+      renderWithProviders(
+        <MessageContainer {...defaultProps} messages={[m2, m1]} />,
+      );
+
+      const container = getScrollContainer();
+      mockScrollGeometry(container, {
+        scrollTop: 600,
+        scrollHeight: 1000,
+        clientHeight: 400,
+      });
+      // distance from bottom = 0 → pinned
+      fireEvent.scroll(container);
+      vi.spyOn(container, 'getBoundingClientRect').mockReturnValue(
+        makeRect({ top: 0, height: 400 }),
+      );
+
+      const el = document.querySelector('[data-message-id="msg-1"]') as HTMLElement;
+      const rectSpy = vi
+        .spyOn(el, 'getBoundingClientRect')
+        .mockReturnValue(makeRect({ top: -250, height: 200 }));
+
+      const growthObserver = findResizeObserverFor(el);
+      expect(growthObserver).toBeDefined();
+
+      act(() => {
+        growthObserver!.trigger([el]);
+      });
+      rectSpy.mockReturnValue(makeRect({ top: -250, height: 500 }));
+      act(() => {
+        growthObserver!.trigger([el]);
+      });
+
+      // No compensation increment — while pinned, the bottom-pin observer
+      // (a separate mechanism) owns keeping the view glued to the bottom.
+      expect(container.scrollTop).toBe(600);
     });
   });
 
@@ -754,6 +946,38 @@ describe('MessageContainer', () => {
         bottomObserver!.trigger([{ isIntersecting: true }]);
       });
       expect(onLoadNewer).not.toHaveBeenCalled();
+    });
+
+    it('releases older pagination when anchored with no pending highlight', () => {
+      // Regression: if the around-fetch outlives the 3s highlight flash,
+      // highlightMessageId is already cleared when messages arrive. Initial
+      // positioning must still complete and release the pagination
+      // suppression — otherwise the anchored view strands with older
+      // pagination permanently dead.
+      const onLoadMore = vi.fn().mockResolvedValue(undefined);
+      const messages = [createMessage({ id: 'msg-1' })];
+
+      renderWithProviders(
+        <MessageContainer
+          {...defaultProps}
+          messages={messages}
+          mode="anchored"
+          jumpToPresent={vi.fn()}
+          continuationToken="older-token"
+          onLoadMore={onLoadMore}
+        />,
+      );
+
+      // threshold=0 observers: bottom sentinel (1st) and top sentinel (2nd)
+      const thresholdZeroObservers = mockObserverInstances.filter(
+        (inst) => inst.options?.threshold === 0,
+      );
+      expect(thresholdZeroObservers.length).toBeGreaterThanOrEqual(2);
+
+      act(() => {
+        thresholdZeroObservers[1].trigger([{ isIntersecting: true }]);
+      });
+      expect(onLoadMore).toHaveBeenCalledTimes(1);
     });
 
     it('shows loading skeletons when isLoadingNewer is true', () => {

--- a/frontend/src/__tests__/components/MessageContainer.test.tsx
+++ b/frontend/src/__tests__/components/MessageContainer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
-import { screen, waitFor, act } from '@testing-library/react';
+import { screen, waitFor, act, fireEvent } from '@testing-library/react';
 import { renderWithProviders } from '../test-utils';
 import MessageContainer from '../../components/Message/MessageContainer';
 import { createMessage, resetFactoryCounter } from '../test-utils/factories';
@@ -86,9 +86,30 @@ const defaultProps = {
   messageInput: <div data-testid="message-input">input</div>,
 };
 
-/** Find the column-reverse scroll container */
+/** Find the message scroll container */
 function getScrollContainer() {
   return screen.getByTestId('scroll-container');
+}
+
+/**
+ * Make scroll geometry mockable on a jsdom element: writable scrollTop plus
+ * configurable scrollHeight/clientHeight.
+ */
+function mockScrollGeometry(
+  el: HTMLElement,
+  { scrollTop = 0, scrollHeight = 0, clientHeight = 0 } = {},
+) {
+  let top = scrollTop;
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    get: () => top,
+    set: (v: number) => { top = v; },
+  });
+  const setScrollHeight = (v: number) =>
+    Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => v });
+  setScrollHeight(scrollHeight);
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => clientHeight });
+  return { setScrollHeight };
 }
 
 /** Get the IntersectionObserver instance that observes a given element */
@@ -170,7 +191,7 @@ describe('MessageContainer', () => {
       expect(screen.getByTestId('message-msg-c')).toBeInTheDocument();
     });
 
-    it('renders scroll container with column-reverse layout', () => {
+    it('renders scroll container as a normal column', () => {
       const messages = [createMessage({ id: 'msg-1' })];
 
       renderWithProviders(
@@ -179,6 +200,33 @@ describe('MessageContainer', () => {
 
       const container = getScrollContainer();
       expect(container).toBeInTheDocument();
+      expect(container).toHaveStyle({ flexDirection: 'column' });
+    });
+
+    it('renders messages in chronological DOM order (oldest first) given newest-first input', () => {
+      // Regression test for the cross-message text selection bug: native
+      // selection follows DOM order, so the DOM must be chronological even
+      // though the messages prop arrives newest-first.
+      const messages = [
+        createMessage({ id: 'msg-newest' }),
+        createMessage({ id: 'msg-middle' }),
+        createMessage({ id: 'msg-oldest' }),
+      ];
+
+      renderWithProviders(
+        <MessageContainer {...defaultProps} messages={messages} />,
+      );
+
+      const container = getScrollContainer();
+      const rendered = Array.from(
+        container.querySelectorAll('[data-testid^="message-msg-"]'),
+      ).map((el) => el.getAttribute('data-testid'));
+
+      expect(rendered).toEqual([
+        'message-msg-oldest',
+        'message-msg-middle',
+        'message-msg-newest',
+      ]);
     });
 
     it('always renders message input outside the scroll container', () => {
@@ -220,7 +268,7 @@ describe('MessageContainer', () => {
       expect(screen.getByRole('button')).toBeInTheDocument();
     });
 
-    it('calls scrollTo({ top: 0 }) when FAB is clicked', async () => {
+    it('scrolls to the container scrollHeight when FAB is clicked', async () => {
       const messages = [createMessage({ id: 'msg-1' })];
       const { user } = renderWithProviders(
         <MessageContainer {...defaultProps} messages={messages} />,
@@ -238,8 +286,10 @@ describe('MessageContainer', () => {
       });
 
       await user.click(screen.getByRole('button'));
+      // Visual bottom in a normal column is scrollTop = scrollHeight
+      // (0 in jsdom, but asserted against the element's own value).
       expect(container.scrollTo).toHaveBeenCalledWith({
-        top: 0,
+        top: container.scrollHeight,
         behavior: 'smooth',
       });
     });
@@ -359,6 +409,86 @@ describe('MessageContainer', () => {
     });
   });
 
+  // ── Scroll anchoring ───────────────────────────────────────────────
+  describe('scroll anchoring', () => {
+    it('sticks to bottom when a new message arrives while pinned', () => {
+      const m1 = createMessage({ id: 'msg-1' });
+      const m2 = createMessage({ id: 'msg-2' });
+      const { rerender } = renderWithProviders(
+        <MessageContainer {...defaultProps} messages={[m2, m1]} />,
+      );
+
+      const container = getScrollContainer();
+      mockScrollGeometry(container, {
+        scrollTop: 600,
+        scrollHeight: 1000,
+        clientHeight: 400,
+      });
+      // distance from bottom = 1000 - 600 - 400 = 0 → pinned
+      fireEvent.scroll(container);
+
+      // A new newest message arrives (prop is newest-first)
+      const m3 = createMessage({ id: 'msg-3' });
+      rerender(<MessageContainer {...defaultProps} messages={[m3, m2, m1]} />);
+
+      expect(container.scrollTop).toBe(1000);
+    });
+
+    it('does not move the viewport for a new message while reading history', () => {
+      const m1 = createMessage({ id: 'msg-1' });
+      const m2 = createMessage({ id: 'msg-2' });
+      const { rerender } = renderWithProviders(
+        <MessageContainer {...defaultProps} messages={[m2, m1]} />,
+      );
+
+      const container = getScrollContainer();
+      mockScrollGeometry(container, {
+        scrollTop: 100,
+        scrollHeight: 1000,
+        clientHeight: 400,
+      });
+      // distance from bottom = 500 → not pinned
+      fireEvent.scroll(container);
+
+      const m3 = createMessage({ id: 'msg-3' });
+      rerender(<MessageContainer {...defaultProps} messages={[m3, m2, m1]} />);
+
+      expect(container.scrollTop).toBe(100);
+    });
+
+    it('adjusts scrollTop when an older page is prepended', () => {
+      const m1 = createMessage({ id: 'msg-1' });
+      const m2 = createMessage({ id: 'msg-2' });
+      const { rerender } = renderWithProviders(
+        <MessageContainer {...defaultProps} messages={[m2, m1]} />,
+      );
+
+      const container = getScrollContainer();
+      const { setScrollHeight } = mockScrollGeometry(container, {
+        scrollTop: 500,
+        scrollHeight: 1000,
+        clientHeight: 400,
+      });
+      // distance from bottom = 100 → not pinned (reading history)
+      fireEvent.scroll(container);
+
+      // Re-render with a fresh array identity (same content) so the
+      // stabilization effect records the 1000px baseline scrollHeight.
+      rerender(<MessageContainer {...defaultProps} messages={[m2, m1]} />);
+
+      // Older page arrives: appended to the newest-first prop, which renders
+      // as a prepend at the top of the chronological DOM.
+      setScrollHeight(1300);
+      const m0 = createMessage({ id: 'msg-0' });
+      rerender(
+        <MessageContainer {...defaultProps} messages={[m2, m1, m0]} />,
+      );
+
+      // scrollTop shifted by the 300px height delta → viewport stays put
+      expect(container.scrollTop).toBe(800);
+    });
+  });
+
   // ── Unread message divider ─────────────────────────────────────────
   describe('unread message divider', () => {
     it('shows divider at the correct position', () => {
@@ -384,17 +514,17 @@ describe('MessageContainer', () => {
       const divider = screen.getByTestId('unread-divider');
       expect(divider).toHaveTextContent('2 new messages');
 
-      // Verify DOM order: in column-reverse, DOM order is newest-first.
-      // The divider should appear between msg-b (unread) and msg-c (last read) in DOM,
-      // which visually places it between msg-c (above) and msg-b (below).
+      // Verify DOM order: rendering is chronological (oldest first), so the
+      // DOM is msg-c (last read), divider, msg-b, msg-a — placing the divider
+      // between the last-read message and the first unread one.
       const container = getScrollContainer();
       const children = Array.from(container.querySelectorAll('[data-testid]'));
       const testIds = children.map((el) => el.getAttribute('data-testid'));
       const dividerIdx = testIds.indexOf('unread-divider');
       const msgBIdx = testIds.indexOf('message-msg-b');
       const msgCIdx = testIds.indexOf('message-msg-c');
-      expect(dividerIdx).toBeGreaterThan(msgBIdx);
-      expect(dividerIdx).toBeLessThan(msgCIdx);
+      expect(dividerIdx).toBeGreaterThan(msgCIdx);
+      expect(dividerIdx).toBeLessThan(msgBIdx);
     });
 
     it('does not show divider when unreadCount is 0', () => {
@@ -417,7 +547,7 @@ describe('MessageContainer', () => {
       expect(screen.queryByTestId('unread-divider')).not.toBeInTheDocument();
     });
 
-    it('does not show divider when last read message is the newest (index 0)', () => {
+    it('does not show divider when last read message is the newest', () => {
       const messages = [
         createMessage({ id: 'msg-a' }),
         createMessage({ id: 'msg-b' }),

--- a/frontend/src/components/Message/MessageContainer.tsx
+++ b/frontend/src/components/Message/MessageContainer.tsx
@@ -241,8 +241,13 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
               overflowAnchor: "none",
             }}
           >
-            {/* Top sentinel: first in DOM = visual top */}
-            <Box ref={topSentinelRef} sx={{ height: '1px', flexShrink: 0 }} />
+            {/* Top sentinel: first in DOM = visual top. marginTop: 'auto'
+                bottom-packs sparse channels (content shorter than the
+                viewport sits at the visual bottom, like column-reverse did);
+                once content overflows, the auto margin resolves to 0.
+                Do NOT swap this for justifyContent: flex-end — that breaks
+                scrolling in some engines. */}
+            <Box ref={topSentinelRef} sx={{ height: '1px', flexShrink: 0, marginTop: 'auto' }} />
 
             {/* Loading skeleton at visual top for older messages */}
             {isLoadingMore && (

--- a/frontend/src/components/Message/MessageContainer.tsx
+++ b/frontend/src/components/Message/MessageContainer.tsx
@@ -85,6 +85,16 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
 }) => {
   const { isMobile } = useResponsive();
 
+  // Context identity (channel or DM group) — used for read receipts and to
+  // reset scroll positioning when switching contexts.
+  const contextKey = channelId || directMessageGroupId;
+
+  // The messages prop arrives newest-first (useMessages contract). Render
+  // oldest-first so DOM order matches chronological order — native text
+  // selection follows DOM order, so this is what makes cross-message
+  // selection highlight correctly.
+  const orderedMessages = useMemo(() => [...messages].reverse(), [messages]);
+
   const {
     scrollContainerRef,
     bottomSentinelRef,
@@ -97,6 +107,7 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
     mode,
     highlightMessageId,
     highlightSeq,
+    resetKey: contextKey,
     onLoadMore,
     isLoadingMore,
     continuationToken,
@@ -124,16 +135,16 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
   });
 
   // Read receipts - determine where to show unread divider
-  const contextKey = channelId || directMessageGroupId;
   const { lastReadMessageId: getLastReadMessageId, unreadCount: getUnreadCount } = useReadReceipts();
   const lastReadMessageId = getLastReadMessageId(contextKey);
   const unreadCount = getUnreadCount(contextKey);
 
-  // Find the index of the last read message in the newest-first array
+  // Find the index of the last read message in the chronological (oldest-first)
+  // render order; the divider goes right after it, before the first unread.
   const lastReadIndex = useMemo(() => {
     if (!lastReadMessageId) return -1;
-    return messages.findIndex((msg) => msg.id === lastReadMessageId);
-  }, [messages, lastReadMessageId]);
+    return orderedMessages.findIndex((msg) => msg.id === lastReadMessageId);
+  }, [orderedMessages, lastReadMessageId]);
 
   const skeletonCount = 10;
 
@@ -222,14 +233,19 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
               minHeight: 0,
               overflowY: "auto",
               display: "flex",
-              flexDirection: "column-reverse",
+              flexDirection: "column",
+              // useBidirectionalScroll is the single owner of scroll
+              // stabilization. Chrome suppresses native anchoring at
+              // scrollTop===0 — exactly when older pages load — so it can't be
+              // relied on and must not double-compensate with our manual logic.
+              overflowAnchor: "none",
             }}
           >
-            {/* Bottom sentinel: first in DOM = visual bottom in column-reverse */}
-            <Box ref={bottomSentinelRef} sx={{ height: '1px', flexShrink: 0 }} />
+            {/* Top sentinel: first in DOM = visual top */}
+            <Box ref={topSentinelRef} sx={{ height: '1px', flexShrink: 0 }} />
 
-            {/* Loading skeleton at visual bottom for newer messages (anchored mode) */}
-            {isLoadingNewer && (
+            {/* Loading skeleton at visual top for older messages */}
+            {isLoadingMore && (
               <Box sx={{ p: 2, textAlign: "center" }}>
                 <MessageSkeleton />
                 <MessageSkeleton />
@@ -237,16 +253,14 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
               </Box>
             )}
 
-            <Box sx={{ px: 2, minHeight: 20 }} />
-
-            {/* Messages newest-first; column-reverse shows oldest at top */}
-            {messages.map((message, index) => {
+            {/* Messages oldest-first: DOM order = chronological order, so
+                native text selection across messages highlights correctly */}
+            {orderedMessages.map((message, index) => {
               const isHighlighted = highlightMessageId === message.id;
-              // Show divider before the last-read message in DOM.
-              // In column-reverse, "before in DOM" = "below visually",
-              // placing the divider between last-read (above) and first-unread (below).
+              // Show divider right after the last-read message, i.e. before
+              // the first unread message.
               const showDividerBefore =
-                unreadCount > 0 && lastReadIndex > 0 && index === lastReadIndex;
+                unreadCount > 0 && lastReadIndex !== -1 && index === lastReadIndex + 1;
 
               // Composite key: when highlighted, include highlightSeq so React remounts
               // the element and restarts the CSS flash animation on re-clicks.
@@ -281,8 +295,10 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
               );
             })}
 
-            {/* Loading skeleton at DOM end = visual top */}
-            {isLoadingMore && (
+            <Box sx={{ px: 2, minHeight: 20 }} />
+
+            {/* Loading skeleton at visual bottom for newer messages (anchored mode) */}
+            {isLoadingNewer && (
               <Box sx={{ p: 2, textAlign: "center" }}>
                 <MessageSkeleton />
                 <MessageSkeleton />
@@ -290,8 +306,8 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
               </Box>
             )}
 
-            {/* Top sentinel: last in DOM = visual top */}
-            <Box ref={topSentinelRef} sx={{ height: '1px', flexShrink: 0 }} />
+            {/* Bottom sentinel: last in DOM = visual bottom */}
+            <Box ref={bottomSentinelRef} sx={{ height: '1px', flexShrink: 0 }} />
           </Box>
         ) : (
           <Box

--- a/frontend/src/hooks/useAnchoredModeTransition.ts
+++ b/frontend/src/hooks/useAnchoredModeTransition.ts
@@ -57,7 +57,7 @@ export const useAnchoredModeTransition = ({
   useEffect(() => {
     if (prevModeRef.current === 'anchored' && mode === 'normal') {
       const el = scrollContainerRef.current;
-      el?.scrollTo({ top: el.scrollHeight });
+      if (el) el.scrollTo({ top: el.scrollHeight });
     }
     prevModeRef.current = mode;
   }, [mode, scrollContainerRef]);

--- a/frontend/src/hooks/useAnchoredModeTransition.ts
+++ b/frontend/src/hooks/useAnchoredModeTransition.ts
@@ -51,11 +51,13 @@ export const useAnchoredModeTransition = ({
   }, [mode, atBottom, hasNewer, isLoadingNewer, jumpToPresent]);
 
   // Scroll to bottom when transitioning anchored → normal.
-  // Column-reverse preserves scrollTop from anchored mode; reset to 0 (visual bottom).
+  // The list renders oldest-first in a normal column, so the visual bottom is
+  // scrollTop = scrollHeight (the anchored-mode scrollTop is otherwise kept).
   const prevModeRef = useRef(mode);
   useEffect(() => {
     if (prevModeRef.current === 'anchored' && mode === 'normal') {
-      scrollContainerRef.current?.scrollTo({ top: 0 });
+      const el = scrollContainerRef.current;
+      el?.scrollTo({ top: el.scrollHeight });
     }
     prevModeRef.current = mode;
   }, [mode, scrollContainerRef]);

--- a/frontend/src/hooks/useBidirectionalScroll.ts
+++ b/frontend/src/hooks/useBidirectionalScroll.ts
@@ -170,12 +170,29 @@ export const useBidirectionalScroll = ({
     if (initialPositionedRef.current) return;
     const container = scrollContainerRef.current;
     if (!container || messages.length === 0) return;
-    if (mode === 'anchored') return;
+
+    if (mode === 'anchored') {
+      // If the around-fetch outlived the highlight flash, highlightMessageId
+      // is already cleared by the time messages arrive and the
+      // scroll-to-highlight effect will never fire. Position mid-list (the
+      // fetch centers on the target message) and — crucially — release the
+      // positioning machine so pagination suppression doesn't stick forever.
+      if (!highlightMessageId) {
+        container.scrollTop = Math.max(
+          0,
+          (container.scrollHeight - container.clientHeight) / 2,
+        );
+        initialPositionedRef.current = true;
+        olderLoadSuppressedRef.current = false;
+        newerLoadSuppressedRef.current = false;
+      }
+      return;
+    }
 
     container.scrollTop = container.scrollHeight;
     initialPositionedRef.current = true;
     olderLoadSuppressedRef.current = false;
-  }, [messages, mode]);
+  }, [messages, mode, highlightMessageId]);
 
   // Older-prepend stabilization (both modes). Older pages are inserted at the
   // DOM start, which grows scrollHeight above the viewport and would yank the
@@ -207,12 +224,18 @@ export const useBidirectionalScroll = ({
   // Stick-to-bottom on new messages: when the newest message changes while the
   // user is pinned to the bottom, keep the view glued to the bottom.
   // (messages prop is newest-first, so messages[0] is the newest.)
+  // Normal mode ONLY: in anchored mode a newest-id change means a newer page
+  // was appended below the viewport (websocket handlers never touch the
+  // anchored cache) — it needs no correction, and forcing scrollTop to the
+  // bottom would teleport the user past the loaded page, re-trigger the bottom
+  // sentinel, and cascade newer loads all the way to the present.
   useLayoutEffect(() => {
     const container = scrollContainerRef.current;
     if (!container || messages.length === 0) return;
 
     const newestId = messages[0]?.id;
     if (
+      mode === 'normal' &&
       prevNewestIdRef.current !== undefined &&
       newestId !== prevNewestIdRef.current &&
       pinnedToBottomRef.current
@@ -220,7 +243,7 @@ export const useBidirectionalScroll = ({
       container.scrollTop = container.scrollHeight;
     }
     prevNewestIdRef.current = newestId;
-  }, [messages]);
+  }, [messages, mode]);
 
   // Track whether the user is pinned to the visual bottom.
   useEffect(() => {
@@ -238,9 +261,14 @@ export const useBidirectionalScroll = ({
   // Bottom-pin on content growth (late-loading images/embeds). With native
   // overflow anchoring disabled (overflowAnchor: "none"), content that grows
   // near the bottom would otherwise push the newest message out of view.
+  // Normal mode ONLY: this observer is recreated on message changes and its
+  // initial callbacks fire with a possibly stale pinned=true — in anchored
+  // mode that would teleport the user to the bottom after a newer page load
+  // (see the stick-to-bottom gate above; both mechanisms must be gated).
   useEffect(() => {
     const container = scrollContainerRef.current;
     if (!container || typeof ResizeObserver === 'undefined') return;
+    if (mode !== 'normal') return;
 
     const ro = new ResizeObserver(() => {
       if (pinnedToBottomRef.current) {
@@ -252,7 +280,48 @@ export const useBidirectionalScroll = ({
       ro.observe(child);
     }
     return () => ro.disconnect();
-  }, [hasMessages, messages]);
+  }, [hasMessages, messages, mode]);
+
+  // Above-viewport growth compensation while reading history. When media above
+  // the viewport finishes loading (image placeholder swap, late link embed),
+  // the content below it — including the user's viewport — gets pushed down.
+  // With overflowAnchor: "none" nothing else compensates, so track each
+  // message element's height and shift scrollTop by the growth delta when the
+  // grown element sits above the viewport while the user is NOT pinned to the
+  // bottom (the bottom-pin observer owns the pinned case). The first callback
+  // for a newly observed element only records its height — no compensation —
+  // which also avoids double-compensating prepended pages (the oldest-id
+  // stabilization above already handles those).
+  const knownHeightsRef = useRef(new WeakMap<Element, number>());
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || typeof ResizeObserver === 'undefined') return;
+
+    const heights = knownHeightsRef.current;
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const el = entry.target;
+        const newHeight = el.getBoundingClientRect().height;
+        const prevHeight = heights.get(el);
+        heights.set(el, newHeight);
+        if (prevHeight === undefined) continue; // first observation: record only
+        const delta = newHeight - prevHeight;
+        if (delta <= 0) continue;
+        if (pinnedToBottomRef.current) continue; // bottom-pin owns this case
+        if (el.getBoundingClientRect().top < container.getBoundingClientRect().top) {
+          container.scrollTop += delta;
+        }
+      }
+    });
+    // messageRefs is populated by render-time ref callbacks, so by the time
+    // this effect runs it holds the current message elements; unmounted
+    // elements were removed by their ref callbacks and simply aren't
+    // re-observed (disconnect below drops them from the old observer).
+    for (const el of messageRefs.current.values()) {
+      ro.observe(el);
+    }
+    return () => ro.disconnect();
+  }, [messages]);
 
   // Suppress pagination when entering anchored mode, until scroll-to-highlight
   // completes. When the highlight clears (flash timeout or mode change), lift

--- a/frontend/src/hooks/useBidirectionalScroll.ts
+++ b/frontend/src/hooks/useBidirectionalScroll.ts
@@ -363,7 +363,8 @@ export const useBidirectionalScroll = ({
   // Visual bottom is scrollTop = scrollHeight in a normal column.
   const scrollToBottom = useCallback(() => {
     const el = scrollContainerRef.current;
-    el?.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
   }, []);
 
   return {

--- a/frontend/src/hooks/useBidirectionalScroll.ts
+++ b/frontend/src/hooks/useBidirectionalScroll.ts
@@ -1,11 +1,14 @@
 import { useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
 
 interface UseBidirectionalScrollOptions {
+  /** Messages newest-first (prop contract); the DOM renders them oldest-first. */
   messages: { id: string }[];
   mode: 'normal' | 'anchored';
   highlightMessageId?: string;
   /** Sequence counter — increments on every jump request so re-clicks to the same message trigger a new scroll. */
   highlightSeq?: number;
+  /** Identifies the current context (channel/DM); changing it resets positioning state. */
+  resetKey?: string;
 
   // Older pagination
   onLoadMore?: () => Promise<void>;
@@ -19,19 +22,29 @@ interface UseBidirectionalScrollOptions {
 }
 
 /**
- * Manages bidirectional infinite scroll for a column-reverse message list.
+ * Manages bidirectional infinite scroll for a chronological (oldest-first DOM)
+ * message list in a normal `column` flex container.
+ *
+ * The container renders with `overflowAnchor: "none"` — this hook is the single
+ * owner of scroll stabilization. Chrome's native anchoring is suppressed at
+ * scrollTop===0, which is exactly when older pages load in a normal column, so
+ * it cannot be relied on and must not double-compensate.
  *
  * Handles:
- * - IntersectionObserver sentinels for older (top) and newer (bottom) pagination
- * - Scroll stabilization when newer messages are prepended in anchored mode
+ * - Initial positioning at the bottom (newest message) per context (resetKey)
+ * - IntersectionObserver sentinels for older (visual top / DOM start) and
+ *   newer (visual bottom / DOM end) pagination
+ * - Scroll stabilization when older messages are prepended (both modes)
+ * - Stick-to-bottom for new messages and late content growth while pinned
  * - Scroll-to-highlight for jump-to-message
- * - Newer-load suppression until initial highlight scroll completes
+ * - Load suppression until initial positioning / highlight scroll completes
  */
 export const useBidirectionalScroll = ({
   messages,
   mode,
   highlightMessageId,
   highlightSeq = 0,
+  resetKey,
   onLoadMore,
   isLoadingMore,
   continuationToken,
@@ -46,9 +59,29 @@ export const useBidirectionalScroll = ({
   const [atBottom, setAtBottom] = useState(true);
 
   // Suppresses onLoadNewer until the initial scroll-to-highlight completes.
-  // Without this, column-reverse starts at scrollTop=0 (visual bottom), making
-  // the bottom sentinel visible on first render and triggering cascading loads.
+  // Without this, an anchored list may momentarily show the bottom sentinel
+  // before the highlight scroll fires, triggering cascading newer loads.
   const newerLoadSuppressedRef = useRef(false);
+
+  // Suppresses onLoadMore until initial positioning completes. A normal column
+  // starts at scrollTop=0 (visual TOP), so the top sentinel is visible on first
+  // render — without this guard, older pages would cascade before the initial
+  // scroll-to-bottom (or scroll-to-highlight in anchored mode) runs.
+  const olderLoadSuppressedRef = useRef(true);
+
+  // True once the initial scroll position for the current context has been set
+  // (scroll-to-bottom in normal mode, scroll-to-highlight in anchored mode).
+  const initialPositionedRef = useRef(false);
+
+  // Whether the user is at (or near) the visual bottom — used to decide if new
+  // messages / content growth should keep the view glued to the bottom.
+  const pinnedToBottomRef = useRef(true);
+
+  // Older-prepend stabilization state.
+  const prevScrollHeightRef = useRef(0);
+  const prevOldestIdRef = useRef<string | undefined>(undefined);
+  // Stick-to-bottom state.
+  const prevNewestIdRef = useRef<string | undefined>(undefined);
 
   // Single ref for all pagination state — keeps IntersectionObservers stable.
   // Without this, observers would be recreated on every loading/token change,
@@ -58,8 +91,10 @@ export const useBidirectionalScroll = ({
 
   const hasMessages = messages.length > 0;
 
-  // Bottom sentinel: first in DOM = visual bottom in column-reverse.
+  // Bottom sentinel: last in DOM = visual bottom in a normal column.
   // Tracks atBottom state; in anchored mode also triggers newer message loading.
+  // NOTE: must stay the FIRST observer-creating effect — tests index observers
+  // by creation order (bottom first, top second).
   useEffect(() => {
     const sentinel = bottomSentinelRef.current;
     const container = scrollContainerRef.current;
@@ -86,8 +121,8 @@ export const useBidirectionalScroll = ({
     return () => observer.disconnect();
   }, [hasMessages, mode]);
 
-  // Top sentinel: last in DOM = visual top in column-reverse.
-  // Triggers older message loading.
+  // Top sentinel: first in DOM = visual top in a normal column.
+  // Triggers older message loading once initial positioning has completed.
   useEffect(() => {
     const sentinel = topSentinelRef.current;
     const container = scrollContainerRef.current;
@@ -96,7 +131,13 @@ export const useBidirectionalScroll = ({
     const observer = new IntersectionObserver(
       ([entry]) => {
         const p = paginationRef.current;
-        if (entry.isIntersecting && !p.isLoadingMore && p.continuationToken && p.onLoadMore) {
+        if (
+          entry.isIntersecting &&
+          !p.isLoadingMore &&
+          p.continuationToken &&
+          p.onLoadMore &&
+          !olderLoadSuppressedRef.current
+        ) {
           p.onLoadMore();
         }
       },
@@ -106,38 +147,125 @@ export const useBidirectionalScroll = ({
     return () => observer.disconnect();
   }, [hasMessages]);
 
-  // Stabilize scroll when newer messages are prepended in anchored mode.
-  // In column-reverse, newer messages appear at the visual bottom (DOM start).
-  // Without adjustment, the viewport jumps. Shifting scrollTop by the height
-  // delta keeps the user's current view stable.
-  const prevScrollHeightRef = useRef(0);
-  const prevFirstMsgIdRef = useRef<string | undefined>(undefined);
+  // Reset positioning/stabilization state when switching contexts (channel/DM).
+  // Declared before the positioning and stabilization effects so it runs first
+  // within the same commit.
+  const prevResetKeyRef = useRef(resetKey);
+  useLayoutEffect(() => {
+    if (prevResetKeyRef.current === resetKey) return;
+    prevResetKeyRef.current = resetKey;
+    initialPositionedRef.current = false;
+    olderLoadSuppressedRef.current = true;
+    pinnedToBottomRef.current = true;
+    prevScrollHeightRef.current = 0;
+    prevOldestIdRef.current = undefined;
+    prevNewestIdRef.current = undefined;
+  }, [resetKey]);
+
+  // Initial positioning on the first non-empty message set for this context.
+  // Normal mode: jump straight to the bottom (newest message) and release the
+  // older-load suppression. Anchored mode: positioning belongs to the
+  // scroll-to-highlight effect below; suppression stays on until it fires.
+  useLayoutEffect(() => {
+    if (initialPositionedRef.current) return;
+    const container = scrollContainerRef.current;
+    if (!container || messages.length === 0) return;
+    if (mode === 'anchored') return;
+
+    container.scrollTop = container.scrollHeight;
+    initialPositionedRef.current = true;
+    olderLoadSuppressedRef.current = false;
+  }, [messages, mode]);
+
+  // Older-prepend stabilization (both modes). Older pages are inserted at the
+  // DOM start, which grows scrollHeight above the viewport and would yank the
+  // view upward. Shifting scrollTop by the height delta keeps the current view
+  // stable. (Newer pages in anchored mode append at the DOM end and need no
+  // compensation.)
   useLayoutEffect(() => {
     const container = scrollContainerRef.current;
     if (!container || messages.length === 0) return;
 
-    const firstMsgId = messages[0]?.id;
+    const oldestId = messages[messages.length - 1]?.id;
     const currentScrollHeight = container.scrollHeight;
     const prevScrollHeight = prevScrollHeightRef.current;
 
     if (
-      mode === 'anchored' &&
-      prevFirstMsgIdRef.current &&
-      firstMsgId !== prevFirstMsgIdRef.current &&
+      initialPositionedRef.current &&
+      prevOldestIdRef.current !== undefined &&
+      oldestId !== prevOldestIdRef.current &&
       prevScrollHeight > 0 &&
       currentScrollHeight > prevScrollHeight
     ) {
-      const delta = currentScrollHeight - prevScrollHeight;
-      container.scrollTop -= delta;
+      container.scrollTop += currentScrollHeight - prevScrollHeight;
     }
 
     prevScrollHeightRef.current = currentScrollHeight;
-    prevFirstMsgIdRef.current = firstMsgId;
-  }, [messages, mode]);
+    prevOldestIdRef.current = oldestId;
+  }, [messages]);
 
-  // Suppress onLoadNewer when entering anchored mode, until scroll-to-highlight completes
+  // Stick-to-bottom on new messages: when the newest message changes while the
+  // user is pinned to the bottom, keep the view glued to the bottom.
+  // (messages prop is newest-first, so messages[0] is the newest.)
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || messages.length === 0) return;
+
+    const newestId = messages[0]?.id;
+    if (
+      prevNewestIdRef.current !== undefined &&
+      newestId !== prevNewestIdRef.current &&
+      pinnedToBottomRef.current
+    ) {
+      container.scrollTop = container.scrollHeight;
+    }
+    prevNewestIdRef.current = newestId;
+  }, [messages]);
+
+  // Track whether the user is pinned to the visual bottom.
   useEffect(() => {
-    newerLoadSuppressedRef.current = mode === 'anchored' && !!highlightMessageId;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const onScroll = () => {
+      pinnedToBottomRef.current =
+        container.scrollHeight - container.scrollTop - container.clientHeight < 40;
+    };
+    container.addEventListener('scroll', onScroll, { passive: true });
+    return () => container.removeEventListener('scroll', onScroll);
+  }, [hasMessages]);
+
+  // Bottom-pin on content growth (late-loading images/embeds). With native
+  // overflow anchoring disabled (overflowAnchor: "none"), content that grows
+  // near the bottom would otherwise push the newest message out of view.
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || typeof ResizeObserver === 'undefined') return;
+
+    const ro = new ResizeObserver(() => {
+      if (pinnedToBottomRef.current) {
+        container.scrollTop = container.scrollHeight;
+      }
+    });
+    ro.observe(container);
+    for (const child of Array.from(container.children)) {
+      ro.observe(child);
+    }
+    return () => ro.disconnect();
+  }, [hasMessages, messages]);
+
+  // Suppress pagination when entering anchored mode, until scroll-to-highlight
+  // completes. When the highlight clears (flash timeout or mode change), lift
+  // the newer suppression; the older suppression is lifted only once initial
+  // positioning has happened for this context.
+  useEffect(() => {
+    const suppress = mode === 'anchored' && !!highlightMessageId;
+    newerLoadSuppressedRef.current = suppress;
+    if (suppress) {
+      olderLoadSuppressedRef.current = true;
+    } else if (initialPositionedRef.current) {
+      olderLoadSuppressedRef.current = false;
+    }
   }, [mode, highlightMessageId]);
 
   // Scroll to highlighted message (once per highlightSeq).
@@ -153,17 +281,20 @@ export const useBidirectionalScroll = ({
       if (el) {
         el.scrollIntoView({ behavior: "instant", block: "center" });
         lastScrolledSeqRef.current = highlightSeq;
-        // Allow onLoadNewer after the browser processes the scroll
+        initialPositionedRef.current = true;
+        // Allow pagination after the browser processes the scroll
         requestAnimationFrame(() => {
           newerLoadSuppressedRef.current = false;
+          olderLoadSuppressedRef.current = false;
         });
       }
     }
   }, [highlightMessageId, highlightSeq, messages]);
 
-  // scrollTop=0 is visual bottom in column-reverse
+  // Visual bottom is scrollTop = scrollHeight in a normal column.
   const scrollToBottom = useCallback(() => {
-    scrollContainerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+    const el = scrollContainerRef.current;
+    el?.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
   }, []);
 
   return {


### PR DESCRIPTION
## Problem

Selecting text across multiple messages highlights the wrong ranges (wraps "top to bottom"). Native browser selection follows **DOM order**, and the message list rendered newest-first inside a `flex-direction: column-reverse` container — so DOM order was the exact reverse of visual order.

## Fix

Render messages **oldest-first in a normal column** (the prop contract stays newest-first; the component reverses for render), and replace the free scroll-anchoring that `column-reverse` provided with explicit logic in `useBidirectionalScroll` (same return signature):

- initial scroll-to-bottom per channel/DM (`resetKey`), pre-paint
- pinned-to-bottom tracking + stick-to-bottom on new messages + ResizeObserver bottom-pin for late content growth — all gated to normal mode so anchored (jump-to-message) reading is never yanked
- older-page prepend `scrollTop` compensation in both modes; native `overflow-anchor` disabled so there is exactly one owner
- above-viewport growth compensation: when an image/link-preview finishes loading above the viewport while you're reading history, `scrollTop` is adjusted by the delta so the view doesn't jump (per-message ResizeObserver via the existing `messageRefs`)
- `marginTop: auto` on the first child restores bottom-packing for sparse channels
- anchored mode releases pagination suppression even if the around-fetch outlives the 3s highlight window

## Review

This was the riskiest change of the batch, so it got the heaviest treatment: two adversarial reviews (correctness walked the scroll state machine against event-loop ordering; regression walked every consumer — mark-as-read, unread divider, cache updaters, FAB, thread panel, e2e specs). All four must-fix findings from those reviews are addressed in the second commit. Verified non-issues: message grouping (none exists), `useMessageVisibility` semantics, unread-divider placement math, websocket cache updaters.

Known cosmetic leftover: the older-page loading skeleton mounting at the top shifts content for a moment until the page lands (compensation would double-count against prepend stabilization; punted deliberately).

## Tests

38/38 in `MessageContainer.test.tsx` (5 new: chronological DOM order — the actual regression test for selection — anchored no-yank, marginTop auto, growth compensation pinned/unpinned, anchored suppression release).

## Manual checklist (jsdom can't validate scroll feel — worth a real pass)

- [ ] Select text across 5+ messages, both drag directions; copy → chronological order
- [ ] Channel opens at bottom; new messages stick when at bottom, don't yank when scrolled up
- [ ] Scroll up through an image-heavy channel: no jumps as images load
- [ ] Search → jump to result → scroll up AND down → Jump to Present
- [ ] Sparse channel (2-3 messages) renders at the bottom
- [ ] Unread divider position; DM and channel; mobile layout

Part of the undocumented-bug batch (#373–#376).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
