### PR TITLE
fix(livekit): DM presence membership checks, token TTL cap, direct authz tests, ghost-listener guarantee

### DIFF
--- a/backend/src/livekit/dto/create-token.dto.ts
+++ b/backend/src/livekit/dto/create-token.dto.ts
@@ -4,6 +4,7 @@ import {
   IsOptional,
   IsNumber,
   Min,
+  Max,
 } from 'class-validator';
 
 export class CreateTokenDto {
@@ -19,8 +20,15 @@ export class CreateTokenDto {
   @IsString()
   name?: string;
 
+  /**
+   * Token TTL in seconds. Capped at 3600 (1 hour, the default) so that a
+   * user removed from a channel/DM keeps lingering room access only until
+   * their current token expires — an unbounded client-supplied TTL would
+   * turn that window into effectively permanent access.
+   */
   @IsOptional()
   @IsNumber()
   @Min(1)
+  @Max(3600)
   ttl?: number;
 }

--- a/backend/src/voice-presence/voice-presence.controller.ts
+++ b/backend/src/voice-presence/voice-presence.controller.ts
@@ -142,11 +142,17 @@ export class VoicePresenceController {
 }
 
 @Controller('dm-groups/:dmGroupId/voice-presence')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, RbacGuard)
 export class DmVoicePresenceController {
   constructor(private readonly voicePresenceService: VoicePresenceService) {}
 
   @Get()
+  @RequiredActions(RbacActions.READ_MESSAGE)
+  @RbacResource({
+    type: RbacResourceType.DM_GROUP,
+    idKey: 'dmGroupId',
+    source: ResourceIdSource.PARAM,
+  })
   @ApiOkResponse({ type: DmVoicePresenceResponseDto })
   async getDmPresence(
     @Param('dmGroupId') dmGroupId: string,
@@ -160,6 +166,12 @@ export class DmVoicePresenceController {
   }
 
   @Post('refresh')
+  @RequiredActions(RbacActions.READ_MESSAGE)
+  @RbacResource({
+    type: RbacResourceType.DM_GROUP,
+    idKey: 'dmGroupId',
+    source: ResourceIdSource.PARAM,
+  })
   @ApiCreatedResponse({ type: RefreshDmPresenceResponseDto })
   async refreshDmPresence(
     @Param('dmGroupId') dmGroupId: string,

--- a/backend/src/voice-presence/voice-presence.service.spec.ts
+++ b/backend/src/voice-presence/voice-presence.service.spec.ts
@@ -38,6 +38,7 @@ describe('VoicePresenceService', () => {
     mockDatabaseService = {
       directMessageGroup: {
         findFirst: jest.fn(),
+        findUnique: jest.fn(),
       },
       directMessageGroupMember: {
         findFirst: jest.fn(),
@@ -755,6 +756,184 @@ describe('VoicePresenceService', () => {
 
       expect(mockRedis.pipeline).not.toHaveBeenCalled();
       expect(websocketService.sendToRoom).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * Ghost-listener guarantee: the LiveKit webhook path is the authoritative
+   * source of presence. A participant_joined for a user who NEVER called the
+   * app's join/refresh endpoints must still create a presence entry in the
+   * exact store the REST read path (getChannelPresence/getDmPresence)
+   * returns — so nobody can lurk in a room invisibly. participant_left must
+   * remove that entry again.
+   */
+  describe('webhook presence (ghost-listener guarantee)', () => {
+    const mockUser = {
+      id: 'ghost-user',
+      username: 'ghostuser',
+      displayName: 'Ghost User',
+      avatarUrl: null,
+    };
+
+    it('participant_joined for a channel room creates a presence entry visible via getChannelPresence', async () => {
+      const channelId = 'channel-ghost';
+
+      // Room is not a DM group -> treated as a channel
+      mockDatabaseService.directMessageGroup.findUnique.mockResolvedValue(null);
+      // User has no existing presence entry (never called join/refresh)
+      mockRedis.get.mockResolvedValue(null);
+      mockDatabaseService.user.findUnique.mockResolvedValue(mockUser);
+
+      await service.handleWebhookParticipantJoined(channelId, mockUser.id);
+
+      // Entry written under the exact keys the REST read path consumes
+      expect(mockPipeline.set).toHaveBeenCalledWith(
+        `voice_presence:user:${channelId}:${mockUser.id}`,
+        expect.any(String),
+        'EX',
+        90,
+      );
+      expect(mockPipeline.sadd).toHaveBeenCalledWith(
+        `voice_presence:channel:${channelId}:members`,
+        mockUser.id,
+      );
+      expect(websocketService.sendToRoom).toHaveBeenCalledWith(
+        channelId,
+        ServerEvents.VOICE_CHANNEL_USER_JOINED,
+        expect.objectContaining({
+          channelId,
+          user: expect.objectContaining({ id: mockUser.id }),
+        }),
+      );
+
+      // Round-trip: feed the written payload back through the read path
+      const writtenJson = mockPipeline.set.mock.calls[0][1] as string;
+      mockRedis.smembers.mockResolvedValue([mockUser.id]);
+      mockRedis.mget.mockResolvedValue([writtenJson]);
+
+      const presence = await service.getChannelPresence(channelId);
+
+      expect(presence).toHaveLength(1);
+      expect(presence[0]).toMatchObject({
+        id: mockUser.id,
+        username: mockUser.username,
+      });
+    });
+
+    it('participant_left for a channel room removes the presence entry', async () => {
+      const channelId = 'channel-ghost';
+      const userData = {
+        id: mockUser.id,
+        username: mockUser.username,
+        joinedAt: new Date().toISOString(),
+        isDeafened: false,
+        isServerMuted: false,
+      };
+
+      mockDatabaseService.directMessageGroup.findUnique.mockResolvedValue(null);
+      mockRedis.get.mockResolvedValue(JSON.stringify(userData));
+
+      await service.handleWebhookParticipantLeft(channelId, mockUser.id);
+
+      expect(mockPipeline.del).toHaveBeenCalledWith(
+        `voice_presence:user:${channelId}:${mockUser.id}`,
+      );
+      expect(mockPipeline.srem).toHaveBeenCalledWith(
+        `voice_presence:channel:${channelId}:members`,
+        mockUser.id,
+      );
+      expect(websocketService.sendToRoom).toHaveBeenCalledWith(
+        channelId,
+        ServerEvents.VOICE_CHANNEL_USER_LEFT,
+        expect.objectContaining({ channelId, userId: mockUser.id }),
+      );
+
+      // Read path now sees an empty channel
+      mockRedis.smembers.mockResolvedValue([]);
+      const presence = await service.getChannelPresence(channelId);
+      expect(presence).toEqual([]);
+    });
+
+    it('participant_joined for a DM room creates a presence entry visible via getDmPresence', async () => {
+      const dmGroupId = 'dm-ghost';
+
+      // Room IS a DM group
+      mockDatabaseService.directMessageGroup.findUnique.mockResolvedValue({
+        id: dmGroupId,
+      });
+      // User has no existing presence entry
+      mockRedis.get.mockResolvedValue(null);
+      mockDatabaseService.user.findUnique.mockResolvedValue(mockUser);
+      // No one else in the call yet (isFirstUser check)
+      mockRedis.smembers.mockResolvedValue([]);
+
+      await service.handleWebhookParticipantJoined(dmGroupId, mockUser.id);
+
+      expect(mockPipeline.set).toHaveBeenCalledWith(
+        `dm_voice_presence:user:${dmGroupId}:${mockUser.id}`,
+        expect.any(String),
+        'EX',
+        90,
+      );
+      expect(mockPipeline.sadd).toHaveBeenCalledWith(
+        `dm_voice_presence:dm:${dmGroupId}:members`,
+        mockUser.id,
+      );
+      // First user joining announces the call start
+      expect(websocketService.sendToRoom).toHaveBeenCalledWith(
+        `dm:${dmGroupId}`,
+        ServerEvents.DM_VOICE_CALL_STARTED,
+        expect.objectContaining({ dmGroupId, startedBy: mockUser.id }),
+      );
+
+      // Round-trip: feed the written payload back through the read path
+      const writtenJson = mockPipeline.set.mock.calls[0][1] as string;
+      mockRedis.smembers.mockResolvedValue([mockUser.id]);
+      mockRedis.mget.mockResolvedValue([writtenJson]);
+
+      const presence = await service.getDmPresence(dmGroupId);
+
+      expect(presence).toHaveLength(1);
+      expect(presence[0]).toMatchObject({
+        id: mockUser.id,
+        username: mockUser.username,
+      });
+    });
+
+    it('participant_left for a DM room removes the presence entry', async () => {
+      const dmGroupId = 'dm-ghost';
+      const userData = {
+        id: mockUser.id,
+        username: mockUser.username,
+        joinedAt: new Date().toISOString(),
+        isDeafened: false,
+        isServerMuted: false,
+      };
+
+      mockDatabaseService.directMessageGroup.findUnique.mockResolvedValue({
+        id: dmGroupId,
+      });
+      mockRedis.get.mockResolvedValue(JSON.stringify(userData));
+
+      await service.handleWebhookParticipantLeft(dmGroupId, mockUser.id);
+
+      expect(mockPipeline.del).toHaveBeenCalledWith(
+        `dm_voice_presence:user:${dmGroupId}:${mockUser.id}`,
+      );
+      expect(mockPipeline.srem).toHaveBeenCalledWith(
+        `dm_voice_presence:dm:${dmGroupId}:members`,
+        mockUser.id,
+      );
+      expect(websocketService.sendToRoom).toHaveBeenCalledWith(
+        `dm:${dmGroupId}`,
+        ServerEvents.DM_VOICE_USER_LEFT,
+        expect.objectContaining({ dmGroupId, userId: mockUser.id }),
+      );
+
+      // Read path now sees an empty call
+      mockRedis.smembers.mockResolvedValue([]);
+      const presence = await service.getDmPresence(dmGroupId);
+      expect(presence).toEqual([]);
     });
   });
 

--- a/backend/test/livekit-authz.e2e-spec.ts
+++ b/backend/test/livekit-authz.e2e-spec.ts
@@ -1,0 +1,266 @@
+import * as request from 'supertest';
+import {
+  createE2eApp,
+  resetDatabase,
+  seedInstanceInvite,
+  registerUser,
+  loginUser,
+  E2eApp,
+  RegisteredUser,
+} from './helpers/e2e-app';
+
+/**
+ * Direct authorization coverage for the LiveKit token + DM voice-presence
+ * endpoints through the REAL guard chain (JwtAuthGuard -> RbacGuard ->
+ * PermissionsService -> Postgres). Previously this gating was only proven
+ * transitively via permissions.service.spec.ts.
+ *
+ * Covers:
+ *  - POST /api/livekit/token      (CHANNEL resource, JOIN_CHANNEL)
+ *  - POST /api/livekit/dm-token   (DM_GROUP resource, READ_MESSAGE)
+ *  - GET  /api/dm-groups/:id/voice-presence          (DM membership required)
+ *  - POST /api/dm-groups/:id/voice-presence/refresh  (DM membership required)
+ *  - CreateTokenDto ttl cap (@Max(3600)) end-to-end via ValidationPipe
+ *
+ * The instance owner bypasses RBAC (rbac.guard.ts short-circuit), so the
+ * owner account is used only for setup; the actual assertions use regular
+ * InstanceRole.USER accounts.
+ */
+
+// LiveKit credentials are not part of the CI e2e environment (no LiveKit
+// server is needed — AccessToken generation is pure JWT signing). Provide
+// dev-style defaults without overriding a configured environment.
+process.env.LIVEKIT_API_KEY ??= 'devkey';
+process.env.LIVEKIT_API_SECRET ??=
+  'e2e-secret-that-is-at-least-32-characters-long';
+process.env.LIVEKIT_URL ??= 'ws://localhost:7880';
+
+describe('LiveKit token & DM voice-presence authorization (e2e)', () => {
+  let app: E2eApp;
+
+  const owner = {
+    username: 'e2e-lk-owner',
+    password: 'Password123!',
+    email: 'e2e-lk-owner@test.local',
+  };
+  const memberA = {
+    username: 'e2e-lk-member-a',
+    password: 'Password123!',
+    email: 'e2e-lk-member-a@test.local',
+  };
+  const memberB = {
+    username: 'e2e-lk-member-b',
+    password: 'Password123!',
+    email: 'e2e-lk-member-b@test.local',
+  };
+  const outsider = {
+    username: 'e2e-lk-outsider',
+    password: 'Password123!',
+    email: 'e2e-lk-outsider@test.local',
+  };
+
+  let ownerToken: string;
+  let memberAToken: string;
+  let memberBToken: string;
+  let outsiderToken: string;
+
+  let memberAUser: RegisteredUser;
+  let memberBUser: RegisteredUser;
+
+  let communityId: string;
+  let voiceChannelId: string;
+  let dmGroupId: string;
+
+  beforeAll(async () => {
+    app = await createE2eApp();
+    await resetDatabase(app);
+    await seedInstanceInvite(app);
+
+    await registerUser(app, owner); // first -> InstanceRole.OWNER
+    memberAUser = await registerUser(app, memberA);
+    memberBUser = await registerUser(app, memberB);
+    await registerUser(app, outsider);
+
+    ownerToken = (await loginUser(app, owner.username, owner.password))
+      .accessToken;
+    memberAToken = (await loginUser(app, memberA.username, memberA.password))
+      .accessToken;
+    memberBToken = (await loginUser(app, memberB.username, memberB.password))
+      .accessToken;
+    outsiderToken = (await loginUser(app, outsider.username, outsider.password))
+      .accessToken;
+
+    // Owner creates a community with a voice channel and adds memberA
+    // (memberA receives the default "Member" role, which grants JOIN_CHANNEL).
+    const community = await request(app.getHttpServer())
+      .post('/api/community')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ name: 'E2E LiveKit Community' })
+      .expect(201);
+    communityId = (community.body as { id: string }).id;
+
+    await request(app.getHttpServer())
+      .post('/api/membership')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ userId: memberAUser.id, communityId })
+      .expect(201);
+
+    const channel = await request(app.getHttpServer())
+      .post('/api/channels')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({
+        name: 'e2e-lk-voice',
+        communityId,
+        type: 'VOICE',
+        isPrivate: false,
+      })
+      .expect(201);
+    voiceChannelId = (channel.body as { id: string }).id;
+
+    // memberA opens a DM group with memberB; the outsider is not a member.
+    const dmGroup = await request(app.getHttpServer())
+      .post('/api/direct-messages')
+      .set('Authorization', `Bearer ${memberAToken}`)
+      .send({ userIds: [memberBUser.id] })
+      .expect(201);
+    dmGroupId = (dmGroup.body as { id: string }).id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('POST /api/livekit/token (channel rooms)', () => {
+    it('rejects unauthenticated requests', async () => {
+      await request(app.getHttpServer())
+        .post('/api/livekit/token')
+        .send({ identity: 'ignored', roomId: voiceChannelId })
+        .expect(401);
+    });
+
+    it('denies a user who is not a member of the channel community', async () => {
+      await request(app.getHttpServer())
+        .post('/api/livekit/token')
+        .set('Authorization', `Bearer ${outsiderToken}`)
+        .send({ identity: 'ignored', roomId: voiceChannelId })
+        .expect(403);
+    });
+
+    it('issues a token to a community member with JOIN_CHANNEL', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/livekit/token')
+        .set('Authorization', `Bearer ${memberAToken}`)
+        .send({ identity: 'ignored', roomId: voiceChannelId })
+        .expect(201);
+
+      const body = res.body as {
+        token: string;
+        identity: string;
+        roomId: string;
+      };
+      expect(typeof body.token).toBe('string');
+      expect(body.roomId).toBe(voiceChannelId);
+      // Identity must be the authenticated user, not the client-sent value
+      expect(body.identity).toBe(memberAUser.id);
+    });
+  });
+
+  describe('CreateTokenDto ttl cap', () => {
+    it('rejects a ttl above 3600 seconds (lingering-access bound)', async () => {
+      await request(app.getHttpServer())
+        .post('/api/livekit/token')
+        .set('Authorization', `Bearer ${memberAToken}`)
+        .send({ identity: 'ignored', roomId: voiceChannelId, ttl: 999999 })
+        .expect(400);
+    });
+
+    it('accepts a ttl at the 3600 second cap', async () => {
+      await request(app.getHttpServer())
+        .post('/api/livekit/token')
+        .set('Authorization', `Bearer ${memberAToken}`)
+        .send({ identity: 'ignored', roomId: voiceChannelId, ttl: 3600 })
+        .expect(201);
+    });
+
+    it('applies the same cap to dm-token', async () => {
+      await request(app.getHttpServer())
+        .post('/api/livekit/dm-token')
+        .set('Authorization', `Bearer ${memberAToken}`)
+        .send({ identity: 'ignored', roomId: dmGroupId, ttl: 999999 })
+        .expect(400);
+    });
+  });
+
+  describe('POST /api/livekit/dm-token (DM rooms)', () => {
+    it('rejects unauthenticated requests', async () => {
+      await request(app.getHttpServer())
+        .post('/api/livekit/dm-token')
+        .send({ identity: 'ignored', roomId: dmGroupId })
+        .expect(401);
+    });
+
+    it('denies a user who is not a member of the DM group', async () => {
+      await request(app.getHttpServer())
+        .post('/api/livekit/dm-token')
+        .set('Authorization', `Bearer ${outsiderToken}`)
+        .send({ identity: 'ignored', roomId: dmGroupId })
+        .expect(403);
+    });
+
+    it('issues a token to a DM group member', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/livekit/dm-token')
+        .set('Authorization', `Bearer ${memberBToken}`)
+        .send({ identity: 'ignored', roomId: dmGroupId })
+        .expect(201);
+
+      const body = res.body as { token: string; identity: string };
+      expect(typeof body.token).toBe('string');
+      expect(body.identity).toBe(memberBUser.id);
+    });
+  });
+
+  describe('DM voice-presence endpoints (membership required)', () => {
+    it('rejects unauthenticated presence reads', async () => {
+      await request(app.getHttpServer())
+        .get(`/api/dm-groups/${dmGroupId}/voice-presence`)
+        .expect(401);
+    });
+
+    it('denies presence reads to a non-member of the DM group', async () => {
+      await request(app.getHttpServer())
+        .get(`/api/dm-groups/${dmGroupId}/voice-presence`)
+        .set('Authorization', `Bearer ${outsiderToken}`)
+        .expect(403);
+    });
+
+    it('denies presence refresh to a non-member of the DM group', async () => {
+      await request(app.getHttpServer())
+        .post(`/api/dm-groups/${dmGroupId}/voice-presence/refresh`)
+        .set('Authorization', `Bearer ${outsiderToken}`)
+        .expect(403);
+    });
+
+    it('allows a DM member to refresh and read presence', async () => {
+      await request(app.getHttpServer())
+        .post(`/api/dm-groups/${dmGroupId}/voice-presence/refresh`)
+        .set('Authorization', `Bearer ${memberAToken}`)
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .get(`/api/dm-groups/${dmGroupId}/voice-presence`)
+        .set('Authorization', `Bearer ${memberAToken}`)
+        .expect(200);
+
+      const body = res.body as {
+        dmGroupId: string;
+        users: Array<{ id: string }>;
+        count: number;
+      };
+      expect(body.dmGroupId).toBe(dmGroupId);
+      // The refresh above re-registered memberA (expired-key path), so the
+      // member appears in the presence list the REST read path returns.
+      expect(body.users.map((u) => u.id)).toContain(memberAUser.id);
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to a security audit of the LiveKit token/presence surface, prompted by the question "can someone subscribe to a room they shouldn't, or listen without being displayed?"

## Audit verdict (no code needed)

- Both token endpoints were **already properly gated**: private channels require an explicit channel-membership row (voice and text identical), DM tokens require DM-group membership, the grant is pinned to the single authorized room, and client-supplied identity is overwritten server-side. The historical "heard a stream I never joined" symptom traces to the pre-#367 autoSubscribe misconfiguration, not the token path.
- **Ghost listeners are already surfaced**: `participant_joined`/`participant_left` webhooks create/remove full presence entries for users who never touched the app's join endpoint — a scripted bare-LiveKit client shows up in the sidebar like anyone else. Webhook signatures are verified (`WebhookReceiver`, hard-403 when unconfigured). ⚠️ Deployment note: this guarantee requires LiveKit's `webhook.urls` to point at the backend — worth confirming on the k8s instance.

## What this PR changes

1. **DM presence endpoints gained membership checks** — `GET/POST /dm-groups/:id/voice-presence*` previously required only a valid JWT, exposing who's in any DM voice call to any authenticated user. Now RBAC-gated on DM-group membership like the dm-token endpoint.
2. **Token TTL capped at 3600s** (`@Max` on the shared DTO) — bounds lingering media access after removal from a channel/community to the token expiry.
3. **Direct authorization e2e tests** (new `backend/test/livekit-authz.e2e-spec.ts`, 13 tests): 401/403/success matrices for channel token, DM token, and DM presence; identity-forcing assertion; TTL-cap 400s. Previously the token gating was proven only transitively through PermissionsService unit tests.
4. **Ghost-listener guarantee pinned** — 4 new round-trip tests: webhook join of a user unknown to app presence → appears in the presence read path; webhook leave → removed (channel + DM).

## Verification

89/89 unit tests (5 suites), 13/13 e2e against a dedicated test DB, eslint clean. No API shape changes (no SDK regen needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
