### PR TITLE
fix(voice): Android PWA background call survival (#350) + PWA/notification hardening

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -9189,7 +9189,9 @@
           },
           "ttl": {
             "type": "number",
-            "minimum": 1
+            "description": "Token TTL in seconds. Capped at 3600 (1 hour, the default) so that a\nuser removed from a channel/DM keeps lingering room access only until\ntheir current token expires — an unbounded client-supplied TTL would\nturn that window into effectively permanent access.",
+            "minimum": 1,
+            "maximum": 3600
           }
         },
         "required": [
@@ -10020,6 +10022,10 @@
             "type": "string",
             "nullable": true
           },
+          "dndTimezone": {
+            "type": "string",
+            "nullable": true
+          },
           "defaultChannelLevel": {
             "type": "string"
           },
@@ -10044,6 +10050,7 @@
           "doNotDisturb",
           "dndStartTime",
           "dndEndTime",
+          "dndTimezone",
           "defaultChannelLevel",
           "dmNotifications",
           "createdAt",
@@ -10077,6 +10084,10 @@
           "dndEndTime": {
             "type": "string",
             "pattern": "/^([01]\\d|2[0-3]):([0-5]\\d)$/"
+          },
+          "dndTimezone": {
+            "type": "string",
+            "pattern": "/^[A-Za-z_]+(\\/[A-Za-z0-9_+-]+)*$/"
           },
           "defaultChannelLevel": {
             "type": "string",

--- a/backend/prisma/migrations/20260703004500_add_dnd_timezone/migration.sql
+++ b/backend/prisma/migrations/20260703004500_add_dnd_timezone/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "UserNotificationSettings" ADD COLUMN "dndTimezone" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -194,6 +194,7 @@ model UserNotificationSettings {
   doNotDisturb        Boolean  @default(false)
   dndStartTime        String? // "22:00" - 24-hour format
   dndEndTime          String? // "08:00" - 24-hour format
+  dndTimezone         String? // IANA timezone (e.g. "Europe/Berlin"); set from the client on save
   defaultChannelLevel String   @default("mentions") // 'all' | 'mentions' | 'none'
   dmNotifications     Boolean  @default(true)
   createdAt           DateTime @default(now())

--- a/backend/src/notifications/dnd.util.spec.ts
+++ b/backend/src/notifications/dnd.util.spec.ts
@@ -1,0 +1,108 @@
+import { isDndActive, DndSettings } from './dnd.util';
+
+const base: DndSettings = {
+  doNotDisturb: true,
+  dndStartTime: null,
+  dndEndTime: null,
+  dndTimezone: null,
+};
+
+// Fixed instant: 2026-07-03T12:30:00Z
+const NOON_UTC = new Date('2026-07-03T12:30:00Z');
+
+describe('isDndActive', () => {
+  it('returns false when DND is off', () => {
+    expect(isDndActive({ ...base, doNotDisturb: false }, NOON_UTC)).toBe(false);
+  });
+
+  it('returns true for manual DND with no time window', () => {
+    expect(isDndActive(base, NOON_UTC)).toBe(true);
+  });
+
+  it('returns true when only one bound is set (treated as manual toggle)', () => {
+    expect(isDndActive({ ...base, dndStartTime: '22:00' }, NOON_UTC)).toBe(
+      true,
+    );
+    expect(isDndActive({ ...base, dndEndTime: '08:00' }, NOON_UTC)).toBe(true);
+  });
+
+  it('returns true for malformed times (fails closed to manual toggle)', () => {
+    expect(
+      isDndActive(
+        { ...base, dndStartTime: '25:99', dndEndTime: '08:00' },
+        NOON_UTC,
+      ),
+    ).toBe(true);
+  });
+
+  describe('same-day window (UTC)', () => {
+    const window = { ...base, dndStartTime: '09:00', dndEndTime: '17:00' };
+
+    it('is active inside the window', () => {
+      expect(isDndActive(window, NOON_UTC)).toBe(true);
+    });
+
+    it('is inactive outside the window', () => {
+      expect(isDndActive(window, new Date('2026-07-03T18:30:00Z'))).toBe(false);
+      expect(isDndActive(window, new Date('2026-07-03T08:59:00Z'))).toBe(false);
+    });
+
+    it('start is inclusive, end is exclusive', () => {
+      expect(isDndActive(window, new Date('2026-07-03T09:00:00Z'))).toBe(true);
+      expect(isDndActive(window, new Date('2026-07-03T17:00:00Z'))).toBe(false);
+    });
+  });
+
+  describe('overnight window (UTC)', () => {
+    const overnight = { ...base, dndStartTime: '22:00', dndEndTime: '08:00' };
+
+    it('is active late at night and early morning', () => {
+      expect(isDndActive(overnight, new Date('2026-07-03T23:30:00Z'))).toBe(
+        true,
+      );
+      expect(isDndActive(overnight, new Date('2026-07-03T03:00:00Z'))).toBe(
+        true,
+      );
+    });
+
+    it('is inactive during the day', () => {
+      expect(isDndActive(overnight, NOON_UTC)).toBe(false);
+    });
+  });
+
+  describe('timezone handling', () => {
+    it('evaluates the window in the stored timezone', () => {
+      // 12:30 UTC = 21:30 in Tokyo (UTC+9): inside a 21:00-23:00 window there
+      const settings = {
+        ...base,
+        dndStartTime: '21:00',
+        dndEndTime: '23:00',
+        dndTimezone: 'Asia/Tokyo',
+      };
+      expect(isDndActive(settings, NOON_UTC)).toBe(true);
+      // ...but not in UTC
+      expect(isDndActive({ ...settings, dndTimezone: null }, NOON_UTC)).toBe(
+        false,
+      );
+    });
+
+    it('falls back to UTC for an invalid timezone instead of throwing', () => {
+      const settings = {
+        ...base,
+        dndStartTime: '09:00',
+        dndEndTime: '17:00',
+        dndTimezone: 'Not/AZone',
+      };
+      expect(isDndActive(settings, NOON_UTC)).toBe(true);
+    });
+  });
+
+  it('treats a degenerate window (start === end) as all-day DND', () => {
+    expect(
+      isDndActive(
+        { ...base, dndStartTime: '10:00', dndEndTime: '10:00' },
+        NOON_UTC,
+      ),
+    ).toBe(true);
+  });
+});

--- a/backend/src/notifications/dnd.util.ts
+++ b/backend/src/notifications/dnd.util.ts
@@ -1,0 +1,90 @@
+/**
+ * Do-Not-Disturb window evaluation.
+ *
+ * DND suppresses *delivery side effects* (push notifications server-side,
+ * sounds/desktop notifications client-side) — never notification record
+ * creation or WebSocket emission, which unread counts depend on.
+ */
+
+export interface DndSettings {
+  doNotDisturb: boolean;
+  /** "HH:mm" 24-hour wall-clock in the user's timezone */
+  dndStartTime: string | null;
+  /** "HH:mm" 24-hour wall-clock in the user's timezone */
+  dndEndTime: string | null;
+  /**
+   * IANA timezone the times are expressed in. Sent by the client when DND
+   * settings are saved; may be stale if the user travels without
+   * re-saving. Null/invalid falls back to server-UTC evaluation.
+   */
+  dndTimezone: string | null;
+}
+
+const TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+/** Minutes since midnight for an "HH:mm" string, or null if malformed. */
+function parseTime(value: string | null): number | null {
+  if (!value || !TIME_PATTERN.test(value)) {
+    return null;
+  }
+  const [hours, minutes] = value.split(':').map(Number);
+  return hours * 60 + minutes;
+}
+
+/** Current minutes-since-midnight in the given timezone (UTC fallback). */
+function currentMinutesIn(timezone: string | null, now: Date): number {
+  let formatted: string;
+  try {
+    formatted = new Intl.DateTimeFormat('en-GB', {
+      timeZone: timezone ?? 'UTC',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).format(now);
+  } catch {
+    // Invalid IANA name — evaluate in UTC rather than failing delivery
+    formatted = new Intl.DateTimeFormat('en-GB', {
+      timeZone: 'UTC',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).format(now);
+  }
+  const [hours, minutes] = formatted.split(':').map(Number);
+  // Intl can emit "24:xx" for midnight in some environments
+  return (hours % 24) * 60 + minutes;
+}
+
+/**
+ * Whether the user's Do-Not-Disturb is in effect right now.
+ *
+ * - DND off → false
+ * - DND on with no (or malformed) time window → true (manual toggle)
+ * - DND on with window → true iff the user-local wall-clock time is inside
+ *   it; overnight windows (start > end, e.g. 22:00–08:00) wrap midnight.
+ */
+export function isDndActive(
+  settings: DndSettings,
+  now: Date = new Date(),
+): boolean {
+  if (!settings.doNotDisturb) {
+    return false;
+  }
+
+  const start = parseTime(settings.dndStartTime);
+  const end = parseTime(settings.dndEndTime);
+  if (start === null || end === null) {
+    return true;
+  }
+
+  const current = currentMinutesIn(settings.dndTimezone, now);
+  if (start === end) {
+    // Degenerate window — treat as all-day DND
+    return true;
+  }
+  if (start > end) {
+    // Overnight window, e.g. 22:00 → 08:00
+    return current >= start || current < end;
+  }
+  return current >= start && current < end;
+}

--- a/backend/src/notifications/dto/notification-response.dto.ts
+++ b/backend/src/notifications/dto/notification-response.dto.ts
@@ -12,6 +12,7 @@ export class UserNotificationSettingsDto {
   doNotDisturb: boolean;
   dndStartTime: string | null;
   dndEndTime: string | null;
+  dndTimezone: string | null;
   defaultChannelLevel: string;
   dmNotifications: boolean;
   createdAt: Date;

--- a/backend/src/notifications/dto/update-notification-settings.dto.ts
+++ b/backend/src/notifications/dto/update-notification-settings.dto.ts
@@ -40,6 +40,13 @@ export class UpdateNotificationSettingsDto {
 
   @IsOptional()
   @IsString()
+  @Matches(/^[A-Za-z_]+(\/[A-Za-z0-9_+-]+)*$/, {
+    message: 'dndTimezone must be an IANA timezone name (e.g. Europe/Berlin)',
+  })
+  dndTimezone?: string;
+
+  @IsOptional()
+  @IsString()
   @IsIn(['all', 'mentions', 'none'])
   defaultChannelLevel?: string;
 

--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -1173,6 +1173,42 @@ describe('NotificationsService', () => {
       // Push should be suppressed
       expect(pushNotificationsService.sendToUser).not.toHaveBeenCalled();
     });
+
+    it('should suppress push when DND is active (manual toggle)', async () => {
+      presenceService.isActive.mockResolvedValue(false);
+      const message = setupForPushTest();
+      mockDatabase.userNotificationSettings.upsert.mockResolvedValue(
+        UserNotificationSettingsFactory.build({ doNotDisturb: true }),
+      );
+
+      await service.processMessageForNotifications(message as any);
+
+      // Record + WS emission still happen; only push is suppressed
+      expect(mockDatabase.notification.create).toHaveBeenCalled();
+      expect(pushNotificationsService.sendToUser).not.toHaveBeenCalled();
+    });
+
+    it('should send push when DND is enabled but outside the scheduled window', async () => {
+      presenceService.isActive.mockResolvedValue(false);
+      const message = setupForPushTest();
+      // Window that can never contain "now": start === end is all-day,
+      // so instead compute a 1-minute window guaranteed not to include now (UTC)
+      const now = new Date();
+      const farHour = (now.getUTCHours() + 12) % 24;
+      const pad = (n: number) => String(n).padStart(2, '0');
+      mockDatabase.userNotificationSettings.upsert.mockResolvedValue(
+        UserNotificationSettingsFactory.build({
+          doNotDisturb: true,
+          dndStartTime: `${pad(farHour)}:00`,
+          dndEndTime: `${pad(farHour)}:59`,
+          dndTimezone: 'UTC',
+        }),
+      );
+
+      await service.processMessageForNotifications(message as any);
+
+      expect(pushNotificationsService.sendToUser).toHaveBeenCalled();
+    });
   });
 
   // ============================================================================

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -23,6 +23,7 @@ import { NotificationsGateway } from './notifications.gateway';
 import { PushNotificationsService } from '@/push-notifications/push-notifications.service';
 import { PresenceService } from '@/presence/presence.service';
 import { flattenSpansToDisplayText } from '@/common/utils/text.utils';
+import { isDndActive } from './dnd.util';
 
 @Injectable()
 export class NotificationsService {
@@ -339,9 +340,9 @@ export class NotificationsService {
     // Get user notification settings (creates default if missing)
     const settings = await this.getUserSettings(userId);
 
-    // TODO: DND should suppress push notifications and desktop side effects,
-    // not notification record creation. Move DND check to sendPushNotification()
-    // and implement client-side DND in useNotificationSideEffects.
+    // DND deliberately does NOT gate notification creation — it suppresses
+    // delivery side effects only: push in sendPushNotification() (server)
+    // and sounds/desktop notifications in useNotificationSideEffects (client).
 
     // Check DM notifications — applies to both DIRECT_MESSAGE and THREAD_REPLY in DM context
     if (directMessageGroupId && !settings.dmNotifications) {
@@ -451,6 +452,15 @@ export class NotificationsService {
       if (isActive) {
         this.logger.debug(
           `Suppressing push notification for active user ${userId}`,
+        );
+        return;
+      }
+
+      // Respect Do-Not-Disturb (manual toggle or scheduled window)
+      const settings = await this.getUserSettings(userId);
+      if (isDndActive(settings)) {
+        this.logger.debug(
+          `Suppressing push notification for user ${userId} (DND active)`,
         );
         return;
       }

--- a/backend/src/push-notifications/push-notifications.service.ts
+++ b/backend/src/push-notifications/push-notifications.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import * as webpush from 'web-push';
 import { DatabaseService } from '@/database/database.service';
 import { SubscribePushDto } from './dto/subscribe.dto';
@@ -285,8 +286,10 @@ export class PushNotificationsService implements OnModuleInit {
   }
 
   /**
-   * Clean up expired subscriptions (can be called by a cron job)
+   * Clean up expired subscriptions. Runs daily; duplicate runs across
+   * replicas are harmless (idempotent deleteMany).
    */
+  @Cron(CronExpression.EVERY_DAY_AT_4AM)
   async cleanupExpiredSubscriptions(): Promise<number> {
     // Remove subscriptions older than 30 days that haven't been updated
     const thirtyDaysAgo = new Date();

--- a/backend/src/test-utils/factories/user-notification-settings.factory.ts
+++ b/backend/src/test-utils/factories/user-notification-settings.factory.ts
@@ -15,6 +15,7 @@ export class UserNotificationSettingsFactory {
       doNotDisturb: overrides.doNotDisturb ?? false,
       dndStartTime: overrides.dndStartTime ?? null,
       dndEndTime: overrides.dndEndTime ?? null,
+      dndTimezone: overrides.dndTimezone ?? null,
       defaultChannelLevel: overrides.defaultChannelLevel || 'mentions',
       dmNotifications: overrides.dmNotifications ?? true,
       createdAt: overrides.createdAt || new Date(),

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Box, AppBar, Toolbar, Typography, IconButton } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 import { Outlet, useNavigate } from "react-router-dom";
@@ -32,6 +32,7 @@ import { IncomingCallProvider } from "./contexts/IncomingCallContext";
 import { IncomingCallListener } from "./components/DirectMessage/IncomingCallListener";
 import { IncomingCallBanner } from "./components/DirectMessage/IncomingCallBanner";
 import { useThemeSync } from "./hooks/useThemeSync";
+import { useAppBadge } from "./hooks/useAppBadge";
 import { disconnectSocket } from "./utils/socketSingleton";
 import { clearSavedConnection } from "./features/voice/voiceActions";
 import { clearTokens, getElectronRefreshToken } from "./utils/tokenService";
@@ -97,10 +98,8 @@ const Layout: React.FC = () => {
   // Attempt to recover voice connection after page refresh
   useVoiceRecovery();
 
-  // Update document title with instance name
-  useEffect(() => {
-    document.title = instanceName;
-  }, [instanceName]);
+  // Document title (with "(N)" unread prefix) + PWA icon badge
+  useAppBadge(instanceName);
 
   const [isMenuExpanded, setIsMenuExpanded] = React.useState(false);
   const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(

--- a/frontend/src/__tests__/components/VoiceBottomBar.test.tsx
+++ b/frontend/src/__tests__/components/VoiceBottomBar.test.tsx
@@ -130,6 +130,14 @@ vi.mock('../../hooks/useVoicePresenceHeartbeat', () => ({
   useVoicePresenceHeartbeat: vi.fn(),
 }));
 
+vi.mock('../../hooks/useVoiceMediaSession', () => ({
+  useVoiceMediaSession: vi.fn(),
+}));
+
+vi.mock('../../hooks/useVoiceForegroundResync', () => ({
+  useVoiceForegroundResync: vi.fn(),
+}));
+
 vi.mock('../../hooks/useServerMuteEffect', () => ({
   useServerMuteEffect: vi.fn(),
 }));

--- a/frontend/src/__tests__/features/voiceActions.test.ts
+++ b/frontend/src/__tests__/features/voiceActions.test.ts
@@ -52,6 +52,13 @@ vi.mock('livekit-client', () => {
     DisconnectReason: {},
     VideoCaptureOptions: {},
     AudioCaptureOptions: {},
+    // Referenced by utils/livekitWorkerTimers.ts (imported via voiceActions)
+    CriticalTimers: {
+      setTimeout: vi.fn(),
+      setInterval: vi.fn(),
+      clearTimeout: vi.fn(),
+      clearInterval: vi.fn(),
+    },
   };
 });
 

--- a/frontend/src/__tests__/hooks/useAppBadge.test.tsx
+++ b/frontend/src/__tests__/hooks/useAppBadge.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useAppBadge } from '../../hooks/useAppBadge';
+import { notificationsControllerGetUnreadCountQueryKey } from '../../api-client/@tanstack/react-query.gen';
+
+const mockSetAppBadge = vi.fn().mockResolvedValue(undefined);
+const mockClearAppBadge = vi.fn().mockResolvedValue(undefined);
+
+function renderWithUnreadCount(count: number | null, baseTitle = 'Semaphore Chat') {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  if (count !== null) {
+    queryClient.setQueryData(notificationsControllerGetUnreadCountQueryKey(), { count });
+  }
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, ...renderHook(() => useAppBadge(baseTitle), { wrapper }) };
+}
+
+describe('useAppBadge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(navigator, 'setAppBadge', {
+      value: mockSetAppBadge,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(navigator, 'clearAppBadge', {
+      value: mockClearAppBadge,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    delete (navigator as { setAppBadge?: unknown }).setAppBadge;
+    delete (navigator as { clearAppBadge?: unknown }).clearAppBadge;
+    document.title = '';
+  });
+
+  it('sets the app badge and title prefix when there are unread notifications', () => {
+    renderWithUnreadCount(5);
+
+    expect(mockSetAppBadge).toHaveBeenCalledWith(5);
+    expect(document.title).toBe('(5) Semaphore Chat');
+  });
+
+  it('clears the badge and prefix when unread count is zero', () => {
+    renderWithUnreadCount(0);
+
+    expect(mockClearAppBadge).toHaveBeenCalled();
+    expect(mockSetAppBadge).not.toHaveBeenCalled();
+    expect(document.title).toBe('Semaphore Chat');
+  });
+
+  it('updates badge and title when the cached count changes', async () => {
+    const { queryClient } = renderWithUnreadCount(1);
+    expect(document.title).toBe('(1) Semaphore Chat');
+
+    queryClient.setQueryData(notificationsControllerGetUnreadCountQueryKey(), { count: 7 });
+
+    await waitFor(() => {
+      expect(document.title).toBe('(7) Semaphore Chat');
+    });
+    expect(mockSetAppBadge).toHaveBeenLastCalledWith(7);
+  });
+
+  it('still manages the title when the Badging API is unavailable', () => {
+    delete (navigator as { setAppBadge?: unknown }).setAppBadge;
+    delete (navigator as { clearAppBadge?: unknown }).clearAppBadge;
+
+    expect(() => renderWithUnreadCount(3)).not.toThrow();
+    expect(document.title).toBe('(3) Semaphore Chat');
+  });
+
+  it('uses the plain base title before any count is cached', () => {
+    renderWithUnreadCount(null, 'My Instance');
+    expect(document.title).toBe('My Instance');
+  });
+});

--- a/frontend/src/__tests__/hooks/useVoiceForegroundResync.test.ts
+++ b/frontend/src/__tests__/hooks/useVoiceForegroundResync.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { DisconnectReason, type Room } from 'livekit-client';
+import { useVoiceForegroundResync } from '../../hooks/useVoiceForegroundResync';
+import { VoiceActionType, VoiceSessionType, type VoiceState } from '../../contexts/VoiceContext';
+
+const mockDispatch = vi.fn();
+
+vi.mock('../../contexts/VoiceContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../contexts/VoiceContext')>();
+  return {
+    ...actual,
+    useVoiceDispatch: () => ({ dispatch: mockDispatch, stateRef: { current: null } }),
+  };
+});
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+interface MockRoom {
+  state: string;
+  canPlaybackAudio: boolean;
+  startAudio: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  off: ReturnType<typeof vi.fn>;
+}
+
+function createMockRoom(overrides: Partial<MockRoom> = {}): MockRoom {
+  return {
+    state: 'connected',
+    canPlaybackAudio: true,
+    startAudio: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn(),
+    off: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createVoiceState(overrides: Partial<VoiceState> = {}): VoiceState {
+  return {
+    isConnected: true,
+    isConnecting: false,
+    connectionError: null,
+    contextType: VoiceSessionType.Channel,
+    currentChannelId: 'chan-1',
+    channelName: 'General Voice',
+    communityId: 'comm-1',
+    isPrivate: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    currentDmGroupId: null,
+    dmGroupName: null,
+    isDeafened: false,
+    showVideoTiles: false,
+    screenShareAudioFailed: false,
+    requestMaximize: false,
+    selectedAudioInputId: null,
+    selectedAudioOutputId: null,
+    selectedVideoInputId: null,
+    wasMutedBeforeDeafen: false,
+    isServerMuted: false,
+    watchingCameras: new Set<string>(),
+    watchingScreenShares: new Set<string>(),
+    hiddenLocalTiles: new Set<string>(),
+    ...overrides,
+  };
+}
+
+const createActions = () => ({
+  joinVoiceChannel: vi.fn().mockResolvedValue(undefined),
+  joinDmVoice: vi.fn().mockResolvedValue(undefined),
+});
+
+async function fireVisibilityChange() {
+  await act(async () => {
+    document.dispatchEvent(new Event('visibilitychange'));
+    // flush the async resync
+    await Promise.resolve();
+  });
+}
+
+describe('useVoiceForegroundResync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    });
+  });
+
+  it('rejoins the channel when the room is dead but context says connected', async () => {
+    const room = createMockRoom({ state: 'disconnected' });
+    const actions = createActions();
+    renderHook(() =>
+      useVoiceForegroundResync({ room: room as unknown as Room, state: createVoiceState(), actions })
+    );
+
+    await fireVisibilityChange();
+
+    expect(actions.joinVoiceChannel).toHaveBeenCalledWith(
+      'chan-1',
+      'General Voice',
+      'comm-1',
+      false,
+      '2026-01-01T00:00:00.000Z'
+    );
+  });
+
+  it('rejoins via joinDmVoice for DM contexts', async () => {
+    const actions = createActions();
+    renderHook(() =>
+      useVoiceForegroundResync({
+        room: null,
+        state: createVoiceState({
+          contextType: VoiceSessionType.Dm,
+          currentChannelId: null,
+          channelName: null,
+          communityId: null,
+          currentDmGroupId: 'dm-1',
+          dmGroupName: 'Alice & Bob',
+        }),
+        actions,
+      })
+    );
+
+    await fireVisibilityChange();
+
+    expect(actions.joinDmVoice).toHaveBeenCalledWith('dm-1', 'Alice & Bob');
+    expect(actions.joinVoiceChannel).not.toHaveBeenCalled();
+  });
+
+  it('dispatches SetDisconnected when the rejoin fails', async () => {
+    const actions = createActions();
+    actions.joinVoiceChannel.mockRejectedValue(new Error('token expired'));
+    renderHook(() =>
+      useVoiceForegroundResync({
+        room: createMockRoom({ state: 'disconnected' }) as unknown as Room,
+        state: createVoiceState(),
+        actions,
+      })
+    );
+
+    await fireVisibilityChange();
+
+    expect(mockDispatch).toHaveBeenCalledWith({ type: VoiceActionType.SetDisconnected });
+  });
+
+  it('dispatches SetDisconnected when context state is too incomplete to rejoin', async () => {
+    const actions = createActions();
+    renderHook(() =>
+      useVoiceForegroundResync({
+        room: null,
+        state: createVoiceState({ channelName: null }),
+        actions,
+      })
+    );
+
+    await fireVisibilityChange();
+
+    expect(actions.joinVoiceChannel).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith({ type: VoiceActionType.SetDisconnected });
+  });
+
+  it('calls startAudio when connected but audio playback is blocked', async () => {
+    const room = createMockRoom({ canPlaybackAudio: false });
+    renderHook(() =>
+      useVoiceForegroundResync({ room: room as unknown as Room, state: createVoiceState(), actions: createActions() })
+    );
+
+    await fireVisibilityChange();
+
+    expect(room.startAudio).toHaveBeenCalled();
+  });
+
+  it('does nothing when the room is healthy and audio is playable', async () => {
+    const room = createMockRoom();
+    const actions = createActions();
+    renderHook(() =>
+      useVoiceForegroundResync({ room: room as unknown as Room, state: createVoiceState(), actions })
+    );
+
+    await fireVisibilityChange();
+
+    expect(room.startAudio).not.toHaveBeenCalled();
+    expect(actions.joinVoiceChannel).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when voice context is not connected', async () => {
+    const actions = createActions();
+    renderHook(() =>
+      useVoiceForegroundResync({ room: null, state: createVoiceState({ isConnected: false }), actions })
+    );
+
+    await fireVisibilityChange();
+
+    expect(actions.joinVoiceChannel).not.toHaveBeenCalled();
+  });
+
+  it('does nothing while hidden', async () => {
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    const actions = createActions();
+    renderHook(() =>
+      useVoiceForegroundResync({
+        room: createMockRoom({ state: 'disconnected' }) as unknown as Room,
+        state: createVoiceState(),
+        actions,
+      })
+    );
+
+    await fireVisibilityChange();
+
+    expect(actions.joinVoiceChannel).not.toHaveBeenCalled();
+  });
+
+  it('rejoins on unexpected room disconnect while visible', async () => {
+    const room = createMockRoom();
+    const actions = createActions();
+    renderHook(() =>
+      useVoiceForegroundResync({ room: room as unknown as Room, state: createVoiceState(), actions })
+    );
+
+    const disconnectedHandler = room.on.mock.calls.find(([event]) => event === 'disconnected')?.[1];
+    expect(disconnectedHandler).toBeDefined();
+
+    // Simulate the room dying with a server-side reason
+    room.state = 'disconnected';
+    await act(async () => {
+      disconnectedHandler!(DisconnectReason.SERVER_SHUTDOWN);
+      await Promise.resolve();
+    });
+
+    expect(actions.joinVoiceChannel).toHaveBeenCalled();
+  });
+
+  it('ignores CLIENT_INITIATED disconnects (user hangup)', async () => {
+    const room = createMockRoom();
+    const actions = createActions();
+    renderHook(() =>
+      useVoiceForegroundResync({ room: room as unknown as Room, state: createVoiceState(), actions })
+    );
+
+    const disconnectedHandler = room.on.mock.calls.find(([event]) => event === 'disconnected')?.[1];
+    room.state = 'disconnected';
+    await act(async () => {
+      disconnectedHandler!(DisconnectReason.CLIENT_INITIATED);
+      await Promise.resolve();
+    });
+
+    expect(actions.joinVoiceChannel).not.toHaveBeenCalled();
+  });
+
+  it('does not start a second rejoin while one is in flight', async () => {
+    const actions = createActions();
+    let resolveJoin: () => void;
+    actions.joinVoiceChannel.mockImplementation(
+      () => new Promise<void>((resolve) => { resolveJoin = resolve; })
+    );
+    renderHook(() =>
+      useVoiceForegroundResync({
+        room: createMockRoom({ state: 'disconnected' }) as unknown as Room,
+        state: createVoiceState(),
+        actions,
+      })
+    );
+
+    await fireVisibilityChange();
+    await fireVisibilityChange();
+
+    expect(actions.joinVoiceChannel).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveJoin!();
+      await Promise.resolve();
+    });
+  });
+});

--- a/frontend/src/__tests__/hooks/useVoiceMediaSession.test.ts
+++ b/frontend/src/__tests__/hooks/useVoiceMediaSession.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useVoiceMediaSession } from '../../hooks/useVoiceMediaSession';
+import { isElectron } from '../../utils/platform';
+
+vi.mock('../../utils/platform', () => ({
+  isElectron: vi.fn(() => false),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+class MockMediaMetadata {
+  title: string;
+  artist: string;
+  constructor(init: { title: string; artist: string }) {
+    this.title = init.title;
+    this.artist = init.artist;
+  }
+}
+
+interface MockMediaSession {
+  metadata: MockMediaMetadata | null;
+  playbackState: string;
+  setActionHandler: ReturnType<typeof vi.fn>;
+  setMicrophoneActive: ReturnType<typeof vi.fn>;
+}
+
+function createMockMediaSession(): MockMediaSession {
+  return {
+    metadata: null,
+    playbackState: 'none',
+    setActionHandler: vi.fn(),
+    setMicrophoneActive: vi.fn(),
+  };
+}
+
+const defaultOptions = {
+  isConnected: true,
+  contextName: 'General Voice',
+  isMicrophoneEnabled: true,
+  onHangup: vi.fn(),
+  onToggleMic: vi.fn(),
+};
+
+describe('useVoiceMediaSession', () => {
+  let mockSession: MockMediaSession;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isElectron).mockReturnValue(false);
+    mockSession = createMockMediaSession();
+    Object.defineProperty(navigator, 'mediaSession', {
+      value: mockSession,
+      configurable: true,
+      writable: true,
+    });
+    vi.stubGlobal('MediaMetadata', MockMediaMetadata);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    // Remove the mediaSession we defined so tests stay isolated
+    delete (navigator as { mediaSession?: unknown }).mediaSession;
+  });
+
+  it('sets metadata, playback state, and action handlers while connected', () => {
+    renderHook(() => useVoiceMediaSession(defaultOptions));
+
+    expect(mockSession.metadata).toMatchObject({
+      title: 'General Voice',
+      artist: 'Semaphore Chat',
+    });
+    expect(mockSession.playbackState).toBe('playing');
+    expect(mockSession.setActionHandler).toHaveBeenCalledWith('hangup', expect.any(Function));
+    expect(mockSession.setActionHandler).toHaveBeenCalledWith('togglemicrophone', expect.any(Function));
+    expect(mockSession.setMicrophoneActive).toHaveBeenCalledWith(true);
+  });
+
+  it('falls back to a generic title when no context name is available', () => {
+    renderHook(() => useVoiceMediaSession({ ...defaultOptions, contextName: null }));
+    expect(mockSession.metadata).toMatchObject({ title: 'Voice call' });
+  });
+
+  it('invokes hangup and mic callbacks from the registered handlers', () => {
+    const onHangup = vi.fn();
+    const onToggleMic = vi.fn();
+    renderHook(() => useVoiceMediaSession({ ...defaultOptions, onHangup, onToggleMic }));
+
+    const calls = mockSession.setActionHandler.mock.calls as [string, (() => void) | null][];
+    const hangupHandler = calls.find(([action, h]) => action === 'hangup' && h)?.[1];
+    const micHandler = calls.find(([action, h]) => action === 'togglemicrophone' && h)?.[1];
+
+    hangupHandler?.();
+    micHandler?.();
+    expect(onHangup).toHaveBeenCalledTimes(1);
+    expect(onToggleMic).toHaveBeenCalledTimes(1);
+  });
+
+  it('mirrors mic mute state via setMicrophoneActive', () => {
+    const { rerender } = renderHook(
+      (props: { isMicrophoneEnabled: boolean }) =>
+        useVoiceMediaSession({ ...defaultOptions, isMicrophoneEnabled: props.isMicrophoneEnabled }),
+      { initialProps: { isMicrophoneEnabled: true } }
+    );
+    expect(mockSession.setMicrophoneActive).toHaveBeenLastCalledWith(true);
+
+    rerender({ isMicrophoneEnabled: false });
+    expect(mockSession.setMicrophoneActive).toHaveBeenLastCalledWith(false);
+  });
+
+  it('clears session state on disconnect', () => {
+    const { rerender } = renderHook(
+      (props: { isConnected: boolean }) =>
+        useVoiceMediaSession({ ...defaultOptions, isConnected: props.isConnected }),
+      { initialProps: { isConnected: true } }
+    );
+
+    rerender({ isConnected: false });
+
+    expect(mockSession.metadata).toBeNull();
+    expect(mockSession.playbackState).toBe('none');
+    expect(mockSession.setActionHandler).toHaveBeenCalledWith('hangup', null);
+    expect(mockSession.setActionHandler).toHaveBeenCalledWith('togglemicrophone', null);
+  });
+
+  it('swallows setActionHandler TypeError for unsupported actions', () => {
+    mockSession.setActionHandler.mockImplementation((action: string) => {
+      if (action === 'togglemicrophone') {
+        throw new TypeError('unsupported action');
+      }
+    });
+
+    expect(() => renderHook(() => useVoiceMediaSession(defaultOptions))).not.toThrow();
+    // hangup still registered despite togglemicrophone throwing
+    expect(mockSession.setActionHandler).toHaveBeenCalledWith('hangup', expect.any(Function));
+  });
+
+  it('does nothing when not connected', () => {
+    renderHook(() => useVoiceMediaSession({ ...defaultOptions, isConnected: false }));
+    expect(mockSession.setActionHandler).not.toHaveBeenCalled();
+    expect(mockSession.metadata).toBeNull();
+  });
+
+  it('does nothing in Electron', () => {
+    vi.mocked(isElectron).mockReturnValue(true);
+    renderHook(() => useVoiceMediaSession(defaultOptions));
+    expect(mockSession.setActionHandler).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the Media Session API is absent', () => {
+    delete (navigator as { mediaSession?: unknown }).mediaSession;
+    expect(() => renderHook(() => useVoiceMediaSession(defaultOptions))).not.toThrow();
+  });
+
+  it('tolerates a mediaSession without setMicrophoneActive', () => {
+    delete (mockSession as { setMicrophoneActive?: unknown }).setMicrophoneActive;
+    expect(() => renderHook(() => useVoiceMediaSession(defaultOptions))).not.toThrow();
+    expect(mockSession.playbackState).toBe('playing');
+  });
+});

--- a/frontend/src/__tests__/utils/dnd.test.ts
+++ b/frontend/src/__tests__/utils/dnd.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { isDndActive, type ClientDndSettings } from '../../utils/dnd';
+
+const base: ClientDndSettings = {
+  doNotDisturb: true,
+  dndStartTime: null,
+  dndEndTime: null,
+};
+
+// Local-time dates (client DND evaluates against the device clock)
+const at = (hours: number, minutes = 0) => new Date(2026, 6, 3, hours, minutes);
+
+describe('isDndActive (client)', () => {
+  it('returns false when DND is off', () => {
+    expect(isDndActive({ ...base, doNotDisturb: false }, at(12))).toBe(false);
+  });
+
+  it('returns true for manual DND with no time window', () => {
+    expect(isDndActive(base, at(12))).toBe(true);
+  });
+
+  it('returns true for malformed times (fails closed to manual toggle)', () => {
+    expect(isDndActive({ ...base, dndStartTime: 'bogus', dndEndTime: '08:00' }, at(12))).toBe(true);
+  });
+
+  describe('same-day window', () => {
+    const window = { ...base, dndStartTime: '09:00', dndEndTime: '17:00' };
+
+    it('is active inside the window', () => {
+      expect(isDndActive(window, at(12, 30))).toBe(true);
+    });
+
+    it('is inactive outside the window', () => {
+      expect(isDndActive(window, at(8, 59))).toBe(false);
+      expect(isDndActive(window, at(18, 0))).toBe(false);
+    });
+
+    it('start is inclusive, end is exclusive', () => {
+      expect(isDndActive(window, at(9, 0))).toBe(true);
+      expect(isDndActive(window, at(17, 0))).toBe(false);
+    });
+  });
+
+  describe('overnight window', () => {
+    const overnight = { ...base, dndStartTime: '22:00', dndEndTime: '08:00' };
+
+    it('is active late at night and early morning', () => {
+      expect(isDndActive(overnight, at(23, 30))).toBe(true);
+      expect(isDndActive(overnight, at(3, 0))).toBe(true);
+    });
+
+    it('is inactive during the day', () => {
+      expect(isDndActive(overnight, at(12, 0))).toBe(false);
+    });
+  });
+
+  it('treats a degenerate window (start === end) as all-day DND', () => {
+    expect(isDndActive({ ...base, dndStartTime: '10:00', dndEndTime: '10:00' }, at(15))).toBe(true);
+  });
+});

--- a/frontend/src/__tests__/utils/installPrompt.test.ts
+++ b/frontend/src/__tests__/utils/installPrompt.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  canInstall,
+  promptInstall,
+  subscribeInstallPrompt,
+  _resetInstallPromptForTests,
+} from '../../utils/installPrompt';
+
+function fireBeforeInstallPrompt(outcome: 'accepted' | 'dismissed' = 'accepted') {
+  const event = new Event('beforeinstallprompt', { cancelable: true }) as Event & {
+    prompt: ReturnType<typeof vi.fn>;
+    userChoice: Promise<{ outcome: string; platform: string }>;
+  };
+  event.prompt = vi.fn().mockResolvedValue(undefined);
+  event.userChoice = Promise.resolve({ outcome, platform: 'web' });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe('installPrompt', () => {
+  beforeEach(() => {
+    _resetInstallPromptForTests();
+  });
+
+  it('starts with no install available', () => {
+    expect(canInstall()).toBe(false);
+  });
+
+  it('captures beforeinstallprompt and reports installable', () => {
+    const event = fireBeforeInstallPrompt();
+    expect(canInstall()).toBe(true);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('notifies subscribers when the prompt is captured', () => {
+    const listener = vi.fn();
+    subscribeInstallPrompt(listener);
+    fireBeforeInstallPrompt();
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('prompts, resolves the outcome, and consumes the event', async () => {
+    const event = fireBeforeInstallPrompt('accepted');
+
+    const outcome = await promptInstall();
+
+    expect(event.prompt).toHaveBeenCalled();
+    expect(outcome).toBe('accepted');
+    expect(canInstall()).toBe(false);
+  });
+
+  it('returns null when no prompt was captured', async () => {
+    expect(await promptInstall()).toBeNull();
+  });
+
+  it('clears the captured prompt on appinstalled', () => {
+    fireBeforeInstallPrompt();
+    expect(canInstall()).toBe(true);
+
+    window.dispatchEvent(new Event('appinstalled'));
+    expect(canInstall()).toBe(false);
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeInstallPrompt(listener);
+    unsubscribe();
+    fireBeforeInstallPrompt();
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/utils/livekitWorkerTimers.test.ts
+++ b/frontend/src/__tests__/utils/livekitWorkerTimers.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CriticalTimers } from 'livekit-client';
+import {
+  installLivekitWorkerTimers,
+  _uninstallLivekitWorkerTimersForTests,
+} from '../../utils/livekitWorkerTimers';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+let lastWorkerInstance: MockWorker | null = null;
+let workerShouldFail = false;
+
+class MockWorker {
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+  postMessage = vi.fn();
+  terminate = vi.fn();
+
+  constructor() {
+    if (workerShouldFail) {
+      throw new Error('Worker not supported');
+    }
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    lastWorkerInstance = this;
+  }
+
+  fire(id: number) {
+    this.onmessage?.({ data: { type: 'timer-fired', id } } as MessageEvent);
+  }
+}
+
+const OriginalWorker = globalThis.Worker;
+const nativeSetTimeout = CriticalTimers.setTimeout;
+const nativeSetInterval = CriticalTimers.setInterval;
+const nativeClearTimeout = CriticalTimers.clearTimeout;
+const nativeClearInterval = CriticalTimers.clearInterval;
+
+describe('livekitWorkerTimers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastWorkerInstance = null;
+    workerShouldFail = false;
+    globalThis.Worker = MockWorker as unknown as typeof Worker;
+  });
+
+  afterEach(() => {
+    _uninstallLivekitWorkerTimersForTests();
+    globalThis.Worker = OriginalWorker;
+  });
+
+  it('replaces CriticalTimers statics with worker-backed implementations', () => {
+    installLivekitWorkerTimers();
+
+    expect(lastWorkerInstance).not.toBeNull();
+    expect(CriticalTimers.setTimeout).not.toBe(nativeSetTimeout);
+    expect(CriticalTimers.setInterval).not.toBe(nativeSetInterval);
+    expect(CriticalTimers.clearTimeout).not.toBe(nativeClearTimeout);
+    expect(CriticalTimers.clearInterval).not.toBe(nativeClearInterval);
+  });
+
+  it('is idempotent — second install does not create a second worker', () => {
+    installLivekitWorkerTimers();
+    const first = lastWorkerInstance;
+    installLivekitWorkerTimers();
+    expect(lastWorkerInstance).toBe(first);
+  });
+
+  it('setTimeout posts set-timeout and fires callback once on timer-fired', () => {
+    installLivekitWorkerTimers();
+    const cb = vi.fn();
+
+    const handle = CriticalTimers.setTimeout(cb, 500, 'a', 'b');
+    const id = handle as unknown as number;
+
+    expect(id).toBeGreaterThanOrEqual(1);
+    expect(lastWorkerInstance!.postMessage).toHaveBeenCalledWith({
+      type: 'set-timeout',
+      id,
+      delay: 500,
+    });
+
+    lastWorkerInstance!.fire(id);
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith('a', 'b');
+
+    // One-shot: a stray second fire must not invoke the callback again
+    lastWorkerInstance!.fire(id);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('setInterval fires callback on every timer-fired message', () => {
+    installLivekitWorkerTimers();
+    const cb = vi.fn();
+
+    const id = CriticalTimers.setInterval(cb, 1000) as unknown as number;
+    expect(lastWorkerInstance!.postMessage).toHaveBeenCalledWith({
+      type: 'set-interval',
+      id,
+      delay: 1000,
+    });
+
+    lastWorkerInstance!.fire(id);
+    lastWorkerInstance!.fire(id);
+    lastWorkerInstance!.fire(id);
+    expect(cb).toHaveBeenCalledTimes(3);
+  });
+
+  it('clearTimeout posts clear-timer and prevents the callback from firing', () => {
+    installLivekitWorkerTimers();
+    const cb = vi.fn();
+
+    const handle = CriticalTimers.setTimeout(cb, 500);
+    const id = handle as unknown as number;
+    CriticalTimers.clearTimeout(handle);
+
+    expect(lastWorkerInstance!.postMessage).toHaveBeenCalledWith({
+      type: 'clear-timer',
+      id,
+    });
+
+    lastWorkerInstance!.fire(id);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('clearInterval stops an interval callback', () => {
+    installLivekitWorkerTimers();
+    const cb = vi.fn();
+
+    const handle = CriticalTimers.setInterval(cb, 1000);
+    lastWorkerInstance!.fire(handle as unknown as number);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    CriticalTimers.clearInterval(handle);
+    lastWorkerInstance!.fire(handle as unknown as number);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns distinct truthy ids across calls', () => {
+    installLivekitWorkerTimers();
+    const a = CriticalTimers.setTimeout(vi.fn(), 1) as unknown as number;
+    const b = CriticalTimers.setInterval(vi.fn(), 1) as unknown as number;
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(a).not.toBe(b);
+  });
+
+  it('leaves native timers in place when Worker construction throws', () => {
+    workerShouldFail = true;
+    installLivekitWorkerTimers();
+
+    expect(CriticalTimers.setTimeout).toBe(nativeSetTimeout);
+    expect(CriticalTimers.setInterval).toBe(nativeSetInterval);
+    expect(CriticalTimers.clearTimeout).toBe(nativeClearTimeout);
+    expect(CriticalTimers.clearInterval).toBe(nativeClearInterval);
+  });
+
+  it('reverts to native timers when the worker errors', () => {
+    installLivekitWorkerTimers();
+    const worker = lastWorkerInstance!;
+
+    worker.onerror?.({ message: 'script failed' } as ErrorEvent);
+
+    expect(CriticalTimers.setTimeout).toBe(nativeSetTimeout);
+    expect(CriticalTimers.setInterval).toBe(nativeSetInterval);
+    expect(worker.terminate).toHaveBeenCalled();
+
+    // A new install after revert should work again
+    installLivekitWorkerTimers();
+    expect(CriticalTimers.setTimeout).not.toBe(nativeSetTimeout);
+  });
+});

--- a/frontend/src/components/Settings/InstallAppSettings.tsx
+++ b/frontend/src/components/Settings/InstallAppSettings.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { Card, CardContent, Typography, Divider, Button, Box } from '@mui/material';
+import InstallDesktopIcon from '@mui/icons-material/InstallDesktop';
+import { useInstallPrompt } from '../../hooks/useInstallPrompt';
+import { logger } from '../../utils/logger';
+
+/**
+ * "Install app" section for the settings page. Rendered only when the
+ * browser has offered an install prompt (Chromium) and the app isn't
+ * already installed or running in Electron.
+ */
+const InstallAppSettings: React.FC = () => {
+  const { canInstall, promptInstall } = useInstallPrompt();
+  const [isPrompting, setIsPrompting] = useState(false);
+
+  if (!canInstall) {
+    return null;
+  }
+
+  const handleInstall = async () => {
+    setIsPrompting(true);
+    try {
+      const outcome = await promptInstall();
+      logger.info('[PWA] Install prompt outcome:', outcome);
+    } finally {
+      setIsPrompting(false);
+    }
+  };
+
+  return (
+    <Card sx={{ mb: 3 }}>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Install App
+        </Typography>
+        <Divider sx={{ mb: 2 }} />
+        <Typography variant="body2" color="text.secondary" paragraph>
+          Install Semaphore Chat on this device for faster access, its own
+          window, and better notification support.
+        </Typography>
+        <Box>
+          <Button
+            variant="contained"
+            startIcon={<InstallDesktopIcon />}
+            onClick={handleInstall}
+            disabled={isPrompting}
+          >
+            Install app
+          </Button>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default InstallAppSettings;

--- a/frontend/src/components/Settings/NotificationSettings.tsx
+++ b/frontend/src/components/Settings/NotificationSettings.tsx
@@ -124,7 +124,10 @@ export const NotificationSettings: React.FC = () => {
 
   const handleSave = async () => {
     try {
-      await updateSettings({ body: formValues });
+      // Stamp the device timezone so the backend can evaluate the DND
+      // window in the user's local time when sending push notifications
+      const dndTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      await updateSettings({ body: { ...formValues, dndTimezone } });
       setSaveSuccess(true);
       setTimeout(() => setSaveSuccess(false), 3000);
     } catch (error) {

--- a/frontend/src/components/Voice/VoiceBottomBar.tsx
+++ b/frontend/src/components/Voice/VoiceBottomBar.tsx
@@ -48,6 +48,8 @@ import { LAYOUT_CONSTANTS } from "../../utils/breakpoints";
 import { useSpeaking } from "../../hooks/useSpeaking";
 import { useVoicePresenceHeartbeat } from "../../hooks/useVoicePresenceHeartbeat";
 import { useBackgroundVoiceKeepAlive } from "../../hooks/useBackgroundVoiceKeepAlive";
+import { useVoiceMediaSession } from "../../hooks/useVoiceMediaSession";
+import { useVoiceForegroundResync } from "../../hooks/useVoiceForegroundResync";
 import { useServerMuteEffect } from "../../hooks/useServerMuteEffect";
 import { useRemoteVolumeEffect } from "../../hooks/useRemoteVolumeEffect";
 import { useCurrentUser } from "../../hooks/useCurrentUser";
@@ -75,6 +77,26 @@ export const VoiceBottomBar: React.FC = () => {
 
   // Prevent tab freeze / OS suspension while in voice
   useBackgroundVoiceKeepAlive({ isConnected: state.isConnected });
+
+  // Surface the call via the Media Session API (Android ongoing-call
+  // notification + higher background process priority, see #350)
+  useVoiceMediaSession({
+    isConnected: state.isConnected,
+    contextName: state.channelName ?? state.dmGroupName,
+    isMicrophoneEnabled,
+    onHangup: actions.leaveVoiceChannel,
+    onToggleMic: actions.toggleMute,
+  });
+
+  // Recover calls that silently died while backgrounded/locked (#350)
+  useVoiceForegroundResync({
+    room: state.room,
+    state,
+    actions: {
+      joinVoiceChannel: actions.joinVoiceChannel,
+      joinDmVoice: actions.joinDmVoice,
+    },
+  });
 
   // Keep voice presence TTL alive in Redis while connected
   useVoicePresenceHeartbeat({

--- a/frontend/src/features/voice/voiceActions.ts
+++ b/frontend/src/features/voice/voiceActions.ts
@@ -9,6 +9,7 @@ import { logger } from "../../utils/logger";
 import { isElectron } from "../../utils/platform";
 import { getCachedItem, setCachedItem, removeCachedItem } from "../../utils/storage";
 import { refreshToken as refreshAuthToken } from "../../utils/tokenService";
+import { installLivekitWorkerTimers } from "../../utils/livekitWorkerTimers";
 import { playSound, Sounds } from "../../hooks/useSound";
 
 // Storage key must match useDeviceSettings.ts
@@ -175,6 +176,9 @@ async function connectToLiveKitRoom(
   dispatch: React.Dispatch<VoiceAction>
 ): Promise<Room> {
   logger.info('[Voice] Creating new LiveKit room instance');
+  // Route livekit's connection-critical timers through a Web Worker so
+  // background-tab timer throttling can't starve ping/pong on mobile (#350).
+  installLivekitWorkerTimers();
   const room = new Room();
 
   // Register connection state monitoring before connecting so we catch

--- a/frontend/src/hooks/useAppBadge.ts
+++ b/frontend/src/hooks/useAppBadge.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { notificationsControllerGetUnreadCountOptions } from '../api-client/@tanstack/react-query.gen';
+
+/**
+ * Mirrors the unread notification count onto:
+ *  - the installed PWA's icon via the Badging API (Android home screen /
+ *    desktop taskbar; Chromium-only, feature-detected), and
+ *  - the document title as a "(N) " prefix for browser-tab users.
+ *
+ * The unread-count query cache is kept live by the socket-hub notification
+ * handlers, so this re-renders on every unread change without polling.
+ */
+export function useAppBadge(baseTitle: string): void {
+  const { data } = useQuery(notificationsControllerGetUnreadCountOptions());
+  const unreadCount = data?.count ?? 0;
+
+  // PWA icon badge
+  useEffect(() => {
+    if (!('setAppBadge' in navigator)) {
+      return;
+    }
+    const nav = navigator as Navigator & {
+      setAppBadge: (count?: number) => Promise<void>;
+      clearAppBadge: () => Promise<void>;
+    };
+    if (unreadCount > 0) {
+      nav.setAppBadge(unreadCount).catch(() => {});
+    } else {
+      nav.clearAppBadge().catch(() => {});
+    }
+  }, [unreadCount]);
+
+  // Tab title unread prefix
+  useEffect(() => {
+    document.title = unreadCount > 0 ? `(${unreadCount}) ${baseTitle}` : baseTitle;
+  }, [unreadCount, baseTitle]);
+}

--- a/frontend/src/hooks/useInstallPrompt.ts
+++ b/frontend/src/hooks/useInstallPrompt.ts
@@ -1,0 +1,27 @@
+import { useSyncExternalStore, useCallback } from 'react';
+import { isElectron } from '../utils/platform';
+import {
+  canInstall,
+  isStandalone,
+  promptInstall,
+  subscribeInstallPrompt,
+} from '../utils/installPrompt';
+
+/**
+ * Exposes the captured PWA install prompt (see utils/installPrompt.ts).
+ * `canInstall` is false in Electron, when already installed (standalone),
+ * or when the browser hasn't offered an install prompt.
+ */
+export function useInstallPrompt(): {
+  canInstall: boolean;
+  promptInstall: () => Promise<'accepted' | 'dismissed' | null>;
+} {
+  const installAvailable = useSyncExternalStore(subscribeInstallPrompt, canInstall);
+
+  const handlePrompt = useCallback(() => promptInstall(), []);
+
+  return {
+    canInstall: installAvailable && !isElectron() && !isStandalone(),
+    promptInstall: handlePrompt,
+  };
+}

--- a/frontend/src/hooks/useNotificationSideEffects.ts
+++ b/frontend/src/hooks/useNotificationSideEffects.ts
@@ -11,9 +11,12 @@
 
 import { useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { ServerEvents, NotificationType } from '@semaphore-chat/shared';
 import type { NewNotificationPayload } from '@semaphore-chat/shared';
+import { notificationsControllerGetSettingsOptions } from '../api-client/@tanstack/react-query.gen';
 import { useServerEvent } from '../socket-hub/useServerEvent';
+import { isDndActive } from '../utils/dnd';
 import {
   showNotification,
   formatNotificationContent,
@@ -55,11 +58,17 @@ export function useNotificationSideEffects(options: UseNotificationSideEffectsOp
   const isFocused = useWindowFocus();
   const notificationsRef = useRef<Map<string, NewNotificationPayload>>(new Map());
 
+  // Notification settings for Do-Not-Disturb evaluation (cache is updated
+  // when the user saves settings, so this rarely refetches)
+  const { data: notificationSettings } = useQuery(notificationsControllerGetSettingsOptions());
+
   // Use refs to avoid stale closures in the useServerEvent callback
   const isFocusedRef = useRef(isFocused);
   isFocusedRef.current = isFocused;
   const locationRef = useRef(location);
   locationRef.current = location;
+  const settingsRef = useRef(notificationSettings);
+  settingsRef.current = notificationSettings;
 
   const navigateToNotification = useCallback(
     (notification: { communityId?: string | null; channelId?: string | null; directMessageGroupId?: string | null }) => {
@@ -107,6 +116,14 @@ export function useNotificationSideEffects(options: UseNotificationSideEffectsOp
     })();
 
     if (isViewingContext) return;
+
+    // Do-Not-Disturb suppresses sounds + desktop notifications (cache/unread
+    // updates in notificationHandlers.ts are unaffected)
+    const settings = settingsRef.current;
+    if (settings && isDndActive(settings)) {
+      logger.dev('[Notifications] DND active — suppressing side effects');
+      return;
+    }
 
     // Sound — pick the right sound based on notification type
     if (playSound) {

--- a/frontend/src/hooks/useVoiceForegroundResync.ts
+++ b/frontend/src/hooks/useVoiceForegroundResync.ts
@@ -1,0 +1,155 @@
+import { useEffect, useRef } from 'react';
+import { Room, RoomEvent, ConnectionState, DisconnectReason } from 'livekit-client';
+import { useVoiceDispatch, VoiceActionType, VoiceSessionType, type VoiceState } from '../contexts/VoiceContext';
+import { logger } from '../utils/logger';
+
+interface ResyncActions {
+  joinVoiceChannel: (
+    channelId: string,
+    channelName: string,
+    communityId: string,
+    isPrivate: boolean,
+    createdAt: string
+  ) => Promise<void>;
+  joinDmVoice: (dmGroupId: string, dmGroupName: string) => Promise<void>;
+}
+
+interface UseVoiceForegroundResyncOptions {
+  room: Room | null;
+  state: VoiceState;
+  actions: ResyncActions;
+}
+
+/**
+ * Reconciles voice state when the app returns to the foreground (#350).
+ *
+ * While backgrounded/locked on Android, the LiveKit connection can die in
+ * ways the app never observes: the server drops a ping-starved connection,
+ * or livekit's own `freeze` listener disconnects with CLIENT_INITIATED —
+ * indistinguishable from a user hangup at the Room level. Detection is
+ * therefore a state mismatch (room dead while voice context says
+ * connected), never the disconnect reason.
+ *
+ * On becoming visible:
+ *  - room dead but context says connected → rejoin once from live context
+ *    state (NOT the localStorage saved-connection; its 5-minute expiry is
+ *    too short for a locked phone). On failure, dispatch SetDisconnected
+ *    so the UI stops claiming the call is alive.
+ *  - room connected but audio playback blocked (suspended AudioContext /
+ *    autoplay block after backgrounding) → room.startAudio(). livekit only
+ *    does this itself on iOS.
+ *
+ * Also rejoins when an unexpected disconnect happens while visible, so
+ * server-side drops recover without waiting for a visibility change.
+ */
+export function useVoiceForegroundResync({ room, state, actions }: UseVoiceForegroundResyncOptions): void {
+  const { dispatch } = useVoiceDispatch();
+  const resyncInProgressRef = useRef(false);
+
+  // Keep latest values in refs so the event listeners never go stale.
+  const latestRef = useRef({ room, state, actions, dispatch });
+  latestRef.current = { room, state, actions, dispatch };
+
+  const runResync = async (trigger: string) => {
+    const { room, state, actions, dispatch } = latestRef.current;
+
+    if (resyncInProgressRef.current || !state.isConnected || state.isConnecting) {
+      return;
+    }
+
+    const roomDead = !room || room.state === ConnectionState.Disconnected;
+    if (roomDead) {
+      resyncInProgressRef.current = true;
+      logger.warn(`[Voice] Room dead while context connected (${trigger}) — rejoining`);
+      try {
+        if (state.contextType === VoiceSessionType.Dm && state.currentDmGroupId && state.dmGroupName) {
+          await actions.joinDmVoice(state.currentDmGroupId, state.dmGroupName);
+        } else if (
+          state.currentChannelId &&
+          state.channelName &&
+          state.communityId &&
+          state.isPrivate !== null &&
+          state.createdAt
+        ) {
+          await actions.joinVoiceChannel(
+            state.currentChannelId,
+            state.channelName,
+            state.communityId,
+            state.isPrivate,
+            state.createdAt
+          );
+        } else {
+          logger.error('[Voice] Cannot rejoin: incomplete voice context state');
+          dispatch({ type: VoiceActionType.SetDisconnected });
+        }
+        logger.info('[Voice] Foreground resync rejoin complete');
+      } catch (error) {
+        logger.error('[Voice] Foreground resync rejoin failed:', error);
+        // joinVoiceChannel/joinDmVoice already dispatched SetConnectionError;
+        // make the UI honest about the dead call.
+        dispatch({ type: VoiceActionType.SetDisconnected });
+      } finally {
+        resyncInProgressRef.current = false;
+      }
+      return;
+    }
+
+    if (room.state === ConnectionState.Connected && !room.canPlaybackAudio) {
+      logger.info(`[Voice] Audio playback blocked after ${trigger} — calling startAudio()`);
+      try {
+        await room.startAudio();
+      } catch (error) {
+        logger.warn('[Voice] startAudio() failed (will retry on next foreground):', error);
+      }
+    }
+  };
+
+  // Foreground transitions
+  useEffect(() => {
+    if (!state.isConnected) {
+      return;
+    }
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        void runResync('visibilitychange');
+      }
+    };
+    const handlePageShow = () => void runResync('pageshow');
+    const handleResume = () => void runResync('resume');
+
+    document.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('pageshow', handlePageShow);
+    // Page Lifecycle API: fired when a frozen page is resumed (Chromium)
+    document.addEventListener('resume', handleResume);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('pageshow', handlePageShow);
+      document.removeEventListener('resume', handleResume);
+    };
+  }, [state.isConnected]);
+
+  // Unexpected disconnect while visible → recover immediately
+  useEffect(() => {
+    if (!room) {
+      return;
+    }
+
+    const handleDisconnected = (reason?: DisconnectReason) => {
+      if (reason === DisconnectReason.CLIENT_INITIATED) {
+        // User hangup or livekit's freeze-listener; the freeze case is
+        // reconciled on the next foreground transition instead.
+        return;
+      }
+      if (document.visibilityState === 'visible') {
+        void runResync('unexpected-disconnect');
+      }
+    };
+
+    room.on(RoomEvent.Disconnected, handleDisconnected);
+    return () => {
+      room.off(RoomEvent.Disconnected, handleDisconnected);
+    };
+  }, [room]);
+}

--- a/frontend/src/hooks/useVoiceMediaSession.ts
+++ b/frontend/src/hooks/useVoiceMediaSession.ts
@@ -1,0 +1,88 @@
+import { useEffect } from 'react';
+import { isElectron } from '../utils/platform';
+import { logger } from '../utils/logger';
+
+// 'hangup' / 'togglemicrophone' are in the Media Session spec (video
+// conferencing actions) but missing from the TS DOM lib's union.
+type ExtendedMediaSessionAction = MediaSessionAction | 'hangup' | 'togglemicrophone';
+
+interface UseVoiceMediaSessionOptions {
+  isConnected: boolean;
+  /** Display name of the voice context (channel or DM group). */
+  contextName: string | null;
+  isMicrophoneEnabled: boolean;
+  onHangup: () => void;
+  onToggleMic: () => void;
+}
+
+/**
+ * Registers the active voice call with the browser's Media Session API.
+ *
+ * On Android Chrome this surfaces an ongoing call-style notification with
+ * hangup/mic actions and — critically for #350 — raises the tab's process
+ * priority so the call is less likely to be starved while the app is
+ * backgrounded or the screen is locked.
+ *
+ * Web only: Electron uses powerSaveBlocker instead, and an OS media overlay
+ * for a voice call would be surprising on desktop.
+ */
+export function useVoiceMediaSession({
+  isConnected,
+  contextName,
+  isMicrophoneEnabled,
+  onHangup,
+  onToggleMic,
+}: UseVoiceMediaSessionOptions): void {
+  useEffect(() => {
+    if (!isConnected || isElectron() || !('mediaSession' in navigator)) {
+      return;
+    }
+
+    const mediaSession = navigator.mediaSession;
+
+    // setActionHandler throws TypeError for actions the browser doesn't
+    // support (hangup/togglemicrophone are newer, Chromium-only), so each
+    // registration is wrapped individually.
+    const trySetHandler = (
+      action: ExtendedMediaSessionAction,
+      handler: MediaSessionActionHandler | null
+    ) => {
+      try {
+        mediaSession.setActionHandler(action as MediaSessionAction, handler);
+      } catch {
+        logger.info('[Voice] MediaSession action not supported:', action);
+      }
+    };
+
+    mediaSession.metadata = new MediaMetadata({
+      title: contextName ?? 'Voice call',
+      artist: 'Semaphore Chat',
+    });
+    mediaSession.playbackState = 'playing';
+    trySetHandler('hangup', () => onHangup());
+    trySetHandler('togglemicrophone', () => onToggleMic());
+
+    return () => {
+      trySetHandler('hangup', null);
+      trySetHandler('togglemicrophone', null);
+      mediaSession.playbackState = 'none';
+      mediaSession.metadata = null;
+    };
+  }, [isConnected, contextName, onHangup, onToggleMic]);
+
+  // Mirror the mic state into the call notification's mic indicator.
+  // setMicrophoneActive is Chromium-only and recent — feature-detected.
+  useEffect(() => {
+    if (!isConnected || isElectron() || !('mediaSession' in navigator)) {
+      return;
+    }
+    const mediaSession = navigator.mediaSession as MediaSession & {
+      setMicrophoneActive?: (active: boolean) => void;
+    };
+    try {
+      mediaSession.setMicrophoneActive?.(isMicrophoneEnabled);
+    } catch {
+      // Not supported — ignore.
+    }
+  }, [isConnected, isMicrophoneEnabled]);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,6 +12,10 @@ import { queryClient } from "./queryClient";
 // Configure the generated API client (auth interceptors, base URL)
 configureApiClient();
 
+// Capture the PWA install prompt as early as possible — the browser can
+// fire beforeinstallprompt before React mounts (side-effect import)
+import "./utils/installPrompt";
+
 // Register service worker only in web browser (not Electron file:// context)
 if (!isElectron()) {
   import("virtual:pwa-register")

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -27,6 +27,7 @@ import {
 } from '@mui/icons-material';
 import axios from 'axios';
 import NotificationSettings from '../components/Settings/NotificationSettings';
+import InstallAppSettings from '../components/Settings/InstallAppSettings';
 import VoiceSettings from '../components/Settings/VoiceSettings';
 import SessionsSettings from '../components/Settings/SessionsSettings';
 import {
@@ -303,6 +304,9 @@ const SettingsPage: React.FC = () => {
       <Typography variant="h4" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         <Settings /> Settings
       </Typography>
+
+      {/* Install App Section (web, only when installable) */}
+      <InstallAppSettings />
 
       {/* Notification Settings Section */}
       <Box sx={{ mb: 3 }}>

--- a/frontend/src/sw-custom.ts
+++ b/frontend/src/sw-custom.ts
@@ -88,12 +88,25 @@ self.addEventListener('push', (event: PushEvent) => {
     requireInteraction: false,
   };
 
+  // Flag the app icon (Badging API, Chromium-only). Count-less form: the SW
+  // doesn't know the total unread count; the app sets the exact count via
+  // useAppBadge whenever it's running.
+  (self.navigator as Navigator & { setAppBadge?: () => Promise<void> })
+    .setAppBadge?.()
+    .catch(() => {});
+
   event.waitUntil(self.registration.showNotification(data.title, options));
 });
 
 // Handle notification click
 self.addEventListener('notificationclick', (event: NotificationEvent) => {
   event.notification.close();
+
+  // Clear the SW-set badge flag; once the app opens, useAppBadge takes over
+  // with the exact unread count.
+  (self.navigator as Navigator & { clearAppBadge?: () => Promise<void> })
+    .clearAppBadge?.()
+    .catch(() => {});
 
   const data = event.notification.data as PushNotificationData['data'];
 

--- a/frontend/src/sw-custom.ts
+++ b/frontend/src/sw-custom.ts
@@ -61,6 +61,23 @@ interface PushNotificationData {
   };
 }
 
+/**
+ * Set or clear the app-icon badge flag (Badging API, Chromium-only).
+ * Always resolves — feature-detected and error-swallowed so badge support
+ * can never break notification delivery or click handling.
+ */
+function setBadgeFlag(on: boolean): Promise<void> {
+  const nav = self.navigator as Navigator & {
+    setAppBadge?: () => Promise<void>;
+    clearAppBadge?: () => Promise<void>;
+  };
+  const fn = on ? nav.setAppBadge : nav.clearAppBadge;
+  if (typeof fn !== 'function') {
+    return Promise.resolve();
+  }
+  return fn.call(nav).catch(() => {});
+}
+
 // Handle push notifications
 self.addEventListener('push', (event: PushEvent) => {
   if (!event.data) {
@@ -88,25 +105,20 @@ self.addEventListener('push', (event: PushEvent) => {
     requireInteraction: false,
   };
 
-  // Flag the app icon (Badging API, Chromium-only). Count-less form: the SW
-  // doesn't know the total unread count; the app sets the exact count via
-  // useAppBadge whenever it's running.
-  (self.navigator as Navigator & { setAppBadge?: () => Promise<void> })
-    .setAppBadge?.()
-    .catch(() => {});
-
-  event.waitUntil(self.registration.showNotification(data.title, options));
+  event.waitUntil(
+    Promise.all([
+      self.registration.showNotification(data.title, options),
+      // Flag the app icon (Badging API, Chromium-only). Count-less form: the
+      // SW doesn't know the total unread count; the app sets the exact count
+      // via useAppBadge whenever it's running.
+      setBadgeFlag(true),
+    ]),
+  );
 });
 
 // Handle notification click
 self.addEventListener('notificationclick', (event: NotificationEvent) => {
   event.notification.close();
-
-  // Clear the SW-set badge flag; once the app opens, useAppBadge takes over
-  // with the exact unread count.
-  (self.navigator as Navigator & { clearAppBadge?: () => Promise<void> })
-    .clearAppBadge?.()
-    .catch(() => {});
 
   const data = event.notification.data as PushNotificationData['data'];
 
@@ -120,9 +132,13 @@ self.addEventListener('notificationclick', (event: NotificationEvent) => {
 
   const targetUrl = new URL(`/${hash}`, self.location.origin).href;
 
-  // Focus existing same-origin window or open new one
+  // Clear the SW-set badge flag, then focus an existing same-origin window
+  // or open a new one; once the app opens, useAppBadge takes over with the
+  // exact unread count.
   event.waitUntil(
-    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(async (clients) => {
+    setBadgeFlag(false).then(() =>
+      self.clients.matchAll({ type: 'window', includeUncontrolled: true }),
+    ).then(async (clients) => {
       const existing = clients.find(
         (c) => new URL(c.url).origin === self.location.origin,
       );

--- a/frontend/src/utils/dnd.ts
+++ b/frontend/src/utils/dnd.ts
@@ -1,0 +1,54 @@
+/**
+ * Client-side Do-Not-Disturb evaluation.
+ *
+ * Mirrors backend/src/notifications/dnd.util.ts, but evaluates against the
+ * device's local wall clock (no timezone plumbing needed — the user's DND
+ * window is defined in their own local time).
+ *
+ * DND suppresses delivery side effects only (sounds, desktop
+ * notifications) — never cache updates or unread badges.
+ */
+
+export interface ClientDndSettings {
+  doNotDisturb: boolean;
+  dndStartTime: string | null;
+  dndEndTime: string | null;
+}
+
+const TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+function parseTime(value: string | null): number | null {
+  if (!value || !TIME_PATTERN.test(value)) {
+    return null;
+  }
+  const [hours, minutes] = value.split(':').map(Number);
+  return hours * 60 + minutes;
+}
+
+/**
+ * Whether DND is in effect right now, in device-local time.
+ * - DND off → false
+ * - DND on with no/malformed window → true (manual toggle)
+ * - Overnight windows (start > end, e.g. 22:00–08:00) wrap midnight.
+ */
+export function isDndActive(settings: ClientDndSettings, now: Date = new Date()): boolean {
+  if (!settings.doNotDisturb) {
+    return false;
+  }
+
+  const start = parseTime(settings.dndStartTime);
+  const end = parseTime(settings.dndEndTime);
+  if (start === null || end === null) {
+    return true;
+  }
+
+  const current = now.getHours() * 60 + now.getMinutes();
+  if (start === end) {
+    // Degenerate window — treat as all-day DND
+    return true;
+  }
+  if (start > end) {
+    return current >= start || current < end;
+  }
+  return current >= start && current < end;
+}

--- a/frontend/src/utils/installPrompt.ts
+++ b/frontend/src/utils/installPrompt.ts
@@ -1,0 +1,79 @@
+/**
+ * PWA install-prompt capture.
+ *
+ * Chromium fires `beforeinstallprompt` once, often before React mounts, so
+ * the listener must be registered at module-import time (imported for side
+ * effect in main.tsx). The deferred event is held here and exposed to the
+ * UI via useInstallPrompt().
+ */
+
+export interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
+type Listener = () => void;
+
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+const listeners = new Set<Listener>();
+
+function notify(): void {
+  listeners.forEach((listener) => listener());
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeinstallprompt', (event) => {
+    // Suppress the browser's mini-infobar; we surface our own button
+    event.preventDefault();
+    deferredPrompt = event as BeforeInstallPromptEvent;
+    notify();
+  });
+
+  window.addEventListener('appinstalled', () => {
+    deferredPrompt = null;
+    notify();
+  });
+}
+
+/** Whether an install prompt has been captured and can be shown. */
+export function canInstall(): boolean {
+  return deferredPrompt !== null;
+}
+
+/** Whether the app is already running as an installed PWA. */
+export function isStandalone(): boolean {
+  return (
+    window.matchMedia?.('(display-mode: standalone)').matches ||
+    // iOS Safari legacy flag
+    (navigator as Navigator & { standalone?: boolean }).standalone === true
+  );
+}
+
+/**
+ * Show the browser install prompt. Returns the user's choice, or null if
+ * no prompt is available. The captured event is single-use.
+ */
+export async function promptInstall(): Promise<'accepted' | 'dismissed' | null> {
+  if (!deferredPrompt) {
+    return null;
+  }
+  const prompt = deferredPrompt;
+  await prompt.prompt();
+  const { outcome } = await prompt.userChoice;
+  // The event can only be used once regardless of outcome
+  deferredPrompt = null;
+  notify();
+  return outcome;
+}
+
+/** Subscribe to install-availability changes. Returns an unsubscribe fn. */
+export function subscribeInstallPrompt(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/** Test-only: reset captured state. */
+export function _resetInstallPromptForTests(): void {
+  deferredPrompt = null;
+  listeners.clear();
+}

--- a/frontend/src/utils/livekitWorkerTimers.ts
+++ b/frontend/src/utils/livekitWorkerTimers.ts
@@ -1,0 +1,130 @@
+import { CriticalTimers } from 'livekit-client';
+import { logger } from './logger';
+
+/**
+ * Backs livekit-client's CriticalTimers with Web Worker timers.
+ *
+ * Chrome intensively throttles main-thread setTimeout/setInterval in
+ * backgrounded/locked tabs (1 fire per minute after ~5 minutes), which
+ * starves livekit's signal ping/pong and reconnect timers and silently
+ * kills voice calls on mobile (#350). Worker timers are exempt from that
+ * throttling, so we route CriticalTimers through the shared
+ * background-timer worker.
+ *
+ * Handle contract: livekit only ever passes the values returned by
+ * CriticalTimers.setTimeout/setInterval back to CriticalTimers.clearTimeout/
+ * clearInterval (verified against livekit-client 2.13 — every call site
+ * pairs CriticalTimers.set* with CriticalTimers.clear*). That lets us
+ * return our own numeric ids instead of native timer handles. Revisit if
+ * a livekit upgrade ever mixes native clearTimeout with these handles.
+ */
+
+type TimerCallback = (...args: unknown[]) => void;
+
+interface PendingTimer {
+  fn: TimerCallback;
+  args: unknown[];
+  /** One-shot timers are removed from the map when they fire. */
+  once: boolean;
+}
+
+let worker: Worker | null = null;
+let installed = false;
+// Start at 1 so ids are always truthy (livekit does `if (this.pingTimeout)`).
+let nextId = 1;
+const pending = new Map<number, PendingTimer>();
+
+const nativeTimers = {
+  setTimeout: CriticalTimers.setTimeout,
+  setInterval: CriticalTimers.setInterval,
+  clearTimeout: CriticalTimers.clearTimeout,
+  clearInterval: CriticalTimers.clearInterval,
+};
+
+function revertToNativeTimers(): void {
+  CriticalTimers.setTimeout = nativeTimers.setTimeout;
+  CriticalTimers.setInterval = nativeTimers.setInterval;
+  CriticalTimers.clearTimeout = nativeTimers.clearTimeout;
+  CriticalTimers.clearInterval = nativeTimers.clearInterval;
+  worker?.terminate();
+  worker = null;
+  installed = false;
+  pending.clear();
+}
+
+/**
+ * Override livekit's CriticalTimers with worker-backed implementations.
+ * Idempotent; call before constructing a Room. Falls back to (or reverts
+ * to) native timers if the worker can't be created or errors, in which
+ * case livekit behaves exactly as before this override existed.
+ */
+export function installLivekitWorkerTimers(): void {
+  if (installed || typeof Worker === 'undefined') {
+    return;
+  }
+
+  try {
+    worker = new Worker(
+      new URL('../workers/background-timer.worker.ts', import.meta.url),
+      { type: 'module' }
+    );
+  } catch (error) {
+    logger.warn('[Voice] Background timer worker unavailable, livekit timers stay native:', error);
+    worker = null;
+    return;
+  }
+
+  worker.onmessage = (e: MessageEvent) => {
+    if (e.data?.type !== 'timer-fired') {
+      return;
+    }
+    const timer = pending.get(e.data.id);
+    if (!timer) {
+      return;
+    }
+    if (timer.once) {
+      pending.delete(e.data.id);
+    }
+    timer.fn(...timer.args);
+  };
+
+  worker.onerror = (event) => {
+    // Worker script failed — revert so livekit's own timers keep working.
+    // Any in-flight SDK timers are lost, but livekit's connection-reconcile
+    // watchdog re-arms itself and self-heals.
+    logger.error('[Voice] Background timer worker errored, reverting livekit timers to native:', event.message);
+    revertToNativeTimers();
+  };
+
+  CriticalTimers.setTimeout = ((fn: TimerCallback, delay?: number, ...args: unknown[]) => {
+    const id = nextId++;
+    pending.set(id, { fn, args, once: true });
+    worker?.postMessage({ type: 'set-timeout', id, delay: delay ?? 0 });
+    return id as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof CriticalTimers.setTimeout;
+
+  CriticalTimers.setInterval = ((fn: TimerCallback, delay?: number, ...args: unknown[]) => {
+    const id = nextId++;
+    pending.set(id, { fn, args, once: false });
+    worker?.postMessage({ type: 'set-interval', id, delay: delay ?? 0 });
+    return id as unknown as ReturnType<typeof setInterval>;
+  }) as typeof CriticalTimers.setInterval;
+
+  CriticalTimers.clearTimeout = ((handle: unknown) => {
+    const id = handle as number;
+    if (pending.delete(id)) {
+      worker?.postMessage({ type: 'clear-timer', id });
+    }
+  }) as typeof CriticalTimers.clearTimeout;
+
+  CriticalTimers.clearInterval = CriticalTimers.clearTimeout as typeof CriticalTimers.clearInterval;
+
+  installed = true;
+  logger.info('[Voice] livekit CriticalTimers now worker-backed (background-throttling safe)');
+}
+
+/** Test-only: undo the override and reset module state. */
+export function _uninstallLivekitWorkerTimersForTests(): void {
+  revertToNativeTimers();
+  nextId = 1;
+}

--- a/frontend/src/workers/background-timer.worker.ts
+++ b/frontend/src/workers/background-timer.worker.ts
@@ -25,6 +25,11 @@ const timers = new Map<string, ReturnType<typeof setInterval>>();
 const idTimers = new Map<number, ReturnType<typeof setTimeout>>();
 
 self.onmessage = (e: MessageEvent) => {
+  // Guard against malformed messages — a destructuring throw here would
+  // crash the worker and silently kill every timer it manages.
+  if (typeof e.data !== 'object' || e.data === null) {
+    return;
+  }
   const { type, name, interval, id, delay } = e.data;
 
   switch (type) {

--- a/frontend/src/workers/background-timer.worker.ts
+++ b/frontend/src/workers/background-timer.worker.ts
@@ -1,23 +1,31 @@
 /**
  * Background Timer Worker
  *
- * Manages multiple named interval timers inside a Web Worker.
- * Web Worker timers are NOT subject to background-tab throttling,
- * so they keep firing at full speed even when the page is hidden.
+ * Manages timers inside a Web Worker. Web Worker timers are NOT subject
+ * to background-tab throttling, so they keep firing at full speed even
+ * when the page is hidden or the device screen is locked.
  *
- * Messages IN:
- *   { type: 'start', name: string, interval: number }
- *   { type: 'stop',  name: string }
- *   { type: 'stop-all' }
+ * Two independent protocols share this worker:
  *
- * Messages OUT:
- *   { type: 'tick', name: string }
+ * Named repeating intervals (used by useVoicePresenceHeartbeat):
+ *   IN:  { type: 'start', name: string, interval: number }
+ *        { type: 'stop',  name: string }
+ *        { type: 'stop-all' }
+ *   OUT: { type: 'tick', name: string }
+ *
+ * Id-based one-shot/interval timers (used by livekitWorkerTimers to back
+ * livekit-client's CriticalTimers):
+ *   IN:  { type: 'set-timeout',  id: number, delay: number }
+ *        { type: 'set-interval', id: number, delay: number }
+ *        { type: 'clear-timer',  id: number }
+ *   OUT: { type: 'timer-fired', id: number }
  */
 
 const timers = new Map<string, ReturnType<typeof setInterval>>();
+const idTimers = new Map<number, ReturnType<typeof setTimeout>>();
 
 self.onmessage = (e: MessageEvent) => {
-  const { type, name, interval } = e.data;
+  const { type, name, interval, id, delay } = e.data;
 
   switch (type) {
     case 'start': {
@@ -26,25 +34,57 @@ self.onmessage = (e: MessageEvent) => {
       if (existing !== undefined) {
         clearInterval(existing);
       }
-      const id = setInterval(() => {
+      const timerId = setInterval(() => {
         self.postMessage({ type: 'tick', name });
       }, interval);
-      timers.set(name, id);
+      timers.set(name, timerId);
       break;
     }
 
     case 'stop': {
-      const id = timers.get(name);
-      if (id !== undefined) {
-        clearInterval(id);
+      const timerId = timers.get(name);
+      if (timerId !== undefined) {
+        clearInterval(timerId);
         timers.delete(name);
       }
       break;
     }
 
     case 'stop-all': {
-      timers.forEach((id) => clearInterval(id));
+      timers.forEach((timerId) => clearInterval(timerId));
       timers.clear();
+      break;
+    }
+
+    case 'set-timeout': {
+      idTimers.set(
+        id,
+        setTimeout(() => {
+          idTimers.delete(id);
+          self.postMessage({ type: 'timer-fired', id });
+        }, delay)
+      );
+      break;
+    }
+
+    case 'set-interval': {
+      idTimers.set(
+        id,
+        setInterval(() => {
+          self.postMessage({ type: 'timer-fired', id });
+        }, delay)
+      );
+      break;
+    }
+
+    case 'clear-timer': {
+      const timerId = idTimers.get(id);
+      if (timerId !== undefined) {
+        // Works for both: clearTimeout and clearInterval are interchangeable
+        clearTimeout(timerId);
+        clearInterval(timerId as ReturnType<typeof setInterval>);
+        idTimers.delete(id);
+      }
       break;
     }
   }


### PR DESCRIPTION
Fixes #350.

## The bug

On Android, a voice call joined via the installed PWA loses audio when the phone is locked or the app is backgrounded for a few minutes, while the UI keeps showing "joined".

**Root cause:** Chrome intensively throttles background-tab JS timers (1 fire/min after ~5 min). livekit-client routes its signal ping/pong, reconnect scheduling, and connection watchdog through its `CriticalTimers` statics, which default to native `setTimeout`/`setInterval` — so pings stop, the server drops the connection, and the equally-throttled client never notices. Tabs playing *audible* audio are exempt, which is why active conversation survives but quiet/muted calls die. Two aggravating factors found in our code: the `RoomEvent.Disconnected` handler only *logged* unexpected disconnects (UI claims "joined" forever), and livekit's own `freeze` listener deliberately disconnects (as `CLIENT_INITIATED`) if Chrome freezes the tab anyway.

## The fix (commit 1)

1. **Worker-backed CriticalTimers** (`utils/livekitWorkerTimers.ts`): livekit's connection-critical timers now run in the existing `background-timer.worker.ts` (extended with an id-based protocol) — worker timers are exempt from throttling. Installed before `new Room()`; falls back to native timers if the worker can't start. Handle contract (livekit only passes handles back to `CriticalTimers.clear*`) verified against 2.13 and pinned in a comment.
2. **Media Session integration** (`useVoiceMediaSession`): active calls register metadata, `hangup`/`togglemicrophone` actions, and `setMicrophoneActive` — Android Chrome shows an ongoing call-style notification and raises the tab's process priority. Web only; everything feature-detected.
3. **Foreground resync + honest state** (`useVoiceForegroundResync`): on `visibilitychange`/`pageshow`/`resume`, rejoins when the room is dead while the voice context says connected (detection is a state mismatch, not the disconnect reason — the freeze path reports `CLIENT_INITIATED`), and calls `room.startAudio()` when playback is blocked (livekit only does that on iOS). Unexpected disconnects while visible rejoin immediately; a failed rejoin now dispatches `SetDisconnected` instead of lying.

## PWA/notification hardening (commit 2, from the audit)

- **DND is now enforced** (was a TODO): suppresses push server-side (`sendPushNotification`) and sounds/desktop notifications client-side; records, WS events, and unread counts unaffected. New `dndTimezone` column (migration included) so the backend evaluates the window in the user's local time; overnight windows wrap midnight.
- **`cleanupExpiredSubscriptions()` scheduled** via daily `@Cron` (previously written but never wired).
- **Badging API + tab title**: unread count mirrored to the installed PWA's icon and as a `(N)` title prefix; SW flags the badge for pushes arriving while the app is closed.
- **Custom install prompt**: `beforeinstallprompt` captured at module-import time (the debug page's post-mount listener misses it), surfaced as an "Install app" card in Settings.

## Verification

- Frontend: 132 files / 1423 tests pass, type-check + lint + prod build (SW compiles) clean. 61 new tests across the worker timers, MediaSession, resync, DND, badge, and install-prompt units.
- Backend: 128 suites / 2192 tests pass, lint + build clean.
- Voice E2E (real LiveKit): 18/18 pass, 0 flaky — the timer override doesn't disturb join/reconnect/mute/screenshare/device-switch flows.
- ⚠️ The actual #350 scenario (Chrome's 5-minute intensive throttling + lock screen) can't be simulated in the harness — needs on-device confirmation: install PWA → join call with a second participant → verify the ongoing call notification → lock the phone 10+ min with the remote side silent → remote speaks → audio must play; unlock → still joined. A server-side drop while locked should rejoin on unlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvVeRD4zf7UofaTfNDJm2Z