### PR TITLE
feat(voice): shared speaking context + Discord-style speaking rings on video tiles

### DIFF
--- a/frontend/src/__tests__/components/AuthGate.test.tsx
+++ b/frontend/src/__tests__/components/AuthGate.test.tsx
@@ -42,6 +42,9 @@ vi.mock('../../contexts/VoiceContext', () => ({
 vi.mock('../../contexts/RoomContext', () => ({
   RoomProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
+vi.mock('../../contexts/SpeakingContext', () => ({
+  SpeakingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
 vi.mock('../../contexts/ThreadPanelContext', () => ({
   ThreadPanelProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));

--- a/frontend/src/__tests__/components/SpeakingProvider.test.tsx
+++ b/frontend/src/__tests__/components/SpeakingProvider.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SpeakingProvider } from '../../contexts/SpeakingContext';
+import { useSpeaking } from '../../hooks/useSpeaking';
+
+// The provider is a thin wrapper that mounts useSpeakingDetection exactly once
+// and shares its result via context — mock the underlying hook.
+const mockUseSpeakingDetection = vi.fn();
+vi.mock('../../hooks/useSpeakingDetection', () => ({
+  useSpeakingDetection: () => mockUseSpeakingDetection(),
+}));
+
+function Probe({ userId, testId }: { userId: string; testId: string }) {
+  const { isSpeaking } = useSpeaking();
+  return <div data-testid={testId}>{isSpeaking(userId) ? 'speaking' : 'silent'}</div>;
+}
+
+describe('SpeakingProvider', () => {
+  beforeEach(() => {
+    mockUseSpeakingDetection.mockReset();
+    mockUseSpeakingDetection.mockReturnValue({
+      speakingMap: new Map<string, boolean>([
+        ['alice', true],
+        ['bob', false],
+      ]),
+      isSpeaking: (id: string) => id === 'alice',
+    });
+  });
+
+  it('renders its children', () => {
+    render(
+      <SpeakingProvider>
+        <div data-testid="child">hello</div>
+      </SpeakingProvider>,
+    );
+
+    expect(screen.getByTestId('child')).toHaveTextContent('hello');
+  });
+
+  it('exposes isSpeaking backed by the detection hook speakingMap', () => {
+    render(
+      <SpeakingProvider>
+        <Probe userId="alice" testId="alice" />
+        <Probe userId="bob" testId="bob" />
+        <Probe userId="unknown" testId="unknown" />
+      </SpeakingProvider>,
+    );
+
+    expect(screen.getByTestId('alice')).toHaveTextContent('speaking');
+    expect(screen.getByTestId('bob')).toHaveTextContent('silent');
+    expect(screen.getByTestId('unknown')).toHaveTextContent('silent');
+  });
+
+  it('mounts the detection hook exactly once regardless of consumer count', () => {
+    render(
+      <SpeakingProvider>
+        <Probe userId="alice" testId="a" />
+        <Probe userId="alice" testId="b" />
+        <Probe userId="alice" testId="c" />
+      </SpeakingProvider>,
+    );
+
+    expect(mockUseSpeakingDetection).toHaveBeenCalledTimes(1);
+  });
+
+  it('degrades to "nobody speaking" when used outside a provider', () => {
+    render(<Probe userId="alice" testId="orphan" />);
+
+    expect(screen.getByTestId('orphan')).toHaveTextContent('silent');
+    expect(mockUseSpeakingDetection).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/components/VideoTile.test.tsx
+++ b/frontend/src/__tests__/components/VideoTile.test.tsx
@@ -3,6 +3,7 @@ import { screen, fireEvent } from '@testing-library/react';
 import { renderWithProviders } from '../test-utils';
 import VideoTile from '../../components/Voice/VideoTile';
 import type { VideoTileProps } from '../../components/Voice/VideoTile';
+import { generateTheme } from '../../theme/themeConfig';
 
 vi.mock('../../components/Common/UserAvatar', () => ({
   default: ({ size }: { size?: string }) => (
@@ -12,6 +13,12 @@ vi.mock('../../components/Common/UserAvatar', () => ({
 
 vi.mock('../../components/Voice/ScreenShareVolumeControl', () => ({
   default: () => <div data-testid="volume-control" />,
+}));
+
+// Controllable speaking state from the shared SpeakingContext
+const mockIsSpeaking = vi.fn(() => false);
+vi.mock('../../hooks/useSpeaking', () => ({
+  useSpeaking: () => ({ speakingMap: new Map(), isSpeaking: mockIsSpeaking }),
 }));
 
 // jsdom doesn't implement HTMLMediaElement.play() — stub it to return a resolved promise
@@ -49,6 +56,9 @@ function renderTile(overrides: Partial<VideoTileProps> = {}) {
 describe('VideoTile', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks does not undo mockReturnValue — reset explicitly
+    mockIsSpeaking.mockReset();
+    mockIsSpeaking.mockReturnValue(false);
   });
 
   it('renders no pin or fullscreen buttons (#320)', () => {
@@ -152,5 +162,64 @@ describe('VideoTile', () => {
     renderTile({});
 
     expect(screen.getByTestId('avatar')).toHaveAttribute('data-size', 'fluid');
+  });
+
+  describe('speaking ring (Discord-style)', () => {
+    const positive = generateTheme('dark', 'blue', 'balanced').palette.semantic.status.positive;
+
+    function getCard(text: string | RegExp) {
+      return screen.getByText(text).closest('[class*="MuiCard"]')!;
+    }
+
+    it('shows a green ring on a camera tile when the participant is speaking', () => {
+      mockIsSpeaking.mockReturnValue(true);
+      renderTile({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        videoTrack: createMockTrackPublication('camera') as any,
+      });
+
+      expect(mockIsSpeaking).toHaveBeenCalledWith('RemoteUser');
+      expect(getCard(/RemoteUser/)).toHaveStyle({ borderColor: positive });
+    });
+
+    it('shows a green ring on an avatar-only tile when speaking', () => {
+      mockIsSpeaking.mockReturnValue(true);
+      renderTile({});
+
+      expect(getCard(/RemoteUser/)).toHaveStyle({ borderColor: positive });
+    });
+
+    it('shows a green ring on a camera placeholder tile when speaking', () => {
+      mockIsSpeaking.mockReturnValue(true);
+      renderTile({ isPlaceholder: true, placeholderType: 'camera', onWatch: vi.fn() });
+
+      expect(getCard('Click to watch')).toHaveStyle({ borderColor: positive });
+    });
+
+    it('never shows a ring on a screen-share tile, even when speaking', () => {
+      mockIsSpeaking.mockReturnValue(true);
+      renderTile({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        screenTrack: createMockTrackPublication('screen_share') as any,
+      });
+
+      expect(getCard(/RemoteUser/)).not.toHaveStyle({ borderColor: positive });
+    });
+
+    it('never shows a ring on a screen placeholder tile, even when speaking', () => {
+      mockIsSpeaking.mockReturnValue(true);
+      renderTile({ isPlaceholder: true, placeholderType: 'screen', onWatch: vi.fn() });
+
+      expect(getCard('Click to watch')).not.toHaveStyle({ borderColor: positive });
+    });
+
+    it('shows no ring on a camera tile when not speaking', () => {
+      renderTile({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        videoTrack: createMockTrackPublication('camera') as any,
+      });
+
+      expect(getCard(/RemoteUser/)).not.toHaveStyle({ borderColor: positive });
+    });
   });
 });

--- a/frontend/src/__tests__/components/VoiceBottomBar.test.tsx
+++ b/frontend/src/__tests__/components/VoiceBottomBar.test.tsx
@@ -115,8 +115,8 @@ vi.mock('../../hooks/usePushToTalk', () => ({
   })),
 }));
 
-vi.mock('../../hooks/useSpeakingDetection', () => ({
-  useSpeakingDetection: vi.fn(() => ({
+vi.mock('../../hooks/useSpeaking', () => ({
+  useSpeaking: vi.fn(() => ({
     speakingMap: new Map(),
     isSpeaking: () => false,
   })),

--- a/frontend/src/__tests__/components/VoiceChannelUserList.test.tsx
+++ b/frontend/src/__tests__/components/VoiceChannelUserList.test.tsx
@@ -120,8 +120,8 @@ vi.mock('../../hooks/useVoiceConnection', () => ({
   })),
 }));
 
-vi.mock('../../hooks/useSpeakingDetection', () => ({
-  useSpeakingDetection: vi.fn(() => ({
+vi.mock('../../hooks/useSpeaking', () => ({
+  useSpeaking: vi.fn(() => ({
     speakingMap: new Map(),
     isSpeaking: () => false,
   })),

--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -17,6 +17,7 @@ import { NotificationProvider } from "../contexts/NotificationContext";
 import { VoiceProvider } from "../contexts/VoiceContext";
 import { ConnectionStatusBanner } from "./ConnectionStatusBanner";
 import { RoomProvider } from "../contexts/RoomContext";
+import { SpeakingProvider } from "../contexts/SpeakingContext";
 import { ThreadPanelProvider } from "../contexts/ThreadPanelContext";
 import { UserProfileProvider } from "../contexts/UserProfileContext";
 import { logger } from "../utils/logger";
@@ -157,11 +158,13 @@ export function AuthGate() {
           <VoiceProvider>
             <ConnectionStatusBanner />
             <RoomProvider>
-              <ThreadPanelProvider>
-                <UserProfileProvider>
-                  <Outlet />
-                </UserProfileProvider>
-              </ThreadPanelProvider>
+              <SpeakingProvider>
+                <ThreadPanelProvider>
+                  <UserProfileProvider>
+                    <Outlet />
+                  </UserProfileProvider>
+                </ThreadPanelProvider>
+              </SpeakingProvider>
             </RoomProvider>
           </VoiceProvider>
         </NotificationProvider>

--- a/frontend/src/components/Voice/VideoTile.tsx
+++ b/frontend/src/components/Voice/VideoTile.tsx
@@ -25,6 +25,7 @@ import type {
 } from 'livekit-client';
 import UserAvatar from '../Common/UserAvatar';
 import ScreenShareVolumeControl from './ScreenShareVolumeControl';
+import { useSpeaking } from '../../hooks/useSpeaking';
 
 export interface VideoTileProps {
   participant: RemoteParticipant | LocalParticipant;
@@ -59,6 +60,17 @@ const VideoTile: React.FC<VideoTileProps> = ({
   const videoRef = useRef<HTMLVideoElement>(null);
   const screenRef = useRef<HTMLVideoElement>(null);
   const [isHovered, setIsHovered] = useState(false);
+  const { isSpeaking } = useSpeaking();
+
+  // Discord-style speaking ring: constant transparent border swapped to the
+  // positive status color while speaking, so the ring never shifts layout.
+  // Applied to camera and avatar/placeholder tiles only — never screen shares.
+  const speakingRingSx = (active: boolean) => ({
+    border: active
+      ? `2px solid ${theme.palette.semantic.status.positive}`
+      : '2px solid transparent',
+    transition: 'border-color 0.2s ease',
+  });
   // Handle video track
   useEffect(() => {
     const videoElement = videoRef.current;
@@ -110,7 +122,8 @@ const VideoTile: React.FC<VideoTileProps> = ({
           backgroundColor: 'grey.900',
           overflow: 'hidden',
           cursor: 'pointer',
-          transition: 'background-color 0.15s',
+          ...speakingRingSx(placeholderType !== 'screen' && isSpeaking(participant.identity)),
+          transition: 'background-color 0.15s, border-color 0.2s ease',
           '&:hover': {
             backgroundColor: alpha(theme.palette.primary.main, 0.08),
           },
@@ -170,6 +183,7 @@ const VideoTile: React.FC<VideoTileProps> = ({
         backgroundColor: 'grey.900',
         overflow: 'hidden',
         cursor: onToggleFullscreen ? 'pointer' : 'default',
+        ...speakingRingSx(!hasScreen && isSpeaking(participant.identity)),
       }}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}

--- a/frontend/src/components/Voice/VoiceBottomBar.tsx
+++ b/frontend/src/components/Voice/VoiceBottomBar.tsx
@@ -45,7 +45,7 @@ import { CaptureReplayModal } from "./CaptureReplayModal";
 import { useResponsive } from "../../hooks/useResponsive";
 import { logger } from "../../utils/logger";
 import { LAYOUT_CONSTANTS } from "../../utils/breakpoints";
-import { useSpeakingDetection } from "../../hooks/useSpeakingDetection";
+import { useSpeaking } from "../../hooks/useSpeaking";
 import { useVoicePresenceHeartbeat } from "../../hooks/useVoicePresenceHeartbeat";
 import { useBackgroundVoiceKeepAlive } from "../../hooks/useBackgroundVoiceKeepAlive";
 import { useServerMuteEffect } from "../../hooks/useServerMuteEffect";
@@ -61,7 +61,7 @@ export const VoiceBottomBar: React.FC = () => {
   const { isCameraEnabled, isMicrophoneEnabled } = useLocalMediaState();
   const { isMobile } = useResponsive();
   const { user: currentUser } = useCurrentUser();
-  const { isSpeaking } = useSpeakingDetection();
+  const { isSpeaking } = useSpeaking();
   const [settingsAnchor, setSettingsAnchor] = useState<null | HTMLElement>(
     null
   );

--- a/frontend/src/components/Voice/VoiceChannelUserList.tsx
+++ b/frontend/src/components/Voice/VoiceChannelUserList.tsx
@@ -19,7 +19,7 @@ import { RoomEvent } from "livekit-client";
 import { getUserInfo } from "../../features/users/userApiHelpers";
 import { useServerEvent } from "../../socket-hub/useServerEvent";
 import { ServerEvents } from "@semaphore-chat/shared";
-import { useSpeakingDetection } from "../../hooks/useSpeakingDetection";
+import { useSpeaking } from "../../hooks/useSpeaking";
 import { useVoice } from "../../contexts/VoiceContext";
 import { useTrackSubscriptionActions } from "../../hooks/useTrackSubscription";
 import CompactUserItem from "./components/CompactUserItem";
@@ -39,7 +39,7 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
 }) => {
   const theme = useTheme();
   const { state: voiceState, actions: voiceActions } = useVoiceConnection();
-  const { isSpeaking } = useSpeakingDetection();
+  const { isSpeaking } = useSpeaking();
   const { watchingCameras, watchingScreenShares } = useVoice();
   const trackActions = useTrackSubscriptionActions();
   const [livekitParticipants, setLivekitParticipants] = useState<VoicePresenceUserDto[]>([]);

--- a/frontend/src/components/Voice/VoiceDebugPanel.tsx
+++ b/frontend/src/components/Voice/VoiceDebugPanel.tsx
@@ -9,7 +9,7 @@ import {
   RoomEvent,
 } from 'livekit-client';
 import { useRoom } from '../../hooks/useRoom';
-import { useSpeakingDetection } from '../../hooks/useSpeakingDetection';
+import { useSpeaking } from '../../hooks/useSpeaking';
 import { useTrackSubscriptionActions } from '../../hooks/useTrackSubscription';
 import {
   useVoiceEventLog,
@@ -42,7 +42,7 @@ import { logger } from '../../utils/logger';
 export const VoiceDebugPanel: React.FC = () => {
   const theme = useTheme();
   const { room } = useRoom();
-  const { speakingMap, isSpeaking } = useSpeakingDetection();
+  const { speakingMap, isSpeaking } = useSpeaking();
   const trackActions = useTrackSubscriptionActions();
   const log = useVoiceEventLog();
   const { data: currentUser } = useQuery(userControllerGetProfileOptions());

--- a/frontend/src/contexts/SpeakingContext.tsx
+++ b/frontend/src/contexts/SpeakingContext.tsx
@@ -1,0 +1,34 @@
+import React, { useMemo } from "react";
+import { SpeakingContext, SpeakingContextType } from "./SpeakingContextDef";
+import { useSpeakingDetection } from "../hooks/useSpeakingDetection";
+
+interface SpeakingProviderProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Mounts `useSpeakingDetection` exactly ONCE for the whole app and shares the
+ * result via context.
+ *
+ * Why: the hook owns an AudioContext + worker timer + the voice-activity gate
+ * for the local mic track. Mounting it in multiple components (bottom bar,
+ * user list, debug panel, ...) created N concurrent AudioContexts and N gates
+ * racing on the same published track. Consumers should use `useSpeaking()`
+ * instead of calling `useSpeakingDetection` directly.
+ *
+ * Must be rendered inside RoomProvider (the hook reads the LiveKit room via
+ * useRoom) and above every consumer of speaking state.
+ */
+export const SpeakingProvider: React.FC<SpeakingProviderProps> = ({ children }) => {
+  const { speakingMap } = useSpeakingDetection();
+
+  const value = useMemo<SpeakingContextType>(
+    () => ({
+      speakingMap,
+      isSpeaking: (userId: string) => speakingMap.get(userId) || false,
+    }),
+    [speakingMap],
+  );
+
+  return <SpeakingContext.Provider value={value}>{children}</SpeakingContext.Provider>;
+};

--- a/frontend/src/contexts/SpeakingContextDef.ts
+++ b/frontend/src/contexts/SpeakingContextDef.ts
@@ -1,0 +1,20 @@
+import { createContext } from "react";
+
+export interface SpeakingContextType {
+  /** Map of participant identity (userId) -> currently speaking */
+  speakingMap: Map<string, boolean>;
+  /** Check if a specific user (by identity/userId) is currently speaking */
+  isSpeaking: (userId: string) => boolean;
+}
+
+/**
+ * Safe default so consumers rendered outside a SpeakingProvider (isolated
+ * component tests, storybook-style usage) degrade to "nobody is speaking"
+ * instead of throwing. In the app the provider is always mounted (AuthGate).
+ */
+export const defaultSpeakingContext: SpeakingContextType = {
+  speakingMap: new Map(),
+  isSpeaking: () => false,
+};
+
+export const SpeakingContext = createContext<SpeakingContextType>(defaultSpeakingContext);

--- a/frontend/src/hooks/useSpeaking.ts
+++ b/frontend/src/hooks/useSpeaking.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+import { SpeakingContext } from "../contexts/SpeakingContextDef";
+
+/**
+ * Read shared speaking-detection state from SpeakingProvider.
+ *
+ * Returns `{ speakingMap, isSpeaking }` backed by the single app-wide
+ * `useSpeakingDetection` instance. Outside a provider it degrades to
+ * "nobody is speaking" (see defaultSpeakingContext).
+ */
+export const useSpeaking = () => useContext(SpeakingContext);


### PR DESCRIPTION
Builds on #376 (now merged to main) — completes the Discord-parity voice indicator work.

## What

1. **Single speaking-detection owner.** `useSpeakingDetection` was mounted 3× concurrently (bottom bar, user list, debug panel) = three AudioContexts, three worker timers, and three VA gates racing on the same published track. A new `SpeakingProvider` (in `AuthGate`, inside `RoomProvider`) mounts it once; consumers use `useSpeaking()`. Bonus fix found in review: previously, if all three consumers unmounted mid-call (possible on mobile routes), the gate stopped and the mic went **hot ungated** — the provider now keeps the gate alive for the life of the room.
2. **Discord-style speaking rings on video tiles.** Green 2px ring (same styling as the member-list ring) on camera, avatar, and camera-placeholder tiles while the participant is actually speaking — excluded from screen-share tiles (Discord parity). Transparent-border swap → zero layout shift.

## Review

One adversarial review, approve, no findings. The #1 concern — render cascades of the PR #344 class — was explicitly refuted: tile attach effects have stable deps (no `attach`/`detach` churn), `AudioRenderer` doesn't consume the context, the provider's children are referentially stable so only consumers re-render, and the source hook dedupes so context updates happen only on genuine speaking transitions (~few/sec), the same frequency the old per-component instances re-rendered at.

Accepted residuals (documented, non-blocking): every visible tile re-renders on any speaking flip (cheap, side-effect-free; `React.memo` + boolean prop is the natural follow-up if tile counts grow); a muted-screen-share tile that falls back to its avatar rendering can show a ring (cosmetically defensible).

## Tests

137/137 across 8 files: 4 new provider tests (single-mount, outside-provider no-op degradation), 6 new ring tests (positive style assertions prove the negative screen-tile assertions aren't vacuous), consumer test mocks re-targeted with identical shapes and zero assertion changes. Type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

