### PR TITLE
fix(replay): heal stale egress sessions and notify clients so capture stops 404ing

### DIFF
--- a/backend/src/livekit/livekit-replay.service.spec.ts
+++ b/backend/src/livekit/livekit-replay.service.spec.ts
@@ -858,6 +858,142 @@ describe('LivekitReplayService', () => {
       );
     });
 
+    describe('stale session recovery', () => {
+      const staleSession = {
+        id: 'session-1',
+        userId,
+        channelId: 'channel-1',
+        egressId: 'egress-123',
+        status: 'stopped',
+        error: null,
+        segmentPath: 'session-1',
+        startedAt: new Date('2025-01-01'),
+      };
+
+      it('should heal the session and proceed when LiveKit says the egress is still running', async () => {
+        databaseService.egressSession.findFirst
+          .mockResolvedValueOnce(null) // active-session lookup misses
+          .mockResolvedValueOnce(staleSession); // most-recent session lookup
+        mockEgressClient.listEgress.mockResolvedValue([
+          { status: EgressStatus.EGRESS_ACTIVE },
+        ]);
+        databaseService.egressSession.update.mockResolvedValue({
+          ...staleSession,
+          status: 'active',
+          endedAt: null,
+        });
+
+        const result = await service.captureReplay(userId, dto);
+
+        expect(result.clipId).toBe('clip-1');
+        expect(databaseService.egressSession.update).toHaveBeenCalledWith({
+          where: { id: 'session-1' },
+          data: { status: 'active', endedAt: null, error: null },
+        });
+        expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+      });
+
+      it('should heal the session when LiveKit says the egress is starting', async () => {
+        databaseService.egressSession.findFirst
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(staleSession);
+        mockEgressClient.listEgress.mockResolvedValue([
+          { status: EgressStatus.EGRESS_STARTING },
+        ]);
+        databaseService.egressSession.update.mockResolvedValue({
+          ...staleSession,
+          status: 'active',
+          endedAt: null,
+        });
+
+        const result = await service.captureReplay(userId, dto);
+
+        expect(result.clipId).toBe('clip-1');
+        expect(databaseService.egressSession.update).toHaveBeenCalledWith({
+          where: { id: 'session-1' },
+          data: { status: 'active', endedAt: null, error: null },
+        });
+      });
+
+      it('should emit REPLAY_BUFFER_STOPPED and throw an accurate 404 when the egress is gone', async () => {
+        databaseService.egressSession.findFirst
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(staleSession);
+        mockEgressClient.listEgress.mockResolvedValue([]); // Egress gone
+
+        await expect(service.captureReplay(userId, dto)).rejects.toThrow(
+          'Your replay recording has ended — start screen sharing again to capture.',
+        );
+
+        expect(websocketService.sendToRoom).toHaveBeenCalledWith(
+          'user:user-123',
+          ServerEvents.REPLAY_BUFFER_STOPPED,
+          expect.objectContaining({
+            sessionId: 'session-1',
+            egressId: 'egress-123',
+            channelId: 'channel-1',
+          }),
+        );
+        expect(databaseService.egressSession.update).not.toHaveBeenCalled();
+      });
+
+      it('should emit REPLAY_BUFFER_FAILED when the stale session had failed', async () => {
+        databaseService.egressSession.findFirst
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({
+            ...staleSession,
+            status: 'failed',
+            error: 'Codec error',
+          });
+        mockEgressClient.listEgress.mockResolvedValue([]);
+
+        await expect(service.captureReplay(userId, dto)).rejects.toThrow(
+          NotFoundException,
+        );
+
+        expect(websocketService.sendToRoom).toHaveBeenCalledWith(
+          'user:user-123',
+          ServerEvents.REPLAY_BUFFER_FAILED,
+          expect.objectContaining({
+            sessionId: 'session-1',
+            error: 'Codec error',
+          }),
+        );
+      });
+
+      it('should throw the accurate 404 when listEgress itself fails', async () => {
+        databaseService.egressSession.findFirst
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(staleSession);
+        mockEgressClient.listEgress.mockRejectedValue(
+          new Error('LiveKit unreachable'),
+        );
+
+        await expect(service.captureReplay(userId, dto)).rejects.toThrow(
+          'Your replay recording has ended — start screen sharing again to capture.',
+        );
+
+        expect(websocketService.sendToRoom).toHaveBeenCalledWith(
+          'user:user-123',
+          ServerEvents.REPLAY_BUFFER_STOPPED,
+          expect.any(Object),
+        );
+      });
+
+      it('should throw the generic 404 when the user has no sessions at all', async () => {
+        databaseService.egressSession.findFirst
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(null);
+
+        await expect(service.captureReplay(userId, dto)).rejects.toThrow(
+          'No active replay found. Start screen sharing first.',
+        );
+
+        expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+        expect(mockEgressClient.listEgress).not.toHaveBeenCalled();
+      });
+    });
+
     describe('destination authorization', () => {
       it('should throw ForbiddenException when posting to channel without community membership', async () => {
         const channelDto = {
@@ -982,6 +1118,8 @@ describe('LivekitReplayService', () => {
       const activeSession = {
         id: 'session-1',
         egressId: 'missing-egress',
+        userId: 'user-123',
+        channelId: 'channel-1',
         status: 'active',
       };
 
@@ -996,6 +1134,33 @@ describe('LivekitReplayService', () => {
           data: expect.objectContaining({
             status: 'stopped',
           }),
+        }),
+      );
+    });
+
+    it('should emit REPLAY_BUFFER_STOPPED when egress not found in LiveKit', async () => {
+      const activeSession = {
+        id: 'session-1',
+        egressId: 'missing-egress',
+        userId: 'user-123',
+        channelId: 'channel-1',
+        status: 'active',
+      };
+
+      databaseService.egressSession.findMany.mockResolvedValue([activeSession]);
+      mockEgressClient.listEgress.mockResolvedValue([]); // Egress not found
+
+      await service.reconcileEgressStatus();
+
+      // Without this event the frontend keeps showing the capture button
+      // and every capture attempt 404s (issue #302)
+      expect(websocketService.sendToRoom).toHaveBeenCalledWith(
+        'user:user-123',
+        ServerEvents.REPLAY_BUFFER_STOPPED,
+        expect.objectContaining({
+          sessionId: 'session-1',
+          egressId: 'missing-egress',
+          channelId: 'channel-1',
         }),
       );
     });
@@ -1039,6 +1204,99 @@ describe('LivekitReplayService', () => {
       await service.reconcileEgressStatus();
 
       expect(databaseService.egressSession.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('streamReplay', () => {
+    const userId = 'user-123';
+    const activeSession = {
+      id: 'session-1',
+      userId,
+      channelId: 'channel-1',
+      egressId: 'egress-123',
+      status: 'active',
+      error: null,
+      segmentPath: 'session-1',
+      startedAt: new Date('2025-01-01'),
+    };
+
+    beforeEach(() => {
+      replaySegmentsService.listCompleteSegments.mockResolvedValue([
+        {
+          filename: '2025-01-01T000000-segment_00000.ts',
+          sequence: 0,
+          path: '/app/storage/replay-segments/session-1/2025-01-01T000000-segment_00000.ts',
+        },
+      ]);
+      ffmpegService.concatenateSegments.mockResolvedValue(undefined);
+    });
+
+    it('should stream from an active session', async () => {
+      databaseService.egressSession.findFirst.mockResolvedValue(activeSession);
+
+      const result = await service.streamReplay(userId, 1);
+
+      expect(result).toContain('replay-stream-user-123');
+      expect(ffmpegService.concatenateSegments).toHaveBeenCalled();
+    });
+
+    it('should heal the session and stream when LiveKit says the egress is still running', async () => {
+      databaseService.egressSession.findFirst
+        .mockResolvedValueOnce(null) // active-session lookup misses
+        .mockResolvedValueOnce({ ...activeSession, status: 'stopped' });
+      mockEgressClient.listEgress.mockResolvedValue([
+        { status: EgressStatus.EGRESS_ACTIVE },
+      ]);
+      databaseService.egressSession.update.mockResolvedValue(activeSession);
+
+      const result = await service.streamReplay(userId, 1);
+
+      expect(result).toContain('replay-stream-user-123');
+      expect(databaseService.egressSession.update).toHaveBeenCalledWith({
+        where: { id: 'session-1' },
+        data: { status: 'active', endedAt: null, error: null },
+      });
+    });
+
+    it('should emit REPLAY_BUFFER_STOPPED and throw an accurate 404 when the egress is gone', async () => {
+      databaseService.egressSession.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ ...activeSession, status: 'stopped' });
+      mockEgressClient.listEgress.mockResolvedValue([]);
+
+      await expect(service.streamReplay(userId, 1)).rejects.toThrow(
+        'Your replay recording has ended — start screen sharing again to capture.',
+      );
+
+      expect(websocketService.sendToRoom).toHaveBeenCalledWith(
+        'user:user-123',
+        ServerEvents.REPLAY_BUFFER_STOPPED,
+        expect.objectContaining({
+          sessionId: 'session-1',
+          egressId: 'egress-123',
+          channelId: 'channel-1',
+        }),
+      );
+    });
+  });
+
+  describe('onApplicationBootstrap', () => {
+    it('should run egress reconciliation once at startup', async () => {
+      const reconcileSpy = jest
+        .spyOn(service, 'reconcileEgressStatus')
+        .mockResolvedValue(undefined);
+
+      await service.onApplicationBootstrap();
+
+      expect(reconcileSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw when startup reconciliation fails', async () => {
+      jest
+        .spyOn(service, 'reconcileEgressStatus')
+        .mockRejectedValue(new Error('LiveKit down'));
+
+      await expect(service.onApplicationBootstrap()).resolves.toBeUndefined();
     });
   });
 });

--- a/backend/src/livekit/livekit-replay.service.spec.ts
+++ b/backend/src/livekit/livekit-replay.service.spec.ts
@@ -6,6 +6,7 @@ import {
   BadRequestException,
   ForbiddenException,
   NotFoundException,
+  ServiceUnavailableException,
 } from '@nestjs/common';
 import { LivekitReplayService } from './livekit-replay.service';
 import { DatabaseService } from '@/database/database.service';
@@ -733,6 +734,35 @@ describe('LivekitReplayService', () => {
         }),
       );
     });
+
+    it('should propagate a 503 instead of reporting inactive when LiveKit cannot be checked during the heal', async () => {
+      const staleSession = {
+        id: 'session-1',
+        userId: 'user-123',
+        channelId: 'channel-1',
+        egressId: 'egress-123',
+        status: 'stopped',
+        error: null,
+        segmentPath: 'session-1',
+        startedAt: new Date(Date.now() - 10 * 60 * 1000),
+        endedAt: new Date(Date.now() - 60 * 1000),
+      };
+
+      databaseService.egressSession.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(staleSession);
+      mockEgressClient.listEgress.mockRejectedValue(
+        new Error('LiveKit unreachable'),
+      );
+
+      // hasActiveSession: false would wrongly kill the Custom Trim UI for a
+      // possibly-live buffer — a retryable 503 must surface instead
+      await expect(service.getSessionInfo('user-123')).rejects.toBeInstanceOf(
+        ServiceUnavailableException,
+      );
+      expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+      expect(databaseService.egressSession.updateMany).not.toHaveBeenCalled();
+    });
   });
 
   // Clip library tests (getUserClips, getPublicClips, updateClip, deleteClip, shareClip)
@@ -1144,7 +1174,7 @@ describe('LivekitReplayService', () => {
         );
       });
 
-      it('should throw the accurate 404 when listEgress itself fails', async () => {
+      it('should throw a retryable 503 when listEgress itself fails, without emitting or touching the row', async () => {
         databaseService.egressSession.findFirst
           .mockResolvedValueOnce(null)
           .mockResolvedValueOnce(staleSession);
@@ -1152,15 +1182,19 @@ describe('LivekitReplayService', () => {
           new Error('LiveKit unreachable'),
         );
 
-        await expect(service.captureReplay(userId, dto)).rejects.toThrow(
-          'Your replay recording has ended — start screen sharing again to capture.',
+        const promise = service.captureReplay(userId, dto);
+        await expect(promise).rejects.toBeInstanceOf(
+          ServiceUnavailableException,
+        );
+        await expect(promise).rejects.toThrow(
+          'Could not check your replay status — please try again.',
         );
 
-        expect(websocketService.sendToRoom).toHaveBeenCalledWith(
-          'user:user-123',
-          ServerEvents.REPLAY_BUFFER_STOPPED,
-          expect.any(Object),
-        );
+        // LiveKit unreachable means the recording may still be alive —
+        // no "ended" event, no DB state change
+        expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+        expect(databaseService.egressSession.update).not.toHaveBeenCalled();
+        expect(databaseService.egressSession.updateMany).not.toHaveBeenCalled();
       });
 
       it('should throw the generic 404 when the user has no sessions at all', async () => {
@@ -1412,6 +1446,47 @@ describe('LivekitReplayService', () => {
       await service.reconcileEgressStatus();
 
       expect(databaseService.egressSession.update).not.toHaveBeenCalled();
+    });
+
+    it('should skip a pass while a previous one is still in flight, then run again after it settles', async () => {
+      databaseService.egressSession.findMany.mockResolvedValue([
+        {
+          id: 'session-1',
+          egressId: 'active-egress',
+          userId: 'user-123',
+          channelId: 'channel-1',
+          status: 'active',
+        },
+      ]);
+
+      // Deferred listEgress keeps the first pass hanging mid-reconcile
+      // (the bootstrap fire-and-forget vs cron overlap scenario)
+      let resolveListEgress!: (value: unknown[]) => void;
+      mockEgressClient.listEgress.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveListEgress = resolve;
+        }),
+      );
+
+      const firstPass = service.reconcileEgressStatus();
+      // Let the first pass advance to the in-flight listEgress await
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(mockEgressClient.listEgress).toHaveBeenCalledTimes(1);
+
+      // Second concurrent invocation must bail out immediately
+      await service.reconcileEgressStatus();
+      expect(databaseService.egressSession.findMany).toHaveBeenCalledTimes(1);
+      expect(mockEgressClient.listEgress).toHaveBeenCalledTimes(1);
+
+      resolveListEgress([{ status: EgressStatus.EGRESS_ACTIVE }]);
+      await firstPass;
+
+      // Guard released — a later pass reconciles again
+      mockEgressClient.listEgress.mockResolvedValue([
+        { status: EgressStatus.EGRESS_ACTIVE },
+      ]);
+      await service.reconcileEgressStatus();
+      expect(databaseService.egressSession.findMany).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/backend/src/livekit/livekit-replay.service.spec.ts
+++ b/backend/src/livekit/livekit-replay.service.spec.ts
@@ -283,6 +283,38 @@ describe('LivekitReplayService', () => {
       expect(databaseService.egressSession.update).toHaveBeenCalled();
     });
 
+    it('should tolerate "not active"-family stop errors (case-insensitive) and still clean up', async () => {
+      const activeSession = {
+        id: 'session-1',
+        egressId: 'egress-123',
+        userId: 'user-123',
+        status: 'active',
+        segmentPath: 'session-1',
+      };
+
+      databaseService.egressSession.findFirst.mockResolvedValue(activeSession);
+      // Zombie-active row: the egress already completed on the LiveKit side
+      mockEgressClient.stopEgress.mockRejectedValue(
+        new Error('twirp error failed_precondition: Egress is not active'),
+      );
+      databaseService.egressSession.update.mockResolvedValue({
+        ...activeSession,
+        status: 'stopped',
+      });
+      storageService.deleteSegmentDirectory.mockResolvedValue(undefined);
+
+      // Must not throw — otherwise the zombie row would block the next
+      // screen-share start forever
+      const result = await service.stopReplayBuffer('user-123');
+      expect(result.status).toBe('stopped');
+      expect(databaseService.egressSession.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'session-1' },
+          data: expect.objectContaining({ status: 'stopped' }),
+        }),
+      );
+    });
+
     it('should throw BadRequestException for other egress stop failures', async () => {
       const activeSession = {
         id: 'session-1',
@@ -629,6 +661,78 @@ describe('LivekitReplayService', () => {
       expect(result.totalSegments).toBe(0);
       expect(result.totalDurationSeconds).toBe(0);
     });
+
+    it('should heal a stranded session and report it active when LiveKit says the egress is still running', async () => {
+      const staleSession = {
+        id: 'session-1',
+        userId: 'user-123',
+        channelId: 'channel-1',
+        egressId: 'egress-123',
+        status: 'stopped',
+        error: null,
+        segmentPath: 'session-1',
+        startedAt: new Date(Date.now() - 10 * 60 * 1000),
+        endedAt: new Date(Date.now() - 60 * 1000),
+      };
+
+      databaseService.egressSession.findFirst
+        .mockResolvedValueOnce(null) // active-session lookup misses
+        .mockResolvedValueOnce(staleSession); // most-recent session lookup
+      mockEgressClient.listEgress.mockResolvedValue([
+        { status: EgressStatus.EGRESS_ACTIVE },
+      ]);
+      databaseService.egressSession.updateMany.mockResolvedValue({ count: 1 });
+      replaySegmentsService.listCompleteSegments.mockResolvedValue([
+        {
+          filename: '2025-01-01T000000-segment_00000.ts',
+          sequence: 0,
+          path: '/app/storage/replay-segments/session-1/2025-01-01T000000-segment_00000.ts',
+        },
+      ]);
+
+      const result = await service.getSessionInfo('user-123');
+
+      // The Custom Trim modal stays alive instead of showing "no session"
+      expect(result.hasActiveSession).toBe(true);
+      expect(result.sessionId).toBe('session-1');
+      expect(result.totalSegments).toBe(1);
+      expect(databaseService.egressSession.updateMany).toHaveBeenCalledWith({
+        where: { id: 'session-1', status: 'stopped' },
+        data: { status: 'active', endedAt: null, error: null },
+      });
+    });
+
+    it('should emit the missed stop event and report inactive when the egress is genuinely gone', async () => {
+      const staleSession = {
+        id: 'session-1',
+        userId: 'user-123',
+        channelId: 'channel-1',
+        egressId: 'egress-123',
+        status: 'stopped',
+        error: null,
+        segmentPath: 'session-1',
+        startedAt: new Date(Date.now() - 10 * 60 * 1000),
+        endedAt: new Date(Date.now() - 60 * 1000),
+      };
+
+      databaseService.egressSession.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(staleSession);
+      mockEgressClient.listEgress.mockResolvedValue([]); // Egress gone
+
+      const result = await service.getSessionInfo('user-123');
+
+      expect(result.hasActiveSession).toBe(false);
+      expect(websocketService.sendToRoom).toHaveBeenCalledWith(
+        'user:user-123',
+        ServerEvents.REPLAY_BUFFER_STOPPED,
+        expect.objectContaining({
+          sessionId: 'session-1',
+          egressId: 'egress-123',
+          channelId: 'channel-1',
+        }),
+      );
+    });
   });
 
   // Clip library tests (getUserClips, getPublicClips, updateClip, deleteClip, shareClip)
@@ -859,6 +963,7 @@ describe('LivekitReplayService', () => {
     });
 
     describe('stale session recovery', () => {
+      // Ended recently — within the 24h notify window
       const staleSession = {
         id: 'session-1',
         userId,
@@ -867,7 +972,8 @@ describe('LivekitReplayService', () => {
         status: 'stopped',
         error: null,
         segmentPath: 'session-1',
-        startedAt: new Date('2025-01-01'),
+        startedAt: new Date(Date.now() - 10 * 60 * 1000),
+        endedAt: new Date(Date.now() - 60 * 1000),
       };
 
       it('should heal the session and proceed when LiveKit says the egress is still running', async () => {
@@ -877,17 +983,16 @@ describe('LivekitReplayService', () => {
         mockEgressClient.listEgress.mockResolvedValue([
           { status: EgressStatus.EGRESS_ACTIVE },
         ]);
-        databaseService.egressSession.update.mockResolvedValue({
-          ...staleSession,
-          status: 'active',
-          endedAt: null,
+        databaseService.egressSession.updateMany.mockResolvedValue({
+          count: 1,
         });
 
         const result = await service.captureReplay(userId, dto);
 
         expect(result.clipId).toBe('clip-1');
-        expect(databaseService.egressSession.update).toHaveBeenCalledWith({
-          where: { id: 'session-1' },
+        // Compare-and-swap on the status we read, not a blind update
+        expect(databaseService.egressSession.updateMany).toHaveBeenCalledWith({
+          where: { id: 'session-1', status: 'stopped' },
           data: { status: 'active', endedAt: null, error: null },
         });
         expect(websocketService.sendToRoom).not.toHaveBeenCalled();
@@ -900,19 +1005,79 @@ describe('LivekitReplayService', () => {
         mockEgressClient.listEgress.mockResolvedValue([
           { status: EgressStatus.EGRESS_STARTING },
         ]);
-        databaseService.egressSession.update.mockResolvedValue({
-          ...staleSession,
-          status: 'active',
-          endedAt: null,
+        databaseService.egressSession.updateMany.mockResolvedValue({
+          count: 1,
         });
 
         const result = await service.captureReplay(userId, dto);
 
         expect(result.clipId).toBe('clip-1');
-        expect(databaseService.egressSession.update).toHaveBeenCalledWith({
-          where: { id: 'session-1' },
+        expect(databaseService.egressSession.updateMany).toHaveBeenCalledWith({
+          where: { id: 'session-1', status: 'stopped' },
           data: { status: 'active', endedAt: null, error: null },
         });
+      });
+
+      it('should NOT heal when LiveKit says the egress is ending', async () => {
+        databaseService.egressSession.findFirst
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(staleSession);
+        mockEgressClient.listEgress.mockResolvedValue([
+          { status: EgressStatus.EGRESS_ENDING },
+        ]);
+
+        await expect(service.captureReplay(userId, dto)).rejects.toThrow(
+          'Your replay recording has ended — start screen sharing again to capture.',
+        );
+
+        // No resurrect attempt for a winding-down egress
+        expect(databaseService.egressSession.updateMany).not.toHaveBeenCalled();
+        expect(websocketService.sendToRoom).toHaveBeenCalledWith(
+          'user:user-123',
+          ServerEvents.REPLAY_BUFFER_STOPPED,
+          expect.any(Object),
+        );
+      });
+
+      it('should consult LiveKit before attempting any resurrect update', async () => {
+        const callOrder: string[] = [];
+        databaseService.egressSession.findFirst
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(staleSession);
+        mockEgressClient.listEgress.mockImplementation(() => {
+          callOrder.push('listEgress');
+          return Promise.resolve([{ status: EgressStatus.EGRESS_ACTIVE }]);
+        });
+        databaseService.egressSession.updateMany.mockImplementation(() => {
+          callOrder.push('updateMany');
+          return Promise.resolve({ count: 1 });
+        });
+
+        await service.captureReplay(userId, dto);
+
+        expect(callOrder).toEqual(['listEgress', 'updateMany']);
+      });
+
+      it('should fall through to the ended path when the resurrect CAS loses the race', async () => {
+        databaseService.egressSession.findFirst
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(staleSession);
+        mockEgressClient.listEgress.mockResolvedValue([
+          { status: EgressStatus.EGRESS_ACTIVE },
+        ]);
+        // Row status changed between our read and the update (webhook or
+        // another replica) — CAS matches nothing
+        databaseService.egressSession.updateMany.mockResolvedValue({
+          count: 0,
+        });
+
+        await expect(service.captureReplay(userId, dto)).rejects.toThrow(
+          NotFoundException,
+        );
+
+        // Capture must not proceed on a lost CAS
+        expect(ffmpegService.concatenateSegments).not.toHaveBeenCalled();
+        expect(databaseService.replayClip.create).not.toHaveBeenCalled();
       });
 
       it('should emit REPLAY_BUFFER_STOPPED and throw an accurate 404 when the egress is gone', async () => {
@@ -934,7 +1099,25 @@ describe('LivekitReplayService', () => {
             channelId: 'channel-1',
           }),
         );
-        expect(databaseService.egressSession.update).not.toHaveBeenCalled();
+        expect(databaseService.egressSession.updateMany).not.toHaveBeenCalled();
+      });
+
+      it('should skip the stop event and throw the generic 404 when the session ended more than 24h ago', async () => {
+        databaseService.egressSession.findFirst
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({
+            ...staleSession,
+            startedAt: new Date(Date.now() - 26 * 60 * 60 * 1000),
+            endedAt: new Date(Date.now() - 25 * 60 * 60 * 1000),
+          });
+        mockEgressClient.listEgress.mockResolvedValue([]);
+
+        await expect(service.captureReplay(userId, dto)).rejects.toThrow(
+          'No active replay found. Start screen sharing first.',
+        );
+
+        // No phantom "Replay ended" toast for ancient sessions (stale tabs)
+        expect(websocketService.sendToRoom).not.toHaveBeenCalled();
       });
 
       it('should emit REPLAY_BUFFER_FAILED when the stale session had failed', async () => {
@@ -1114,20 +1297,38 @@ describe('LivekitReplayService', () => {
   });
 
   describe('reconcileEgressStatus', () => {
-    it('should update session when egress not found in LiveKit', async () => {
-      const activeSession = {
-        id: 'session-1',
-        egressId: 'missing-egress',
-        userId: 'user-123',
-        channelId: 'channel-1',
-        status: 'active',
-      };
+    const missingSession = {
+      id: 'session-1',
+      egressId: 'missing-egress',
+      userId: 'user-123',
+      channelId: 'channel-1',
+      status: 'active',
+    };
 
-      databaseService.egressSession.findMany.mockResolvedValue([activeSession]);
+    it('should not act on the first listEgress miss (two-strikes rule)', async () => {
+      databaseService.egressSession.findMany.mockResolvedValue([
+        missingSession,
+      ]);
       mockEgressClient.listEgress.mockResolvedValue([]); // Egress not found
 
       await service.reconcileEgressStatus();
 
+      // A single empty response can be a transient blip — flipping the row
+      // and emitting here would kill the capture button for a live share
+      expect(databaseService.egressSession.update).not.toHaveBeenCalled();
+      expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+    });
+
+    it('should mark stopped and emit REPLAY_BUFFER_STOPPED on the second consecutive miss', async () => {
+      databaseService.egressSession.findMany.mockResolvedValue([
+        missingSession,
+      ]);
+      mockEgressClient.listEgress.mockResolvedValue([]); // Egress not found
+
+      await service.reconcileEgressStatus(); // first miss — strike only
+      await service.reconcileEgressStatus(); // second miss — act
+
+      expect(databaseService.egressSession.update).toHaveBeenCalledTimes(1);
       expect(databaseService.egressSession.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: 'session-1' },
@@ -1136,22 +1337,6 @@ describe('LivekitReplayService', () => {
           }),
         }),
       );
-    });
-
-    it('should emit REPLAY_BUFFER_STOPPED when egress not found in LiveKit', async () => {
-      const activeSession = {
-        id: 'session-1',
-        egressId: 'missing-egress',
-        userId: 'user-123',
-        channelId: 'channel-1',
-        status: 'active',
-      };
-
-      databaseService.egressSession.findMany.mockResolvedValue([activeSession]);
-      mockEgressClient.listEgress.mockResolvedValue([]); // Egress not found
-
-      await service.reconcileEgressStatus();
-
       // Without this event the frontend keeps showing the capture button
       // and every capture attempt 404s (issue #302)
       expect(websocketService.sendToRoom).toHaveBeenCalledWith(
@@ -1163,6 +1348,29 @@ describe('LivekitReplayService', () => {
           channelId: 'channel-1',
         }),
       );
+    });
+
+    it('should clear the strike when the egress reappears between passes', async () => {
+      databaseService.egressSession.findMany.mockResolvedValue([
+        missingSession,
+      ]);
+      mockEgressClient.listEgress
+        .mockResolvedValueOnce([]) // miss #1 — strike
+        .mockResolvedValueOnce([{ status: EgressStatus.EGRESS_ACTIVE }]) // found again — strike cleared
+        .mockResolvedValueOnce([]); // isolated miss — strike #1 again, no action
+
+      await service.reconcileEgressStatus();
+      await service.reconcileEgressStatus();
+      await service.reconcileEgressStatus();
+
+      expect(databaseService.egressSession.update).not.toHaveBeenCalled();
+      expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+
+      // A fourth pass with a second consecutive miss finally acts
+      mockEgressClient.listEgress.mockResolvedValueOnce([]);
+      await service.reconcileEgressStatus();
+
+      expect(databaseService.egressSession.update).toHaveBeenCalledTimes(1);
     });
 
     it('should update session when LiveKit shows failed status', async () => {
@@ -1247,13 +1455,13 @@ describe('LivekitReplayService', () => {
       mockEgressClient.listEgress.mockResolvedValue([
         { status: EgressStatus.EGRESS_ACTIVE },
       ]);
-      databaseService.egressSession.update.mockResolvedValue(activeSession);
+      databaseService.egressSession.updateMany.mockResolvedValue({ count: 1 });
 
       const result = await service.streamReplay(userId, 1);
 
       expect(result).toContain('replay-stream-user-123');
-      expect(databaseService.egressSession.update).toHaveBeenCalledWith({
-        where: { id: 'session-1' },
+      expect(databaseService.egressSession.updateMany).toHaveBeenCalledWith({
+        where: { id: 'session-1', status: 'stopped' },
         data: { status: 'active', endedAt: null, error: null },
       });
     });
@@ -1261,7 +1469,11 @@ describe('LivekitReplayService', () => {
     it('should emit REPLAY_BUFFER_STOPPED and throw an accurate 404 when the egress is gone', async () => {
       databaseService.egressSession.findFirst
         .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce({ ...activeSession, status: 'stopped' });
+        .mockResolvedValueOnce({
+          ...activeSession,
+          status: 'stopped',
+          endedAt: new Date(Date.now() - 60 * 1000),
+        });
       mockEgressClient.listEgress.mockResolvedValue([]);
 
       await expect(service.streamReplay(userId, 1)).rejects.toThrow(
@@ -1281,22 +1493,40 @@ describe('LivekitReplayService', () => {
   });
 
   describe('onApplicationBootstrap', () => {
-    it('should run egress reconciliation once at startup', async () => {
+    it('should run egress reconciliation once at startup', () => {
       const reconcileSpy = jest
         .spyOn(service, 'reconcileEgressStatus')
         .mockResolvedValue(undefined);
 
-      await service.onApplicationBootstrap();
+      service.onApplicationBootstrap();
 
       expect(reconcileSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should not throw when startup reconciliation fails', async () => {
+    it('should not await reconciliation, so a hung LiveKit cannot block boot', () => {
+      // Never-resolving promise — if bootstrap awaited it, this test would
+      // time out (and in production app.listen() would never be reached,
+      // failing k8s startup probes)
+      const reconcileSpy = jest
+        .spyOn(service, 'reconcileEgressStatus')
+        .mockReturnValue(new Promise(() => {}));
+
+      const result = service.onApplicationBootstrap();
+
+      expect(result).toBeUndefined();
+      expect(reconcileSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw or leave an unhandled rejection when startup reconciliation fails', async () => {
       jest
         .spyOn(service, 'reconcileEgressStatus')
         .mockRejectedValue(new Error('LiveKit down'));
 
-      await expect(service.onApplicationBootstrap()).resolves.toBeUndefined();
+      expect(() => service.onApplicationBootstrap()).not.toThrow();
+
+      // Flush the microtask queue so the .catch handler runs (an unhandled
+      // rejection here would fail the test run)
+      await new Promise((resolve) => setImmediate(resolve));
     });
   });
 });

--- a/backend/src/livekit/livekit-replay.service.ts
+++ b/backend/src/livekit/livekit-replay.service.ts
@@ -57,6 +57,22 @@ export class LivekitReplayService implements OnApplicationBootstrap {
   private readonly egressOutputPath: string;
   private readonly clipsPath: string;
 
+  /**
+   * Egress IDs the reconcile cron failed to find in LiveKit exactly once.
+   *
+   * A single empty listEgress response can be a transient LiveKit blip; if
+   * we flipped the session to 'stopped' (and emitted REPLAY_BUFFER_STOPPED)
+   * on the first miss we would kill the client's capture button for a
+   * perfectly live screen share. We only act on the second consecutive
+   * miss. Per-pod memory is fine here: a duplicate stop event from another
+   * replica is harmless, entries are removed when the egress reappears or
+   * once we act, and the set is pruned to currently-active sessions.
+   */
+  private readonly egressMissedOnce = new Set<string>();
+
+  /** Skip the heal's dead-path stop event for sessions older than this. */
+  private static readonly STALE_NOTIFY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
   constructor(
     @Inject(EGRESS_CLIENT)
     private readonly egressClient: EgressClient,
@@ -100,16 +116,17 @@ export class LivekitReplayService implements OnApplicationBootstrap {
    *
    * Sessions left 'active' in the database across a backend restart (missed
    * webhooks, crash mid-egress) would otherwise linger until the first cron
-   * tick. Failures are swallowed so a LiveKit outage can never block boot.
+   * tick. Deliberately fire-and-forget: listEgress has no timeout, so
+   * awaiting it here would let an unreachable LiveKit stall app.listen()
+   * and fail k8s startup/readiness probes. Failures are logged, never
+   * propagated.
    */
-  async onApplicationBootstrap(): Promise<void> {
-    try {
-      await this.reconcileEgressStatus();
-    } catch (error) {
-      this.logger.error(
+  onApplicationBootstrap(): void {
+    void this.reconcileEgressStatus().catch((error) => {
+      this.logger.warn(
         `Startup egress reconciliation failed: ${getErrorMessage(error)}`,
       );
-    }
+    });
   }
 
   /**
@@ -338,8 +355,11 @@ export class LivekitReplayService implements OnApplicationBootstrap {
       this.logger.log(`Egress stopped: ${session.egressId}`);
     } catch (error) {
       const errorMsg = getErrorMessage(error);
-      // If egress doesn't exist on LiveKit side, that's fine - just update DB
-      if (errorMsg.includes('egress does not exist')) {
+      // If the egress is already gone/ended on the LiveKit side, that's
+      // fine - just update the DB. Anything else (network timeout, auth)
+      // is a real failure. Without this tolerance a zombie 'active' row
+      // whose egress already ended would block the next screen-share start.
+      if (this.isEgressAlreadyEndedError(errorMsg)) {
         this.logger.warn(
           `Egress ${session.egressId} already stopped on LiveKit side, cleaning up database`,
         );
@@ -392,6 +412,23 @@ export class LivekitReplayService implements OnApplicationBootstrap {
       egressId: session.egressId,
       status: 'stopped',
     };
+  }
+
+  /**
+   * True when a stopEgress failure means the egress is already gone or
+   * ended on the LiveKit side (so stopping is a no-op, not an error).
+   *
+   * LiveKit server (twirp) error strings, matched case-insensitively and
+   * conservatively:
+   * - 'egress does not exist'  — unknown/expired egress ID
+   * - 'egress is not active'   — egress already completed/aborted
+   */
+  private isEgressAlreadyEndedError(message: string): boolean {
+    const normalized = message.toLowerCase();
+    return (
+      normalized.includes('egress does not exist') ||
+      normalized.includes('egress is not active')
+    );
   }
 
   /**
@@ -543,8 +580,18 @@ export class LivekitReplayService implements OnApplicationBootstrap {
       });
 
       if (activeSessions.length === 0) {
+        this.egressMissedOnce.clear();
         this.logger.debug('No active sessions to reconcile');
         return;
+      }
+
+      // Prune strikes for sessions that are no longer active in the DB
+      // (e.g. resolved by a webhook between passes) so the set can't grow.
+      const activeEgressIds = new Set(activeSessions.map((s) => s.egressId));
+      for (const egressId of this.egressMissedOnce) {
+        if (!activeEgressIds.has(egressId)) {
+          this.egressMissedOnce.delete(egressId);
+        }
       }
 
       this.logger.debug(
@@ -565,9 +612,21 @@ export class LivekitReplayService implements OnApplicationBootstrap {
             egressInfoList.length > 0 ? egressInfoList[0] : null;
 
           if (!egressInfo) {
-            // Egress doesn't exist in LiveKit - mark as stopped
+            // Two-strikes rule: a single empty listEgress response can be a
+            // transient blip. Only mark the session stopped (and notify the
+            // client) on the second consecutive miss.
+            if (!this.egressMissedOnce.has(session.egressId)) {
+              this.egressMissedOnce.add(session.egressId);
+              this.logger.warn(
+                `Egress ${session.egressId} not found in LiveKit (first miss) — will mark stopped if still missing on the next reconcile pass`,
+              );
+              continue;
+            }
+
+            // Second consecutive miss — the egress is genuinely gone.
+            this.egressMissedOnce.delete(session.egressId);
             this.logger.warn(
-              `Egress ${session.egressId} not found in LiveKit, marking as stopped`,
+              `Egress ${session.egressId} not found in LiveKit (second consecutive miss), marking as stopped`,
             );
 
             await this.databaseService.egressSession.update({
@@ -593,6 +652,10 @@ export class LivekitReplayService implements OnApplicationBootstrap {
             reconciledCount++;
             continue;
           }
+
+          // Egress reappeared (or was never missing) — clear any pending
+          // first-miss strike so a later isolated blip starts from zero.
+          this.egressMissedOnce.delete(session.egressId);
 
           // Check LiveKit status
           const livekitStatus = egressInfo.status;
@@ -667,7 +730,8 @@ export class LivekitReplayService implements OnApplicationBootstrap {
   }
 
   /**
-   * On-demand heal for capture/stream requests that find no active session.
+   * On-demand heal for capture/stream/session-info requests that find no
+   * active session.
    *
    * The frontend only clears its capture UI on REPLAY_BUFFER_STOPPED/FAILED
    * events, so a session row that was flipped without an event (missed
@@ -723,23 +787,55 @@ export class LivekitReplayService implements OnApplicationBootstrap {
       egressStatus === EgressStatus.EGRESS_STARTING
     ) {
       // The egress is alive but our row says otherwise (e.g. a transient
-      // empty listEgress marked it stopped). Heal it and continue.
-      this.logger.warn(
-        `Healing session ${recentSession.id} for user ${userId}: DB status '${recentSession.status}' but LiveKit egress ${recentSession.egressId} is still running`,
-      );
-      return this.databaseService.egressSession.update({
-        where: { id: recentSession.id },
+      // empty listEgress marked it stopped). Resurrect it with a
+      // compare-and-swap on the status we read: if a webhook or another
+      // replica changed the row in the meantime, we must not blindly stomp
+      // it back to 'active' (heal-vs-webhook zombie-row race).
+      const resurrected = await this.databaseService.egressSession.updateMany({
+        where: { id: recentSession.id, status: recentSession.status },
         data: {
           status: 'active',
           endedAt: null,
           error: null,
         },
       });
+
+      if (resurrected.count === 1) {
+        this.logger.warn(
+          `Healed session ${recentSession.id} for user ${userId}: DB status '${recentSession.status}' but LiveKit egress ${recentSession.egressId} is still running`,
+        );
+        return {
+          ...recentSession,
+          status: 'active',
+          endedAt: null,
+          error: null,
+        };
+      }
+
+      // Lost the CAS — someone else transitioned the row while we were
+      // checking LiveKit. Treat this attempt as not-healed and fall through
+      // to the accurate-ended handling below.
+      this.logger.warn(
+        `Skipped healing session ${recentSession.id} for user ${userId}: row status changed from '${recentSession.status}' during heal`,
+      );
     }
 
-    // Egress is genuinely gone. The client is still showing the capture
-    // button (or it wouldn't have hit this endpoint) — emit the event it
-    // missed so the UI clears, then fail with an accurate message.
+    // Egress is genuinely gone. If the session ended long ago the client's
+    // state is ancient (e.g. a stale tab) — skip the phantom "ended" toast
+    // and fail with the plain not-found message instead.
+    const endedAtMs = (
+      recentSession.endedAt ?? recentSession.startedAt
+    ).getTime();
+    const notifyMaxAgeMs = LivekitReplayService.STALE_NOTIFY_MAX_AGE_MS;
+    if (Date.now() - endedAtMs > notifyMaxAgeMs) {
+      throw new NotFoundException(
+        'No active replay found. Start screen sharing first.',
+      );
+    }
+
+    // The client is still showing the capture button (or it wouldn't have
+    // hit this endpoint) — emit the event it missed so the UI clears, then
+    // fail with an accurate message.
     if (recentSession.status === 'failed') {
       this.websocketService.sendToRoom(
         RoomName.user(recentSession.userId),
@@ -1226,7 +1322,7 @@ export class LivekitReplayService implements OnApplicationBootstrap {
     bufferStartTime?: Date;
     bufferEndTime?: Date;
   }> {
-    const session = await this.databaseService.egressSession.findFirst({
+    let session = await this.databaseService.egressSession.findFirst({
       where: {
         userId,
         status: 'active',
@@ -1234,7 +1330,19 @@ export class LivekitReplayService implements OnApplicationBootstrap {
     });
 
     if (!session) {
-      return { hasActiveSession: false };
+      // Same heal as captureReplay/streamReplay: a row silently flipped to
+      // stopped while the egress is still running would otherwise leave the
+      // capture modal's Custom Trim dead (hasActiveSession: false) even
+      // though plain Capture heals. If the session is genuinely dead,
+      // recoverStaleSession has already emitted the missed stop/fail event.
+      try {
+        session = await this.recoverStaleSession(userId);
+      } catch (error) {
+        if (error instanceof NotFoundException) {
+          return { hasActiveSession: false };
+        }
+        throw error;
+      }
     }
 
     // Resolve relative segment path to full path

--- a/backend/src/livekit/livekit-replay.service.ts
+++ b/backend/src/livekit/livekit-replay.service.ts
@@ -5,6 +5,7 @@ import {
   BadRequestException,
   ForbiddenException,
   NotFoundException,
+  OnApplicationBootstrap,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Cron } from '@nestjs/schedule';
@@ -21,6 +22,7 @@ import {
   TrackType,
 } from 'livekit-server-sdk';
 import { randomUUID } from 'crypto';
+import { EgressSession } from '@prisma/client';
 import { DatabaseService } from '@/database/database.service';
 import { StorageService } from '@/storage/storage.service';
 import { WebsocketService } from '@/websocket/websocket.service';
@@ -49,7 +51,7 @@ import { EGRESS_CLIENT } from './providers/egress-client.provider';
 import { ROOM_SERVICE_CLIENT } from './providers/room-service.provider';
 
 @Injectable()
-export class LivekitReplayService {
+export class LivekitReplayService implements OnApplicationBootstrap {
   private readonly logger = new Logger(LivekitReplayService.name);
   private readonly segmentsPath: string;
   private readonly egressOutputPath: string;
@@ -91,6 +93,23 @@ export class LivekitReplayService {
       `Egress output path (for LiveKit API): ${this.egressOutputPath}`,
     );
     this.logger.log(`Clips path: ${this.clipsPath}`);
+  }
+
+  /**
+   * Reconcile egress state once at startup.
+   *
+   * Sessions left 'active' in the database across a backend restart (missed
+   * webhooks, crash mid-egress) would otherwise linger until the first cron
+   * tick. Failures are swallowed so a LiveKit outage can never block boot.
+   */
+  async onApplicationBootstrap(): Promise<void> {
+    try {
+      await this.reconcileEgressStatus();
+    } catch (error) {
+      this.logger.error(
+        `Startup egress reconciliation failed: ${getErrorMessage(error)}`,
+      );
+    }
   }
 
   /**
@@ -559,6 +578,18 @@ export class LivekitReplayService {
               },
             });
 
+            // Notify the client so the capture button clears — without this
+            // the frontend keeps offering capture and gets 404s (issue #302).
+            this.websocketService.sendToRoom(
+              RoomName.user(session.userId),
+              ServerEvents.REPLAY_BUFFER_STOPPED,
+              {
+                sessionId: session.id,
+                egressId: session.egressId,
+                channelId: session.channelId,
+              },
+            );
+
             reconciledCount++;
             continue;
           }
@@ -636,6 +667,108 @@ export class LivekitReplayService {
   }
 
   /**
+   * On-demand heal for capture/stream requests that find no active session.
+   *
+   * The frontend only clears its capture UI on REPLAY_BUFFER_STOPPED/FAILED
+   * events, so a session row that was flipped without an event (missed
+   * webhook, silent reconcile, orphan cleanup) strands the button and every
+   * capture 404s (issues #302/#188). When the active-session lookup misses,
+   * this checks the user's most recent session against LiveKit:
+   *
+   * - Egress still running → the DB was wrongly marked stopped (e.g. a
+   *   transient empty listEgress response); heal the row back to 'active'
+   *   and let the capture/stream proceed.
+   * - Egress genuinely gone (or LiveKit unreachable) → emit the missing
+   *   REPLAY_BUFFER_STOPPED/FAILED event so the client clears its UI, then
+   *   throw an accurate NotFoundException.
+   *
+   * @param userId - ID of the user requesting capture/stream
+   * @returns The healed, active session
+   * @throws NotFoundException when no session exists or the egress has ended
+   */
+  private async recoverStaleSession(userId: string): Promise<EgressSession> {
+    // Most recent session regardless of status — the row the stranded
+    // capture button is really pointing at.
+    const recentSession = await this.databaseService.egressSession.findFirst({
+      where: { userId },
+      orderBy: { startedAt: 'desc' },
+    });
+
+    if (!recentSession) {
+      throw new NotFoundException(
+        'No active replay found. Start screen sharing first.',
+      );
+    }
+
+    // Ask LiveKit whether the egress is actually still running. Tolerate a
+    // missing client (LiveKit not configured) and listEgress failures — both
+    // fall through to the "recording ended" path below.
+    let egressStatus: EgressStatus | null = null;
+    if (this.egressClient) {
+      try {
+        const egressInfoList = await this.egressClient.listEgress({
+          egressId: recentSession.egressId,
+        });
+        egressStatus =
+          egressInfoList.length > 0 ? egressInfoList[0].status : null;
+      } catch (error) {
+        this.logger.warn(
+          `Could not verify egress ${recentSession.egressId} during heal: ${getErrorMessage(error)}`,
+        );
+      }
+    }
+
+    if (
+      egressStatus === EgressStatus.EGRESS_ACTIVE ||
+      egressStatus === EgressStatus.EGRESS_STARTING
+    ) {
+      // The egress is alive but our row says otherwise (e.g. a transient
+      // empty listEgress marked it stopped). Heal it and continue.
+      this.logger.warn(
+        `Healing session ${recentSession.id} for user ${userId}: DB status '${recentSession.status}' but LiveKit egress ${recentSession.egressId} is still running`,
+      );
+      return this.databaseService.egressSession.update({
+        where: { id: recentSession.id },
+        data: {
+          status: 'active',
+          endedAt: null,
+          error: null,
+        },
+      });
+    }
+
+    // Egress is genuinely gone. The client is still showing the capture
+    // button (or it wouldn't have hit this endpoint) — emit the event it
+    // missed so the UI clears, then fail with an accurate message.
+    if (recentSession.status === 'failed') {
+      this.websocketService.sendToRoom(
+        RoomName.user(recentSession.userId),
+        ServerEvents.REPLAY_BUFFER_FAILED,
+        {
+          sessionId: recentSession.id,
+          egressId: recentSession.egressId,
+          channelId: recentSession.channelId,
+          error: recentSession.error || 'Unknown error',
+        },
+      );
+    } else {
+      this.websocketService.sendToRoom(
+        RoomName.user(recentSession.userId),
+        ServerEvents.REPLAY_BUFFER_STOPPED,
+        {
+          sessionId: recentSession.id,
+          egressId: recentSession.egressId,
+          channelId: recentSession.channelId,
+        },
+      );
+    }
+
+    throw new NotFoundException(
+      'Your replay recording has ended — start screen sharing again to capture.',
+    );
+  }
+
+  /**
    * Stream a replay clip directly to the client (download-only, no persistence)
    * Creates a temporary file that should be deleted by the controller after streaming
    *
@@ -649,18 +782,15 @@ export class LivekitReplayService {
     );
 
     // 1. Find active egress session for this user
-    const session = await this.databaseService.egressSession.findFirst({
-      where: {
-        userId,
-        status: 'active',
-      },
-    });
-
-    if (!session) {
-      throw new NotFoundException(
-        'No active replay found. Start screen sharing first.',
-      );
-    }
+    // If the row was flipped without notifying the client, try to heal it
+    // (or emit the missed stop event and fail accurately).
+    const session =
+      (await this.databaseService.egressSession.findFirst({
+        where: {
+          userId,
+          status: 'active',
+        },
+      })) ?? (await this.recoverStaleSession(userId));
 
     // 2. Calculate how many segments we need
     // Each segment is ~10 seconds, so 6 segments per minute
@@ -727,18 +857,15 @@ export class LivekitReplayService {
     );
 
     // 1. Find active egress session for this user
-    const session = await this.databaseService.egressSession.findFirst({
-      where: {
-        userId,
-        status: 'active',
-      },
-    });
-
-    if (!session) {
-      throw new NotFoundException(
-        'No active replay found. Start screen sharing first.',
-      );
-    }
+    // If the row was flipped without notifying the client, try to heal it
+    // (or emit the missed stop event and fail accurately).
+    const session =
+      (await this.databaseService.egressSession.findFirst({
+        where: {
+          userId,
+          status: 'active',
+        },
+      })) ?? (await this.recoverStaleSession(userId));
 
     // 2. Resolve relative segment path to full path
     const segmentDir = this.storageService.resolveSegmentPath(

--- a/backend/src/livekit/livekit-replay.service.ts
+++ b/backend/src/livekit/livekit-replay.service.ts
@@ -6,6 +6,7 @@ import {
   ForbiddenException,
   NotFoundException,
   OnApplicationBootstrap,
+  ServiceUnavailableException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Cron } from '@nestjs/schedule';
@@ -16,6 +17,7 @@ import {
   SegmentedFileProtocol,
   EncodingOptions,
   EncodingOptionsPreset,
+  EgressInfo,
   EgressStatus,
   VideoCodec,
   AudioCodec,
@@ -72,6 +74,15 @@ export class LivekitReplayService implements OnApplicationBootstrap {
 
   /** Skip the heal's dead-path stop event for sessions older than this. */
   private static readonly STALE_NOTIFY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+  /**
+   * Non-reentrancy guard for reconcileEgressStatus. The bootstrap kick-off
+   * is fire-and-forget and listEgress has no timeout, so a hung LiveKit
+   * call could still be in flight when the cron fires — overlapping passes
+   * would double-count strikes in egressMissedOnce and race their DB
+   * updates. Per-instance state is fine: the cron is per-pod anyway.
+   */
+  private reconcileInProgress = false;
 
   constructor(
     @Inject(EGRESS_CLIENT)
@@ -571,6 +582,14 @@ export class LivekitReplayService implements OnApplicationBootstrap {
    */
   @Cron('*/1 * * * *') // Every 1 minute
   async reconcileEgressStatus() {
+    if (this.reconcileInProgress) {
+      this.logger.warn(
+        'Skipping egress status reconciliation: previous pass still in progress',
+      );
+      return;
+    }
+    this.reconcileInProgress = true;
+
     this.logger.debug('Running egress status reconciliation...');
 
     try {
@@ -726,6 +745,8 @@ export class LivekitReplayService implements OnApplicationBootstrap {
       this.logger.error(
         `Egress status reconciliation job failed: ${getErrorMessage(error)}`,
       );
+    } finally {
+      this.reconcileInProgress = false;
     }
   }
 
@@ -742,13 +763,17 @@ export class LivekitReplayService implements OnApplicationBootstrap {
    * - Egress still running → the DB was wrongly marked stopped (e.g. a
    *   transient empty listEgress response); heal the row back to 'active'
    *   and let the capture/stream proceed.
-   * - Egress genuinely gone (or LiveKit unreachable) → emit the missing
-   *   REPLAY_BUFFER_STOPPED/FAILED event so the client clears its UI, then
-   *   throw an accurate NotFoundException.
+   * - Egress genuinely gone → emit the missing REPLAY_BUFFER_STOPPED/FAILED
+   *   event so the client clears its UI, then throw an accurate
+   *   NotFoundException.
+   * - LiveKit unreachable (listEgress throws) → we cannot tell whether the
+   *   recording is alive, so throw a retryable ServiceUnavailableException
+   *   without emitting any event or touching the DB row.
    *
    * @param userId - ID of the user requesting capture/stream
    * @returns The healed, active session
    * @throws NotFoundException when no session exists or the egress has ended
+   * @throws ServiceUnavailableException when LiveKit cannot be queried
    */
   private async recoverStaleSession(userId: string): Promise<EgressSession> {
     // Most recent session regardless of status — the row the stranded
@@ -764,22 +789,32 @@ export class LivekitReplayService implements OnApplicationBootstrap {
       );
     }
 
-    // Ask LiveKit whether the egress is actually still running. Tolerate a
-    // missing client (LiveKit not configured) and listEgress failures — both
-    // fall through to the "recording ended" path below.
+    // Ask LiveKit whether the egress is actually still running.
+    //
+    // - Missing client → LiveKit is not configured on this instance at all
+    //   (no URL/key/secret), so no egress can possibly be running; falling
+    //   through to the "recording ended" path below is accurate.
+    // - listEgress throws → LiveKit is configured but unreachable. The
+    //   recording may well still be alive, so telling the client it ended
+    //   (and emitting REPLAY_BUFFER_STOPPED) would wrongly kill a live
+    //   capture UI. Surface a retryable 503 instead — no event, no DB write.
     let egressStatus: EgressStatus | null = null;
     if (this.egressClient) {
+      let egressInfoList: EgressInfo[];
       try {
-        const egressInfoList = await this.egressClient.listEgress({
+        egressInfoList = await this.egressClient.listEgress({
           egressId: recentSession.egressId,
         });
-        egressStatus =
-          egressInfoList.length > 0 ? egressInfoList[0].status : null;
       } catch (error) {
         this.logger.warn(
           `Could not verify egress ${recentSession.egressId} during heal: ${getErrorMessage(error)}`,
         );
+        throw new ServiceUnavailableException(
+          'Could not check your replay status — please try again.',
+        );
       }
+      egressStatus =
+        egressInfoList.length > 0 ? egressInfoList[0].status : null;
     }
 
     if (
@@ -1335,6 +1370,12 @@ export class LivekitReplayService implements OnApplicationBootstrap {
       // capture modal's Custom Trim dead (hasActiveSession: false) even
       // though plain Capture heals. If the session is genuinely dead,
       // recoverStaleSession has already emitted the missed stop/fail event.
+      //
+      // A ServiceUnavailableException (LiveKit unreachable during the heal)
+      // deliberately propagates as a 503 rather than being mapped to
+      // hasActiveSession: false — the frontend gates Custom Trim on that
+      // flag, and a transient LiveKit blip must not report a live buffer as
+      // gone. A 503 lets the client keep its current state and retry.
       try {
         session = await this.recoverStaleSession(userId);
       } catch (error) {

--- a/backend/src/livekit/replay-segments.service.spec.ts
+++ b/backend/src/livekit/replay-segments.service.spec.ts
@@ -3,6 +3,8 @@ import { ConfigService } from '@nestjs/config';
 import { ReplaySegmentsService } from './replay-segments.service';
 import { DatabaseService } from '@/database/database.service';
 import { StorageService } from '@/storage/storage.service';
+import { WebsocketService } from '@/websocket/websocket.service';
+import { ServerEvents } from '@semaphore-chat/shared';
 import { EGRESS_CLIENT } from './providers/egress-client.provider';
 
 // Mock fluent-ffmpeg
@@ -36,6 +38,8 @@ describe('ReplaySegmentsService', () => {
 
   let storageService: any;
 
+  let websocketService: any;
+
   const mockEgressClient = {
     startTrackCompositeEgress: jest.fn(),
     stopEgress: jest.fn(),
@@ -62,6 +66,7 @@ describe('ReplaySegmentsService', () => {
     service = unit;
     databaseService = unitRef.get(DatabaseService);
     storageService = unitRef.get(StorageService);
+    websocketService = unitRef.get(WebsocketService);
 
     // Set up default return values for StorageService
     storageService.resolveSegmentPath.mockImplementation(
@@ -370,6 +375,8 @@ describe('ReplaySegmentsService', () => {
       const oldSession = {
         id: 'old-session',
         egressId: 'old-egress',
+        userId: 'user-123',
+        channelId: 'channel-1',
         segmentPath: 'old-session', // Relative path
         status: 'active',
         startedAt: new Date(Date.now() - 4 * 60 * 60 * 1000), // 4 hours ago
@@ -402,10 +409,46 @@ describe('ReplaySegmentsService', () => {
       );
     });
 
+    it('should notify the user when force-stopping an orphaned session', async () => {
+      const oldSession = {
+        id: 'old-session',
+        egressId: 'old-egress',
+        userId: 'user-123',
+        channelId: 'channel-1',
+        segmentPath: 'old-session',
+        status: 'active',
+        startedAt: new Date(Date.now() - 4 * 60 * 60 * 1000),
+      };
+
+      databaseService.egressSession.findMany.mockResolvedValue([oldSession]);
+      mockEgressClient.stopEgress.mockResolvedValue(undefined);
+      databaseService.egressSession.update.mockResolvedValue({
+        ...oldSession,
+        status: 'stopped',
+      });
+      storageService.segmentDirectoryExists.mockResolvedValue(false);
+
+      await service.cleanupOrphanedSessions();
+
+      // Without this event the frontend keeps showing the capture button
+      // and every capture attempt 404s (issue #302)
+      expect(websocketService.sendToRoom).toHaveBeenCalledWith(
+        'user:user-123',
+        ServerEvents.REPLAY_BUFFER_STOPPED,
+        expect.objectContaining({
+          sessionId: 'old-session',
+          egressId: 'old-egress',
+          channelId: 'channel-1',
+        }),
+      );
+    });
+
     it('should handle egress already stopped', async () => {
       const oldSession = {
         id: 'old-session',
         egressId: 'old-egress',
+        userId: 'user-123',
+        channelId: 'channel-1',
         segmentPath: 'old-session', // Relative path
         status: 'active',
         startedAt: new Date(Date.now() - 4 * 60 * 60 * 1000),

--- a/backend/src/livekit/replay-segments.service.ts
+++ b/backend/src/livekit/replay-segments.service.ts
@@ -10,6 +10,9 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import { EgressClient } from 'livekit-server-sdk';
 import { DatabaseService } from '@/database/database.service';
 import { StorageService } from '@/storage/storage.service';
+import { WebsocketService } from '@/websocket/websocket.service';
+import { ServerEvents } from '@semaphore-chat/shared';
+import { RoomName } from '@/common/utils/room-name.util';
 import { getErrorMessage } from '@/common/utils/error.utils';
 import * as ffmpegModule from 'fluent-ffmpeg';
 import { promises as fs } from 'fs';
@@ -37,6 +40,7 @@ export class ReplaySegmentsService {
     private readonly configService: ConfigService,
     private readonly databaseService: DatabaseService,
     private readonly storageService: StorageService,
+    private readonly websocketService: WebsocketService,
   ) {
     this.cleanupAgeMinutes = parseInt(
       this.configService.get<string>('REPLAY_SEGMENT_CLEANUP_AGE_MINUTES') ||
@@ -176,6 +180,18 @@ export class ReplaySegmentsService {
               endedAt: new Date(),
             },
           });
+
+          // Notify the client so the capture button clears — force-stopping
+          // without an event strands the UI and every capture 404s (#302).
+          this.websocketService.sendToRoom(
+            RoomName.user(session.userId),
+            ServerEvents.REPLAY_BUFFER_STOPPED,
+            {
+              sessionId: session.id,
+              egressId: session.egressId,
+              channelId: session.channelId,
+            },
+          );
 
           // Delete segment directory
           // session.segmentPath is now relative, resolve it using StorageService


### PR DESCRIPTION
Fixes #302. Fixes #188 (confirmed duplicate).

## Root cause

Every "capture 404" reduces to one state: **the DB `egressSession` row is no longer `active`, but the client still shows the capture button** (it only clears on `REPLAY_BUFFER_STOPPED/FAILED` socket events). Several paths flipped the row silently:

- the reconcile cron's "egress not found in `listEgress`" branch updated the row but — unlike its sibling status-mismatch branch — **never emitted** (primary cause; also the healing path for missed webhooks, so those stranded too)
- `cleanupOrphanedSessions` (>3h force-stop) never emitted
- a transient empty `listEgress` response could wrongly kill a **live** session, making capture 404 while egress kept recording
- no startup reconciliation after backend restarts

## Fix

1. **Every state flip now notifies**: the silent reconcile branch and orphan cleanup emit `REPLAY_BUFFER_STOPPED` (same payload/room targeting as existing emitters).
2. **Capture-time heal** (`recoverStaleSession`, shared by capture/stream/session-info): when the active-row lookup misses, check the user's most recent session against LiveKit. Egress actually `ACTIVE`/`STARTING` → heal the row (compare-and-swap) and proceed with the capture. Genuinely dead → emit the missed stop event (so the button finally clears) and return an accurate message: "Your replay recording has ended — start screen sharing again to capture."
3. **Startup reconciliation**: one fire-and-forget reconcile on boot (deliberately not awaited — a blackholed LiveKit must not stall `app.listen()`/k8s probes).

## Hardening (from two adversarial reviews — no must-fixes, all recommendations taken)

- **Two-strikes rule**: the reconcile cron only kills a session after **two consecutive** `listEgress` misses, so a single transient miss can no longer destroy a live share's capture button.
- **Compare-and-swap heal** (`updateMany` guarded on prior status): closes a heal-vs-webhook race that could mint a zombie `active` row, and guards multi-replica double-heal.
- `stopReplayBuffer` tolerates "egress is not active" (in addition to "does not exist") so a zombie row can't block starting the next share.
- Heal extended to `getSessionInfo` so the modal's Custom Trim tab recovers the same way plain Capture does.
- 24h age bound: ancient sessions get the plain "No active replay found" message with no phantom "Replay ended" toast.
- Load-bearing exclusion locked by test: `EGRESS_ENDING` does **not** heal — a deliberately stopped session cannot be resurrected (review verified LiveKit persists ENDING before the stop RPC returns).

## Verification

111 tests green across the four affected suites (26 new: heal paths, two-strikes, CAS, call-order, non-blocking bootstrap, age bound, ENDING exclusion). Reviews verified payload shapes against `shared` contracts, room targeting against the frontend subscription, no frontend/e2e string-matching on the changed message, and no module-wiring cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
