### PR TITLE
fix(voice): PTT keydown respects server mute

### DIFF
--- a/frontend/src/__tests__/hooks/usePushToTalk.test.ts
+++ b/frontend/src/__tests__/hooks/usePushToTalk.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePushToTalk } from '../../hooks/usePushToTalk';
+
+const mockSetMicrophoneEnabled = vi.fn();
+let mockRoom: { localParticipant: { setMicrophoneEnabled: typeof mockSetMicrophoneEnabled } } | null =
+  null;
+
+// Mutable voice state read by both useVoice (render-time) and stateRef (event-time)
+let mockVoiceState: { isConnected: boolean; isServerMuted: boolean };
+const mockStateRef = {
+  get current() {
+    return mockVoiceState;
+  },
+};
+
+vi.mock('../../contexts/VoiceContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../contexts/VoiceContext')>();
+  return {
+    ...actual,
+    useVoice: vi.fn(() => mockVoiceState),
+    useVoiceDispatch: vi.fn(() => ({ dispatch: vi.fn(), stateRef: mockStateRef })),
+  };
+});
+
+// getRoom must be referentially stable across renders (as the real RoomContext
+// provides) — an unstable identity would churn the hook's effect on each render.
+const mockGetRoom = () => mockRoom;
+vi.mock('../../hooks/useRoom', () => ({
+  useRoom: vi.fn(() => ({ getRoom: mockGetRoom })),
+}));
+
+vi.mock('../../hooks/useVoiceSettings', () => ({
+  useVoiceSettings: vi.fn(() => ({
+    inputMode: 'push_to_talk',
+    pushToTalkKey: 'Backquote',
+    pushToTalkKeyDisplay: '`',
+    isPushToTalk: true,
+  })),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { dev: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+function pressPttKey(options: { repeat?: boolean } = {}) {
+  const event = new KeyboardEvent('keydown', { code: 'Backquote' });
+  if (options.repeat) {
+    // jsdom does not honor `repeat` from KeyboardEventInit
+    Object.defineProperty(event, 'repeat', { value: true });
+  }
+  window.dispatchEvent(event);
+}
+
+function releasePttKey() {
+  window.dispatchEvent(new KeyboardEvent('keyup', { code: 'Backquote' }));
+}
+
+describe('usePushToTalk', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSetMicrophoneEnabled.mockResolvedValue(undefined);
+    mockRoom = { localParticipant: { setMicrophoneEnabled: mockSetMicrophoneEnabled } };
+    mockVoiceState = { isConnected: true, isServerMuted: false };
+  });
+
+  it('enables the microphone on PTT keydown when not server-muted', async () => {
+    const { result } = renderHook(() => usePushToTalk());
+
+    await act(async () => {
+      pressPttKey();
+    });
+
+    expect(mockSetMicrophoneEnabled).toHaveBeenCalledWith(true);
+    expect(result.current.isKeyHeld).toBe(true);
+  });
+
+  it('disables the microphone on PTT keyup', async () => {
+    const { result } = renderHook(() => usePushToTalk());
+
+    await act(async () => {
+      pressPttKey();
+      releasePttKey();
+    });
+
+    expect(mockSetMicrophoneEnabled).toHaveBeenLastCalledWith(false);
+    expect(result.current.isKeyHeld).toBe(false);
+  });
+
+  it('does NOT enable the microphone on keydown while server-muted', async () => {
+    mockVoiceState = { isConnected: true, isServerMuted: true };
+    const { result } = renderHook(() => usePushToTalk());
+
+    await act(async () => {
+      pressPttKey();
+    });
+
+    expect(mockSetMicrophoneEnabled).not.toHaveBeenCalled();
+    // Speaking indicator input stays off
+    expect(result.current.isKeyHeld).toBe(false);
+  });
+
+  it('reads the CURRENT server-mute state at keydown time (not a stale closure)', async () => {
+    const { result } = renderHook(() => usePushToTalk());
+
+    // Server mute arrives after the hook rendered its handlers.
+    // Mutate state without re-rendering — the ref must still see it.
+    mockVoiceState.isServerMuted = true;
+
+    await act(async () => {
+      pressPttKey();
+    });
+
+    expect(mockSetMicrophoneEnabled).not.toHaveBeenCalled();
+    expect(result.current.isKeyHeld).toBe(false);
+  });
+
+  it('allows PTT again after the server mute is lifted', async () => {
+    mockVoiceState = { isConnected: true, isServerMuted: true };
+    const { result } = renderHook(() => usePushToTalk());
+
+    await act(async () => {
+      pressPttKey();
+    });
+    expect(mockSetMicrophoneEnabled).not.toHaveBeenCalled();
+
+    mockVoiceState.isServerMuted = false;
+
+    await act(async () => {
+      pressPttKey();
+    });
+
+    expect(mockSetMicrophoneEnabled).toHaveBeenCalledWith(true);
+    expect(result.current.isKeyHeld).toBe(true);
+  });
+
+  it('still allows muting on keyup while server-muted', async () => {
+    mockVoiceState = { isConnected: true, isServerMuted: true };
+    renderHook(() => usePushToTalk());
+
+    await act(async () => {
+      releasePttKey();
+    });
+
+    expect(mockSetMicrophoneEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('ignores non-PTT keys', async () => {
+    renderHook(() => usePushToTalk());
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyA' }));
+    });
+
+    expect(mockSetMicrophoneEnabled).not.toHaveBeenCalled();
+  });
+
+  it('ignores repeat keydown events', async () => {
+    renderHook(() => usePushToTalk());
+
+    await act(async () => {
+      pressPttKey();
+      pressPttKey({ repeat: true });
+    });
+
+    expect(mockSetMicrophoneEnabled).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/usePushToTalk.ts
+++ b/frontend/src/hooks/usePushToTalk.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { useVoice } from '../contexts/VoiceContext';
+import { useVoice, useVoiceDispatch } from '../contexts/VoiceContext';
 import { useRoom } from './useRoom';
 import { useVoiceSettings } from './useVoiceSettings';
 import { logger } from '../utils/logger';
@@ -16,6 +16,7 @@ import { logger } from '../utils/logger';
 export function usePushToTalk() {
   const { getRoom } = useRoom();
   const voiceState = useVoice();
+  const { stateRef } = useVoiceDispatch();
   const { inputMode, pushToTalkKey, pushToTalkKeyDisplay, isPushToTalk } = useVoiceSettings();
 
   const [isKeyHeld, setIsKeyHeld] = useState(false);
@@ -43,6 +44,13 @@ export function usePushToTalk() {
     const room = getRoom();
     if (!room) return;
 
+    // Block transmit when server-muted — mirrors the guard in toggleMicrophone.
+    // Read via stateRef so we see the CURRENT value, not a stale closure.
+    if (stateRef.current.isServerMuted) {
+      logger.dev('[PTT] Key pressed while server muted, ignoring');
+      return;
+    }
+
     try {
       isKeyHeldRef.current = true;
       setIsKeyHeld(true);
@@ -51,7 +59,7 @@ export function usePushToTalk() {
     } catch (error) {
       logger.error('[PTT] Failed to enable microphone:', error);
     }
-  }, [pushToTalkKey, getRoom]);
+  }, [pushToTalkKey, getRoom, stateRef]);
 
   // Handle keyup - disable microphone
   const handleKeyUp = useCallback(async (event: KeyboardEvent) => {


### PR DESCRIPTION
Fixes #380.

A server-muted user in push-to-talk mode could transmit by holding their PTT key: the keydown handler called `setMicrophoneEnabled(true)` without consulting server-mute state, unlike `toggleMicrophone` which guards it. Since #376 made speaking indicators honest, the bypass was visible to the whole channel.

## Fix

Keydown now early-returns when server-muted, reading **live** state via `VoiceContext`'s stable `stateRef` (the same pattern `RoomProvider` uses for event-handler reads) — no stale closure, no listener churn. Keyup/blur/unmount stay unguarded (muting is always allowed). Deafen deliberately does not block PTT, mirroring `toggleMicrophone`'s existing policy.

## Verification

- First-ever `usePushToTalk` test suite (8 tests), including a live-state test that flips server-mute after render without re-rendering and proves the guard still applies. 41/41 across affected suites.
- Joint adversarial review with #381 (both touch this hook): no findings against this branch; combined-tree behavior traced (server-mute arriving mid-hold converges cleanly via `useServerMuteEffect`'s force-mute + unguarded keyup); 29/29 tests on a scratch merge of both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)