### PR TITLE
fix(voice): unmute mic when switching push-to-talk to voice activity

### DIFF
--- a/frontend/src/__tests__/hooks/usePushToTalk.inputModeSwitch.test.ts
+++ b/frontend/src/__tests__/hooks/usePushToTalk.inputModeSwitch.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// --- Mutable mock state -----------------------------------------------------
+
+let mockRoom: { localParticipant: { setMicrophoneEnabled: ReturnType<typeof vi.fn> } } | null =
+  null;
+
+let mockVoiceState: {
+  isConnected: boolean;
+  isServerMuted: boolean;
+  isDeafened: boolean;
+};
+
+let mockVoiceSettings: {
+  inputMode: 'voice_activity' | 'push_to_talk';
+  pushToTalkKey: string;
+  pushToTalkKeyDisplay: string;
+  isPushToTalk: boolean;
+};
+
+const setMockInputMode = (mode: 'voice_activity' | 'push_to_talk') => {
+  mockVoiceSettings = {
+    ...mockVoiceSettings,
+    inputMode: mode,
+    isPushToTalk: mode === 'push_to_talk',
+  };
+};
+
+vi.mock('../../hooks/useRoom', () => ({
+  useRoom: vi.fn(() => ({ getRoom: () => mockRoom })),
+}));
+
+vi.mock('../../contexts/VoiceContext', () => ({
+  useVoice: vi.fn(() => mockVoiceState),
+  // usePushToTalk also reads live state via useVoiceDispatch's stateRef
+  // (the #380 server-mute keydown guard); expose the same mock state there.
+  useVoiceDispatch: vi.fn(() => ({
+    dispatch: vi.fn(),
+    stateRef: {
+      get current() {
+        return mockVoiceState;
+      },
+    },
+  })),
+}));
+
+vi.mock('../../hooks/useVoiceSettings', () => ({
+  useVoiceSettings: vi.fn(() => mockVoiceSettings),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { dev: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { usePushToTalk } from '../../hooks/usePushToTalk';
+
+// --- Tests -------------------------------------------------------------------
+
+describe('usePushToTalk input mode transitions (#381)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRoom = {
+      localParticipant: {
+        setMicrophoneEnabled: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+    mockVoiceState = {
+      isConnected: true,
+      isServerMuted: false,
+      isDeafened: false,
+    };
+    mockVoiceSettings = {
+      inputMode: 'push_to_talk',
+      pushToTalkKey: 'Backquote',
+      pushToTalkKeyDisplay: '`',
+      isPushToTalk: true,
+    };
+  });
+
+  describe('PTT -> voice activity', () => {
+    it('unmutes the mic when switching to voice activity while connected', () => {
+      const { rerender } = renderHook(() => usePushToTalk());
+
+      setMockInputMode('voice_activity');
+      rerender();
+
+      expect(mockRoom!.localParticipant.setMicrophoneEnabled).toHaveBeenCalledTimes(1);
+      expect(mockRoom!.localParticipant.setMicrophoneEnabled).toHaveBeenCalledWith(true);
+    });
+
+    it('does NOT unmute when server-muted', () => {
+      mockVoiceState.isServerMuted = true;
+      const { rerender } = renderHook(() => usePushToTalk());
+
+      setMockInputMode('voice_activity');
+      rerender();
+
+      expect(mockRoom!.localParticipant.setMicrophoneEnabled).not.toHaveBeenCalled();
+    });
+
+    it('does NOT unmute when deafened', () => {
+      mockVoiceState.isDeafened = true;
+      const { rerender } = renderHook(() => usePushToTalk());
+
+      setMockInputMode('voice_activity');
+      rerender();
+
+      expect(mockRoom!.localParticipant.setMicrophoneEnabled).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when not connected to voice', () => {
+      mockVoiceState.isConnected = false;
+      const { rerender } = renderHook(() => usePushToTalk());
+
+      setMockInputMode('voice_activity');
+      rerender();
+
+      expect(mockRoom!.localParticipant.setMicrophoneEnabled).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('voice activity -> PTT', () => {
+    beforeEach(() => {
+      setMockInputMode('voice_activity');
+    });
+
+    it('mutes the mic so it rests muted until the key is held', () => {
+      const { rerender } = renderHook(() => usePushToTalk());
+
+      setMockInputMode('push_to_talk');
+      rerender();
+
+      expect(mockRoom!.localParticipant.setMicrophoneEnabled).toHaveBeenCalledTimes(1);
+      expect(mockRoom!.localParticipant.setMicrophoneEnabled).toHaveBeenCalledWith(false);
+    });
+
+    it('does nothing when not connected to voice', () => {
+      mockVoiceState.isConnected = false;
+      const { rerender } = renderHook(() => usePushToTalk());
+
+      setMockInputMode('push_to_talk');
+      rerender();
+
+      expect(mockRoom!.localParticipant.setMicrophoneEnabled).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('no spurious mic changes', () => {
+    it('does not touch the mic on initial mount (no transition)', () => {
+      renderHook(() => usePushToTalk());
+
+      expect(mockRoom!.localParticipant.setMicrophoneEnabled).not.toHaveBeenCalled();
+    });
+
+    it('does not touch the mic when re-rendering without a mode change', () => {
+      const { rerender } = renderHook(() => usePushToTalk());
+
+      mockVoiceState = { ...mockVoiceState, isServerMuted: true };
+      rerender();
+      mockVoiceState = { ...mockVoiceState, isServerMuted: false };
+      rerender();
+
+      expect(mockRoom!.localParticipant.setMicrophoneEnabled).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/__tests__/hooks/useVoiceSettings.test.ts
+++ b/frontend/src/__tests__/hooks/useVoiceSettings.test.ts
@@ -139,6 +139,46 @@ describe('useVoiceSettings', () => {
     });
   });
 
+  describe('cross-instance sync (same tab)', () => {
+    it('propagates setInputMode to other mounted instances', () => {
+      // e.g. settings dialog instance vs. usePushToTalk's instance in VoiceBottomBar
+      const panel = renderHook(() => useVoiceSettings());
+      const bottomBar = renderHook(() => useVoiceSettings());
+
+      expect(bottomBar.result.current.inputMode).toBe('voice_activity');
+
+      act(() => {
+        panel.result.current.setInputMode('push_to_talk');
+      });
+
+      expect(bottomBar.result.current.inputMode).toBe('push_to_talk');
+      expect(bottomBar.result.current.isPushToTalk).toBe(true);
+    });
+
+    it('propagates saveVoiceSettings changes to other instances', () => {
+      const a = renderHook(() => useVoiceSettings());
+      const b = renderHook(() => useVoiceSettings());
+
+      act(() => {
+        a.result.current.setVoiceActivityThreshold(42);
+      });
+
+      expect(b.result.current.voiceActivityThreshold).toBe(42);
+    });
+
+    it('stops syncing after unmount', () => {
+      const a = renderHook(() => useVoiceSettings());
+      const b = renderHook(() => useVoiceSettings());
+      b.unmount();
+
+      expect(() => {
+        act(() => {
+          a.result.current.setInputMode('push_to_talk');
+        });
+      }).not.toThrow();
+    });
+  });
+
   describe('loads persisted audio processing settings', () => {
     it('restores saved audio processing values', () => {
       mockStorage['semaphore_voice_settings'] = {

--- a/frontend/src/hooks/usePushToTalk.ts
+++ b/frontend/src/hooks/usePushToTalk.ts
@@ -120,6 +120,43 @@ export function usePushToTalk() {
     };
   }, [isActive, pushToTalkKey, handleKeyDown, handleKeyUp, handleBlur, getRoom]);
 
+  // Apply the correct mic state when the input mode changes mid-call (#381).
+  //
+  // PTT -> voice activity: in PTT mode the resting state of the mic
+  // publication is always muted (keyup/blur mute it), and the mute state is
+  // one-dimensional — there is no separate "user clicked mute" flag, so a
+  // manual mute while in PTT mode is indistinguishable from the PTT-idle
+  // mute. The pragmatic rule: unmute so voice activity transmits immediately
+  // (that is what choosing VA means), unless the user is server-muted or
+  // deafened — those states must never be overridden from here.
+  //
+  // Voice activity -> PTT: the resting state must be muted until the PTT key
+  // is held. The activation effect above only attaches listeners and never
+  // mutes, so handle it on the transition.
+  const prevIsPushToTalkRef = useRef(isPushToTalk);
+  useEffect(() => {
+    const wasPushToTalk = prevIsPushToTalkRef.current;
+    prevIsPushToTalkRef.current = isPushToTalk;
+
+    if (wasPushToTalk === isPushToTalk) return;
+    if (!voiceState.isConnected) return;
+
+    const room = getRoom();
+    if (!room) return;
+
+    if (isPushToTalk) {
+      // VA -> PTT: rest muted until the key is held
+      room.localParticipant.setMicrophoneEnabled(false)
+        .then(() => logger.dev('[PTT] Switched to push to talk, microphone muted until key held'))
+        .catch((error) => logger.error('[PTT] Failed to mute microphone on mode switch:', error));
+    } else if (!voiceState.isServerMuted && !voiceState.isDeafened) {
+      // PTT -> VA: unmute so voice activity works (see comment above)
+      room.localParticipant.setMicrophoneEnabled(true)
+        .then(() => logger.dev('[PTT] Switched to voice activity, microphone enabled'))
+        .catch((error) => logger.error('[PTT] Failed to enable microphone on mode switch:', error));
+    }
+  }, [isPushToTalk, voiceState.isConnected, voiceState.isServerMuted, voiceState.isDeafened, getRoom]);
+
   return {
     // Whether PTT mode is currently active (connected + PTT mode enabled)
     isActive,

--- a/frontend/src/hooks/useVoiceSettings.ts
+++ b/frontend/src/hooks/useVoiceSettings.ts
@@ -99,7 +99,9 @@ export const useVoiceSettings = () => {
     const handleSettingsChanged = (event: Event) => {
       const detail = (event as CustomEvent<VoiceSettings>).detail;
       if (detail) {
-        setVoiceSettings(detail);
+        // Identity guard so the dispatching instance's own event (delivered
+        // synchronously, possibly before its setState commits) is a no-op.
+        setVoiceSettings((prev) => (Object.is(prev, detail) ? prev : detail));
       }
     };
     window.addEventListener(VOICE_SETTINGS_EVENT, handleSettingsChanged);
@@ -112,7 +114,7 @@ export const useVoiceSettings = () => {
     setVoiceSettings(newSettings);
     setCachedItem(VOICE_SETTINGS_KEY, newSettings);
     // Notify other useVoiceSettings instances in this tab (self-dispatch is a
-    // no-op: setVoiceSettings receives the same object reference and bails out)
+    // no-op via the listener's Object.is guard on the same object reference)
     window.dispatchEvent(new CustomEvent(VOICE_SETTINGS_EVENT, { detail: newSettings }));
   }, [voiceSettings]);
 

--- a/frontend/src/hooks/useVoiceSettings.ts
+++ b/frontend/src/hooks/useVoiceSettings.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { getCachedItem, setCachedItem } from '../utils/storage';
 
 export type VoiceInputMode = 'voice_activity' | 'push_to_talk';
@@ -15,6 +15,12 @@ export interface VoiceSettings {
 }
 
 const VOICE_SETTINGS_KEY = 'semaphore_voice_settings';
+
+// Same-tab sync event: each useVoiceSettings() call holds its own useState,
+// and localStorage 'storage' events only fire in OTHER tabs. Without this
+// event, a mode change made in the settings dialog would never reach other
+// mounted instances (e.g. usePushToTalk inside VoiceBottomBar) until remount.
+const VOICE_SETTINGS_EVENT = 'semaphore:voice-settings-changed';
 
 const DEFAULT_VOICE_SETTINGS: VoiceSettings = {
   inputMode: 'voice_activity',
@@ -88,11 +94,26 @@ export const useVoiceSettings = () => {
     return saved ? { ...DEFAULT_VOICE_SETTINGS, ...saved } : DEFAULT_VOICE_SETTINGS;
   });
 
+  // Keep all hook instances in sync when any of them saves settings
+  useEffect(() => {
+    const handleSettingsChanged = (event: Event) => {
+      const detail = (event as CustomEvent<VoiceSettings>).detail;
+      if (detail) {
+        setVoiceSettings(detail);
+      }
+    };
+    window.addEventListener(VOICE_SETTINGS_EVENT, handleSettingsChanged);
+    return () => window.removeEventListener(VOICE_SETTINGS_EVENT, handleSettingsChanged);
+  }, []);
+
   // Save voice settings
   const saveVoiceSettings = useCallback((settings: Partial<VoiceSettings>) => {
     const newSettings = { ...voiceSettings, ...settings };
     setVoiceSettings(newSettings);
     setCachedItem(VOICE_SETTINGS_KEY, newSettings);
+    // Notify other useVoiceSettings instances in this tab (self-dispatch is a
+    // no-op: setVoiceSettings receives the same object reference and bails out)
+    window.dispatchEvent(new CustomEvent(VOICE_SETTINGS_EVENT, { detail: newSettings }));
   }, [voiceSettings]);
 
   // Set input mode


### PR DESCRIPTION
Fixes #381.

## The bug was deeper than filed

In PTT mode the publication rests muted, and switching to voice-activity never unmuted it — but the root cause is that `useVoiceSettings` instances had **no same-tab sync at all** (localStorage `storage` events only fire in other tabs). A mid-call mode change in the settings dialog never reached `usePushToTalk`'s instance in the bottom bar: PTT→VA left stale key listeners active, and VA→PTT never attached listeners — a hot mic. Before #376, PTT→VA "worked" only via the transmit-while-muted leak.

## Fix

1. `useVoiceSettings` instances now sync same-tab via a `CustomEvent` dispatched on save (self-dispatch bails via reference equality; listeners cleaned up on unmount).
2. `usePushToTalk` gained a mode-transition effect (prev-value ref, gated on connected): PTT→VA unmutes **unless server-muted or deafened**; VA→PTT mutes until the key is held. Mute state is one-dimensional (no manual-mute flag exists), and in PTT the resting state is always muted — so unmuting on the switch to VA is what the user means; reasoning documented in-code.

## Verification

- New mode-switch suite + sync tests; 79 tests across the 4 affected files.
- Joint adversarial review with #380 (both touch `usePushToTalk.ts`): merges cleanly, runtime interactions traced (mode-switch race vs server-mute WS handler, rapid toggling, mount/reconnect edges) — no findings besides a test-mock incompatibility with #380's context import, fixed here; 29/29 tests pass on a scratch merge of both branches, so merge order doesn't matter.
- Review note (matches pre-existing UX): a server-muted user who switches to VA stays muted after server-unmute until they unmute manually — identical to a plain VA user's behavior today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)