### PR TITLE
fix(voice): tile audio indicator uses mic track; pin non-watcher screen-share-audio silence in e2e

### DIFF
--- a/frontend/e2e/fixtures/voice.fixture.ts
+++ b/frontend/e2e/fixtures/voice.fixture.ts
@@ -87,6 +87,7 @@ export interface SubscriptionStateSample {
   mic: { published: boolean; subscribed: boolean; muted: boolean };
   camera: { published: boolean; subscribed: boolean };
   screenShare: { published: boolean; subscribed: boolean };
+  screenShareAudio: { published: boolean; subscribed: boolean };
 }
 
 /**
@@ -114,7 +115,7 @@ declare global {
     __lkEnableMic: () => Promise<string>;
     __lkSetMic: (enabled: boolean) => Promise<void>;
     __lkSetCamera: (enabled: boolean) => Promise<void>;
-    __lkSetScreenShare: (enabled: boolean) => Promise<void>;
+    __lkSetScreenShare: (enabled: boolean, opts?: { audio?: boolean }) => Promise<void>;
     __lkSwitchMic: (deviceId: string) => Promise<void>;
     __lkWatchCamera: (identity: string) => void;
     __lkUnwatchCamera: (identity: string) => void;
@@ -384,10 +385,21 @@ export async function switchMic(p: Participant, deviceId: string): Promise<void>
  * Start local screen share. Returns true if a ScreenShare publication actually
  * appears (headless desktop capture is not always available); callers may skip
  * with a logged reason when false rather than fail on an env limitation.
+ *
+ * `opts.audio` additionally requests tab/system audio (a ScreenShareAudio
+ * publication) via the app's real capture constraints. Best-effort: headless
+ * Chromium's fake display capture usually has no capturable audio, so callers
+ * must treat the audio publication as optional (check getSubscriptionState).
  */
-export async function startScreenShare(p: Participant): Promise<boolean> {
+export async function startScreenShare(
+  p: Participant,
+  opts: { audio?: boolean } = {},
+): Promise<boolean> {
   try {
-    await p.page.evaluate(() => window.__lkSetScreenShare(true));
+    await p.page.evaluate(
+      (o) => window.__lkSetScreenShare(true, o),
+      { audio: opts.audio ?? false },
+    );
   } catch {
     return false;
   }
@@ -451,6 +463,34 @@ export async function getSubscriptionState(
   remoteIdentity: string,
 ): Promise<SubscriptionStateSample | undefined> {
   return from.page.evaluate((id) => window.__lkGetSubscriptionState(id), remoteIdentity);
+}
+
+/**
+ * Count ScreenShareAudio publications across ALL remote participants in `p`'s
+ * room, split into published vs subscribed. The "non-watcher silence" invariant
+ * is `subscribed === 0` for a participant who never opened any share — it must
+ * hold room-wide, not just against one sharer, so this inspects the raw
+ * `window.__lkRoom` state rather than a single getSubscriptionState() snapshot.
+ */
+export async function countScreenShareAudio(
+  p: Participant,
+): Promise<{ published: number; subscribed: number }> {
+  return p.page.evaluate(() => {
+    const counts = { published: 0, subscribed: 0 };
+    const room = window.__lkRoom;
+    if (!room) return counts;
+    for (const [, participant] of room.remoteParticipants) {
+      const pubs = (participant as {
+        audioTrackPublications: Map<string, { source?: string; isSubscribed?: boolean }>;
+      }).audioTrackPublications;
+      for (const [, pub] of pubs) {
+        if (pub.source !== 'screen_share_audio') continue;
+        counts.published += 1;
+        if (pub.isSubscribed) counts.subscribed += 1;
+      }
+    }
+    return counts;
+  });
 }
 
 /** Assert video IS flowing from `remote` to `from` (subscribed + bytes grow). */

--- a/frontend/e2e/voice/screenshare-subscription.spec.ts
+++ b/frontend/e2e/voice/screenshare-subscription.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Screen-share / video subscription behaviour, end to end against real LiveKit.
+ * Screen-share / video subscription behavior, end to end against real LiveKit.
  *
  * What this proves (all green):
  *   - a participant can publish screen share and a peer RECEIVES the video
@@ -7,7 +7,7 @@
  *   - stopping the share removes the publication for peers;
  *   - the "no bytes to a NON-watcher" guarantee — a bystander who never opens
  *     the tile receives zero video bytes (the autoSubscribe:false bandwidth
- *     optimisation behind [[project_voice_stability_investigation]]);
+ *     optimization);
  *   - the "non-watcher silence" guarantee — ScreenShareAudio obeys the same
  *     opt-in gating: a bystander has ZERO subscribed ScreenShareAudio tracks
  *     until they click watch.
@@ -151,29 +151,38 @@ test.describe('Screen share over real LiveKit', () => {
           'track(s) despite never watching — opt-in audio gating leaked',
       ).toBe(0);
 
-      // The watcher clicks watch → the video subscription appears...
-      await watchScreenShareOf(watcher, sharer.identity);
+      // The BYSTANDER performs the watch transition — not the shared `watcher`,
+      // whose watchingScreenShares entry from earlier serial tests persists and
+      // would auto-resubscribe the moment the share republishes, making
+      // "subscribe only after watch" a false positive. The bystander was just
+      // proven unsubscribed, so this asserts a genuine zero → subscribed
+      // transition. (Last test in the serial suite, so polluting the
+      // bystander's watch state afterwards is harmless.)
+      await watchScreenShareOf(bystander, sharer.identity);
       await expect
         .poll(
           async () =>
-            (await getSubscriptionState(watcher, sharer.identity))?.screenShare.subscribed ?? false,
-          { timeout: 15_000, message: 'watcher never subscribed to the screenshare video' },
+            (await getSubscriptionState(bystander, sharer.identity))?.screenShare.subscribed ??
+            false,
+          { timeout: 15_000, message: 'bystander never subscribed after clicking watch' },
         )
         .toBe(true);
 
       // ...and — when the environment could actually publish share audio — the
       // ScreenShareAudio subscription appears with it (watchScreenShare targets
-      // ScreenShare + ScreenShareAudio), while the bystander stays at zero.
+      // ScreenShare + ScreenShareAudio).
       if (audioCounts.published > 0) {
         await expect
           .poll(
             async () =>
-              (await getSubscriptionState(watcher, sharer.identity))?.screenShareAudio
+              (await getSubscriptionState(bystander, sharer.identity))?.screenShareAudio
                 .subscribed ?? false,
-            { timeout: 15_000, message: 'watcher never subscribed to the ScreenShareAudio track' },
+            {
+              timeout: 15_000,
+              message: 'bystander never subscribed to the ScreenShareAudio track after watching',
+            },
           )
           .toBe(true);
-        expect((await countScreenShareAudio(bystander)).subscribed).toBe(0);
       }
 
       await stopScreenShare(sharer);

--- a/frontend/e2e/voice/screenshare-subscription.spec.ts
+++ b/frontend/e2e/voice/screenshare-subscription.spec.ts
@@ -7,7 +7,10 @@
  *   - stopping the share removes the publication for peers;
  *   - the "no bytes to a NON-watcher" guarantee — a bystander who never opens
  *     the tile receives zero video bytes (the autoSubscribe:false bandwidth
- *     optimisation behind [[project_voice_stability_investigation]]).
+ *     optimisation behind [[project_voice_stability_investigation]]);
+ *   - the "non-watcher silence" guarantee — ScreenShareAudio obeys the same
+ *     opt-in gating: a bystander has ZERO subscribed ScreenShareAudio tracks
+ *     until they click watch.
  *
  * HISTORY (#365): before that fix, `autoSubscribe: false` was passed to the
  * Room *constructor*, where livekit-client silently ignores it — so every
@@ -30,6 +33,7 @@ import {
   waitForVideoFlow,
   expectNoVideoToNonWatcher,
   getSubscriptionState,
+  countScreenShareAudio,
   ADMIN_USER,
   TEST_USER,
   TEST_USER_2,
@@ -103,6 +107,75 @@ test.describe('Screen share over real LiveKit', () => {
         )
         .toBe(true);
       await expectNoVideoToNonWatcher(bystander, sharer, 'screenshare');
+      await stopScreenShare(sharer);
+    },
+  );
+
+  // The audio twin of the guarantee above: ScreenShareAudio must obey the same
+  // opt-in gating as the video, or a share-with-audio would play sound to every
+  // peer in the room whether or not they opened the tile.
+  test(
+    'non-watcher silence: zero subscribed ScreenShareAudio tracks until watch is clicked',
+    async () => {
+      // Request the share WITH audio, using the app's real capture constraints.
+      //
+      // LIMITATION: headless Chromium's fake display capture exposes no
+      // capturable tab/system audio, so the ScreenShareAudio publication is
+      // best-effort in this harness. When it cannot be published, the
+      // room-wide "zero subscribed ScreenShareAudio" sweep below still pins
+      // the policy at the strongest observable level (publication-level:
+      // nothing is subscribed), and the subscribe-on-watch branch is asserted
+      // only when the publication actually exists (headed / audio-capable
+      // environments).
+      const started = await startScreenShare(sharer, { audio: true });
+      test.skip(!started, 'Headless screen capture unavailable.');
+
+      await expect
+        .poll(
+          async () =>
+            (await getSubscriptionState(bystander, sharer.identity))?.screenShare.published ?? false,
+          { timeout: 15_000, message: 'screenshare publication never propagated' },
+        )
+        .toBe(true);
+
+      // Let a would-be ScreenShareAudio publication propagate alongside the
+      // video before sampling (they arrive as separate publications).
+      await bystander.page.waitForTimeout(2_000);
+      const audioCounts = await countScreenShareAudio(bystander);
+
+      // The invariant under test: the bystander never clicked watch, so their
+      // room must contain ZERO subscribed ScreenShareAudio tracks.
+      expect(
+        audioCounts.subscribed,
+        `bystander is subscribed to ${audioCounts.subscribed} ScreenShareAudio ` +
+          'track(s) despite never watching — opt-in audio gating leaked',
+      ).toBe(0);
+
+      // The watcher clicks watch → the video subscription appears...
+      await watchScreenShareOf(watcher, sharer.identity);
+      await expect
+        .poll(
+          async () =>
+            (await getSubscriptionState(watcher, sharer.identity))?.screenShare.subscribed ?? false,
+          { timeout: 15_000, message: 'watcher never subscribed to the screenshare video' },
+        )
+        .toBe(true);
+
+      // ...and — when the environment could actually publish share audio — the
+      // ScreenShareAudio subscription appears with it (watchScreenShare targets
+      // ScreenShare + ScreenShareAudio), while the bystander stays at zero.
+      if (audioCounts.published > 0) {
+        await expect
+          .poll(
+            async () =>
+              (await getSubscriptionState(watcher, sharer.identity))?.screenShareAudio
+                .subscribed ?? false,
+            { timeout: 15_000, message: 'watcher never subscribed to the ScreenShareAudio track' },
+          )
+          .toBe(true);
+        expect((await countScreenShareAudio(bystander)).subscribed).toBe(0);
+      }
+
       await stopScreenShare(sharer);
     },
   );

--- a/frontend/src/__tests__/components/VideoTiles.test.tsx
+++ b/frontend/src/__tests__/components/VideoTiles.test.tsx
@@ -410,6 +410,65 @@ describe('VideoTiles', () => {
     expect(screen.getByText('UserB')).toBeInTheDocument();
   });
 
+  describe('tile audio indicator picks the microphone publication', () => {
+    it('uses the mic track even when a screen-share-audio publication comes first', () => {
+      mockWatchingCameras = new Set(['SharerWithAudio']);
+      // Screen-share audio publication listed BEFORE the mic: the old
+      // `audioTrackPublications[0]` selection would pick it and show a live
+      // mic indicator, even though the actual microphone is muted.
+      const screenAudio = createMockTrackPublication('screen_share_audio', false);
+      const mutedMic = createMockTrackPublication('microphone', true);
+      remoteParticipants.set(
+        'remote-1',
+        createMockParticipant(
+          'SharerWithAudio',
+          [createMockTrackPublication('camera')],
+          [screenAudio, mutedMic],
+        ),
+      );
+
+      renderWithProviders(<VideoTiles />);
+
+      // The muted mic must drive the indicator — not the unmuted share audio.
+      expect(screen.getByTestId('MicOffIcon')).toBeInTheDocument();
+      expect(screen.queryByTestId('MicIcon')).not.toBeInTheDocument();
+    });
+
+    it('shows mic-off for a participant publishing only screen-share audio (no mic)', () => {
+      mockWatchingCameras = new Set(['MiclessSharer']);
+      remoteParticipants.set(
+        'remote-1',
+        createMockParticipant(
+          'MiclessSharer',
+          [createMockTrackPublication('camera')],
+          [createMockTrackPublication('screen_share_audio', false)],
+        ),
+      );
+
+      renderWithProviders(<VideoTiles />);
+
+      expect(screen.getByTestId('MicOffIcon')).toBeInTheDocument();
+      expect(screen.queryByTestId('MicIcon')).not.toBeInTheDocument();
+    });
+
+    it('shows a live mic indicator when the mic publication is unmuted', () => {
+      mockWatchingCameras = new Set(['TalkingSharer']);
+      remoteParticipants.set(
+        'remote-1',
+        createMockParticipant(
+          'TalkingSharer',
+          [createMockTrackPublication('camera')],
+          [createMockTrackPublication('screen_share_audio', true), createMockTrackPublication('microphone', false)],
+        ),
+      );
+
+      renderWithProviders(<VideoTiles />);
+
+      expect(screen.getByTestId('MicIcon')).toBeInTheDocument();
+      expect(screen.queryByTestId('MicOffIcon')).not.toBeInTheDocument();
+    });
+  });
+
   describe('layout modes and pinning', () => {
     beforeEach(() => {
       mockWatchingCameras = new Set(['UserA', 'UserB']);

--- a/frontend/src/components/Voice/VideoTiles.tsx
+++ b/frontend/src/components/Voice/VideoTiles.tsx
@@ -26,12 +26,11 @@ const GRID_CONSTANTS = {
   HEADER_HEIGHT: 48,
   MAX_SIDEBAR_TILES: 6,
 } as const;
-import {
-  Track,
+import { Track, RoomEvent } from 'livekit-client';
+import type {
   TrackPublication,
   RemoteParticipant,
   LocalParticipant,
-  RoomEvent
 } from 'livekit-client';
 
 enum VideoLayoutMode {

--- a/frontend/src/components/Voice/VideoTiles.tsx
+++ b/frontend/src/components/Voice/VideoTiles.tsx
@@ -27,6 +27,7 @@ const GRID_CONSTANTS = {
   MAX_SIDEBAR_TILES: 6,
 } as const;
 import {
+  Track,
   TrackPublication,
   RemoteParticipant,
   LocalParticipant,
@@ -120,7 +121,11 @@ export const VideoTiles: React.FC<VideoTilesProps> = () => {
     // Add local participant tiles (hidden ones become placeholders)
     if (isCameraEnabled || isScreenShareEnabled) {
       const videoTracks = Array.from(localParticipant.videoTrackPublications.values());
-      const audioTrack = Array.from(localParticipant.audioTrackPublications.values())[0];
+      // Pick the microphone publication explicitly — a screen share with audio also
+      // publishes a ScreenShareAudio track, which must not drive the mic indicator.
+      const audioTrack = Array.from(localParticipant.audioTrackPublications.values()).find(
+        (track: TrackPublication) => track.source === Track.Source.Microphone
+      );
 
       const videoTrack = videoTracks.find((track: TrackPublication) =>
         track.source !== 'screen_share' && track.source !== 'screen_share_audio'
@@ -176,7 +181,11 @@ export const VideoTiles: React.FC<VideoTilesProps> = () => {
     // unwatched tracks get placeholder tiles so users can opt in from the grid.
     participants.forEach(participant => {
       const videoTracks = Array.from(participant.videoTrackPublications.values());
-      const audioTrack = Array.from(participant.audioTrackPublications.values())[0];
+      // Pick the microphone publication explicitly — a screen share with audio also
+      // publishes a ScreenShareAudio track, which must not drive the mic indicator.
+      const audioTrack = Array.from(participant.audioTrackPublications.values()).find(
+        (track: TrackPublication) => track.source === Track.Source.Microphone
+      );
 
       const videoTrack = videoTracks.find((track: TrackPublication) =>
         track.source !== 'screen_share' && track.source !== 'screen_share_audio'

--- a/frontend/src/features/voice/VoiceTestHooks.tsx
+++ b/frontend/src/features/voice/VoiceTestHooks.tsx
@@ -57,7 +57,7 @@ export const VoiceTestHooks: FC = () => {
       // When asked, request tab/system audio with the SAME constraints the app's
       // toggleScreenShare path uses (getScreenShareAudioConfig), so E2E exercises
       // the real ScreenShareAudio publication shape. Default (no opts) matches
-      // the historical behaviour: video-only capture.
+      // the historical behavior: video-only capture.
       await room?.localParticipant.setScreenShareEnabled(
         enabled,
         opts?.audio ? { audio: getScreenShareAudioConfig(true) } : undefined,

--- a/frontend/src/features/voice/VoiceTestHooks.tsx
+++ b/frontend/src/features/voice/VoiceTestHooks.tsx
@@ -9,6 +9,7 @@ import {
   getSubscriptionState,
 } from './voiceDiagnostics';
 import { isVoiceTestHookEnabled, type VoiceTestHookWindow } from './voiceTestHooks.types';
+import { getScreenShareAudioConfig } from '../../utils/screenShareResolution';
 import type { VoiceEventEntry } from '../../hooks/useVoiceEventLogDef';
 
 /**
@@ -52,8 +53,15 @@ export const VoiceTestHooks: FC = () => {
     w.__lkSetCamera = async (enabled: boolean) => {
       await room?.localParticipant.setCameraEnabled(enabled);
     };
-    w.__lkSetScreenShare = async (enabled: boolean) => {
-      await room?.localParticipant.setScreenShareEnabled(enabled);
+    w.__lkSetScreenShare = async (enabled: boolean, opts?: { audio?: boolean }) => {
+      // When asked, request tab/system audio with the SAME constraints the app's
+      // toggleScreenShare path uses (getScreenShareAudioConfig), so E2E exercises
+      // the real ScreenShareAudio publication shape. Default (no opts) matches
+      // the historical behaviour: video-only capture.
+      await room?.localParticipant.setScreenShareEnabled(
+        enabled,
+        opts?.audio ? { audio: getScreenShareAudioConfig(true) } : undefined,
+      );
     };
     // Switch the active mic capture device LIVE (the PR #351 behaviour): same
     // Room API the Settings panel's onDeviceChange ultimately calls

--- a/frontend/src/features/voice/voiceDiagnostics.ts
+++ b/frontend/src/features/voice/voiceDiagnostics.ts
@@ -50,6 +50,7 @@ export interface SubscriptionState {
   mic: { published: boolean; subscribed: boolean; muted: boolean };
   camera: { published: boolean; subscribed: boolean };
   screenShare: { published: boolean; subscribed: boolean };
+  screenShareAudio: { published: boolean; subscribed: boolean };
 }
 
 /**
@@ -342,6 +343,7 @@ export function getSubscriptionState(
     mic: { published: false, subscribed: false, muted: false },
     camera: { published: false, subscribed: false },
     screenShare: { published: false, subscribed: false },
+    screenShareAudio: { published: false, subscribed: false },
   };
   for (const [, pub] of remote.trackPublications) {
     if (pub.source === Track.Source.Microphone) {
@@ -350,6 +352,8 @@ export function getSubscriptionState(
       state.camera = { published: true, subscribed: pub.isSubscribed };
     } else if (pub.source === Track.Source.ScreenShare) {
       state.screenShare = { published: true, subscribed: pub.isSubscribed };
+    } else if (pub.source === Track.Source.ScreenShareAudio) {
+      state.screenShareAudio = { published: true, subscribed: pub.isSubscribed };
     }
   }
   return state;

--- a/frontend/src/features/voice/voiceTestHooks.types.ts
+++ b/frontend/src/features/voice/voiceTestHooks.types.ts
@@ -35,8 +35,13 @@ export interface VoiceTestHookWindow {
   __lkSetMic: (enabled: boolean) => Promise<void>;
   /** Enable/disable the local camera (fake-video source headless). */
   __lkSetCamera: (enabled: boolean) => Promise<void>;
-  /** Start/stop local screen share. May reject if headless capture unavailable. */
-  __lkSetScreenShare: (enabled: boolean) => Promise<void>;
+  /**
+   * Start/stop local screen share. May reject if headless capture unavailable.
+   * `opts.audio` requests tab/system audio with the app's real constraints
+   * (a ScreenShareAudio publication) — best-effort: fake-media environments
+   * often provide no capturable audio, in which case only video is published.
+   */
+  __lkSetScreenShare: (enabled: boolean, opts?: { audio?: boolean }) => Promise<void>;
   /** Switch the active mic capture device live (PR #351 — no rejoin). */
   __lkSwitchMic: (deviceId: string) => Promise<void>;
   // --- On-demand subscription (autoSubscribe:false opt-in sources) ---


### PR DESCRIPTION
Client-side half of the screen-share-audio hardening (server-side audit + fixes: #383).

## Changes

1. **Tile audio indicator no longer lies for screen-sharers**: `VideoTiles` picked `audioTrackPublications[0]` as a tile's audio track, which for a participant sharing with audio can be the `ScreenShareAudio` publication instead of the microphone — so the mute indicator reflected the wrong track. Both tile builders now select by `source === Microphone`. Mutation-tested: with the fix reverted, the 3 new unit tests fail.
2. **E2E regression spec pinning non-watcher silence**: new real-LiveKit spec asserts a bystander who never clicks "watch" has **zero subscribed** `ScreenShareAudio` tracks (room-wide sweep), and subscription appears only after watching. This pins the post-#367 behavior so a future subscription regression (a repeat of the silent pre-#367 auto-subscribe era) fails CI/nightly loudly instead of leaking for months. Harness gained an opt-in share-with-audio mode using the app's real capture constraints; headless fake-display capture can't produce actual audio, so the audio-publication branch runs conditionally (documented in-spec) while the zero-subscriptions guarantee always asserts.

## Verification

- Unit: 29/29 (VideoTiles/VideoTile), eslint + type-check clean.
- E2E: all 3 screenshare specs pass against the real-LiveKit stack, including the new one (run locally, 23.9s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)