### PR TITLE
feat(mobile): route-driven mobile navigation with Outlet fallback

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, useState } from "react";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, Navigate } from "react-router-dom";
 import Layout from "./Layout";
+import { useCurrentUser } from "./hooks/useCurrentUser";
 import CssBaseline from "@mui/material/CssBaseline";
 import { CircularProgress, Box } from "@mui/material";
 import { ThemeProvider } from "./contexts/ThemeContext";
@@ -39,7 +40,24 @@ const ProfilePage = React.lazy(() => import("./pages/ProfilePage"));
 const ProfileEditPage = React.lazy(() => import("./pages/ProfileEditPage"));
 const SettingsPage = React.lazy(() => import("./pages/SettingsPage"));
 const CommunityPage = React.lazy(() => import("./pages/CommunityPage"));
+const NotificationsPage = React.lazy(() => import("./pages/NotificationsPage"));
 const NotFoundPage = React.lazy(() => import("./pages/NotFoundPage"));
+
+/** Redirects bare `/profile` to the current user's profile. */
+const ProfileRedirect: React.FC = () => {
+  const { user, isLoading } = useCurrentUser();
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+  if (user?.id) {
+    return <Navigate to={`/profile/${user.id}`} replace />;
+  }
+  return <Navigate to="/" replace />;
+};
 
 function App() {
   // Check if running in Electron and needs server configuration
@@ -89,6 +107,8 @@ function App() {
             <Route path="/" element={<Layout />}>
               <Route index element={<HomePage />} />
               <Route path="direct-messages" element={<DirectMessagesPage />} />
+              <Route path="direct-messages/:dmGroupId" element={<DirectMessagesPage />} />
+              <Route path="notifications" element={<NotificationsPage />} />
               <Route path="friends" element={<FriendsPage />} />
               <Route path="settings" element={<SettingsPage />} />
 
@@ -106,6 +126,7 @@ function App() {
 
               {/* Debug routes (admin only - access check in component) */}
               <Route path="debug/notifications" element={<NotificationDebugPage />} />
+              <Route path="profile" element={<ProfileRedirect />} />
               <Route path="profile/edit" element={<ProfileEditPage />} />
               <Route path="profile/:userId" element={<ProfilePage />} />
               <Route path="community/create" element={<CreateCommunityPage />} />

--- a/frontend/src/__tests__/components/MobileScreenContainerRoute.test.tsx
+++ b/frontend/src/__tests__/components/MobileScreenContainerRoute.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { Routes, Route } from 'react-router-dom';
+import { renderWithProviders } from '../test-utils';
+import { MobileScreenContainer } from '../../components/Mobile/Screens/MobileScreenContainer';
+import { MobileNavigationProvider } from '../../components/Mobile/Navigation/MobileNavigationContext';
+
+describe('MobileScreenContainer — route screen', () => {
+  it('renders the matched router Outlet content for a non-screen route', async () => {
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <MobileNavigationProvider>
+              <MobileScreenContainer />
+            </MobileNavigationProvider>
+          }
+        >
+          <Route path="community/create" element={<div>CREATE COMMUNITY OUTLET</div>} />
+        </Route>
+      </Routes>,
+      { routerProps: { initialEntries: ['/community/create'] } },
+    );
+
+    expect(await screen.findByText('CREATE COMMUNITY OUTLET')).toBeInTheDocument();
+    // Back button from the route app bar is present
+    expect(screen.getByLabelText('Go back')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/parseScreenFromPath.test.tsx
+++ b/frontend/src/__tests__/components/parseScreenFromPath.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseScreenFromPath,
+  type ParsedScreen,
+} from '../../components/Mobile/Navigation/MobileNavigationContext';
+
+describe('parseScreenFromPath', () => {
+  const cases: Array<{
+    pathname: string;
+    expected: ParsedScreen;
+    desc: string;
+  }> = [
+    {
+      desc: 'channel chat',
+      pathname: '/community/c1/channel/ch1',
+      expected: { screen: 'chat', communityId: 'c1', channelId: 'ch1', dmGroupId: null },
+    },
+    {
+      desc: 'community channels list',
+      pathname: '/community/c1',
+      expected: { screen: 'channels', communityId: 'c1', channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'community create -> route (not channels with id=create)',
+      pathname: '/community/create',
+      expected: { screen: 'route', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'community edit -> route',
+      pathname: '/community/c1/edit',
+      expected: { screen: 'route', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'dm chat',
+      pathname: '/direct-messages/dm1',
+      expected: { screen: 'dm-chat', communityId: null, channelId: null, dmGroupId: 'dm1' },
+    },
+    {
+      desc: 'dm list',
+      pathname: '/direct-messages',
+      expected: { screen: 'dm-list', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'notifications',
+      pathname: '/notifications',
+      expected: { screen: 'notifications', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'settings',
+      pathname: '/settings',
+      expected: { screen: 'settings', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'settings nested',
+      pathname: '/settings/appearance',
+      expected: { screen: 'settings', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'profile edit -> route (NOT profile)',
+      pathname: '/profile/edit',
+      expected: { screen: 'route', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'profile bare',
+      pathname: '/profile',
+      expected: { screen: 'profile', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'profile with userId',
+      pathname: '/profile/u1',
+      expected: { screen: 'profile', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'home',
+      pathname: '/',
+      expected: { screen: 'channels', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'admin dashboard -> route',
+      pathname: '/admin',
+      expected: { screen: 'route', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'admin nested -> route',
+      pathname: '/admin/users',
+      expected: { screen: 'route', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'friends -> route',
+      pathname: '/friends',
+      expected: { screen: 'route', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'debug page -> route',
+      pathname: '/debug/notifications',
+      expected: { screen: 'route', communityId: null, channelId: null, dmGroupId: null },
+    },
+    {
+      desc: 'unknown path -> route',
+      pathname: '/something/unknown',
+      expected: { screen: 'route', communityId: null, channelId: null, dmGroupId: null },
+    },
+  ];
+
+  it.each(cases)('maps $desc', ({ pathname, expected }) => {
+    expect(parseScreenFromPath(pathname)).toEqual(expected);
+  });
+});

--- a/frontend/src/components/Mobile/Navigation/MobileBottomNavigation.tsx
+++ b/frontend/src/components/Mobile/Navigation/MobileBottomNavigation.tsx
@@ -16,6 +16,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { notificationsControllerGetUnreadCountOptions } from '../../../api-client/@tanstack/react-query.gen';
 import { useMobileNavigation, type MobileTab } from './MobileNavigationContext';
+import { useReadReceipts } from '../../../hooks/useReadReceipts';
 import { LAYOUT_CONSTANTS, TOUCH_TARGETS } from '../../../utils/breakpoints';
 
 /**
@@ -29,6 +30,7 @@ export const MobileBottomNavigation: React.FC = () => {
   const { activeTab, setActiveTab } = useMobileNavigation();
   const { data: unreadData } = useQuery(notificationsControllerGetUnreadCountOptions());
   const notificationCount = unreadData?.count ?? 0;
+  const { totalDmUnreadCount } = useReadReceipts();
 
   const handleChange = (_event: React.SyntheticEvent, newValue: MobileTab) => {
     setActiveTab(newValue);
@@ -82,7 +84,7 @@ export const MobileBottomNavigation: React.FC = () => {
           label="Messages"
           value="messages"
           icon={
-            <Badge badgeContent={0} color="error">
+            <Badge badgeContent={totalDmUnreadCount} color="error" max={99}>
               <ChatIcon />
             </Badge>
           }

--- a/frontend/src/components/Mobile/Navigation/MobileNavigationContext.tsx
+++ b/frontend/src/components/Mobile/Navigation/MobileNavigationContext.tsx
@@ -104,7 +104,8 @@ export function parseScreenFromPath(pathname: string): ParsedScreen {
     return { screen: 'profile', ...empty };
   }
 
-  // / (home) -> channels (community restored via lastCommunityId in the provider)
+  // / (home) -> channels with no community selected; the Home tab handler
+  // (setActiveTab) is what navigates to lastCommunityId, not this parser
   if (matchPath('/', pathname)) {
     return { screen: 'channels', ...empty };
   }

--- a/frontend/src/components/Mobile/Navigation/MobileNavigationContext.tsx
+++ b/frontend/src/components/Mobile/Navigation/MobileNavigationContext.tsx
@@ -2,12 +2,24 @@
 /**
  * Mobile Navigation Context
  *
- * Screen-based navigation model (replaces panel stack).
- * Integrates with React Router for proper PWA back button support.
+ * Screen-based navigation model derived from the URL. The current screen is a
+ * pure function of `location.pathname` (see `parseScreenFromPath`), so browser
+ * back/forward and deep links stay in sync automatically. Any path that isn't a
+ * known "screen" resolves to the `'route'` screen, which renders the matched
+ * React Router `<Outlet/>` (edit forms, create pages, admin, etc.).
  */
 
-import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+} from 'react';
+import { useNavigate, useLocation, matchPath } from 'react-router-dom';
+
+const LAST_COMMUNITY_KEY = 'semaphore:lastCommunityId';
 
 // Bottom tab options
 export type MobileTab = 'home' | 'messages' | 'notifications' | 'profile';
@@ -20,27 +32,98 @@ export type ScreenType =
   | 'dm-chat'       // DM chat view
   | 'notifications' // Notifications list (notifications tab default)
   | 'profile'       // Profile (profile tab default)
-  | 'settings';     // Settings detail view (from profile tab)
+  | 'settings'      // Settings detail view (from profile tab)
+  | 'route';        // Fallthrough: render matched router Outlet (edit/create/admin/etc.)
+
+export interface ParsedScreen {
+  screen: ScreenType;
+  communityId: string | null;
+  channelId: string | null;
+  dmGroupId: string | null;
+}
+
+/**
+ * Pure mapping from a pathname to a screen + its route params.
+ * Anything not explicitly recognized resolves to the `'route'` screen so the
+ * matched React Router element renders via `<Outlet/>`.
+ */
+export function parseScreenFromPath(pathname: string): ParsedScreen {
+  const empty = { communityId: null, channelId: null, dmGroupId: null };
+
+  // /community/:communityId/channel/:channelId -> chat
+  const chat = matchPath('/community/:communityId/channel/:channelId', pathname);
+  if (chat) {
+    return {
+      screen: 'chat',
+      communityId: chat.params.communityId ?? null,
+      channelId: chat.params.channelId ?? null,
+      dmGroupId: null,
+    };
+  }
+
+  // /community/create and /community/:communityId/edit are dedicated pages -> route
+  // (checked before the bare community match so "create" isn't treated as an id)
+  if (matchPath('/community/create', pathname) || matchPath('/community/:communityId/edit', pathname)) {
+    return { screen: 'route', ...empty };
+  }
+
+  // /community/:communityId (exactly) -> channels
+  const channels = matchPath('/community/:communityId', pathname);
+  if (channels) {
+    return { screen: 'channels', communityId: channels.params.communityId ?? null, channelId: null, dmGroupId: null };
+  }
+
+  // /direct-messages/:dmGroupId -> dm-chat
+  const dmChat = matchPath('/direct-messages/:dmGroupId', pathname);
+  if (dmChat) {
+    return { screen: 'dm-chat', communityId: null, channelId: null, dmGroupId: dmChat.params.dmGroupId ?? null };
+  }
+
+  // /direct-messages -> dm-list
+  if (matchPath('/direct-messages', pathname)) {
+    return { screen: 'dm-list', ...empty };
+  }
+
+  // /notifications -> notifications
+  if (matchPath('/notifications', pathname)) {
+    return { screen: 'notifications', ...empty };
+  }
+
+  // /settings and /settings/* -> settings
+  if (matchPath('/settings', pathname) || matchPath('/settings/*', pathname)) {
+    return { screen: 'settings', ...empty };
+  }
+
+  // /profile/edit is the edit form page -> route (checked before /profile/:userId)
+  if (matchPath('/profile/edit', pathname)) {
+    return { screen: 'route', ...empty };
+  }
+
+  // /profile and /profile/:userId -> profile
+  if (matchPath('/profile', pathname) || matchPath('/profile/:userId', pathname)) {
+    return { screen: 'profile', ...empty };
+  }
+
+  // / (home) -> channels (community restored via lastCommunityId in the provider)
+  if (matchPath('/', pathname)) {
+    return { screen: 'channels', ...empty };
+  }
+
+  // Everything else (admin, friends, debug, unknown) -> render router Outlet
+  return { screen: 'route', ...empty };
+}
 
 // Navigation state
 export interface MobileNavigationState {
-  // Current screen
   currentScreen: ScreenType;
-
-  // Community context (for channels/chat screens)
   communityId: string | null;
   channelId: string | null;
-
-  // DM context (for dm-chat screen)
   dmGroupId: string | null;
-
-  // UI state
   isDrawerOpen: boolean;
 }
 
 // Context type with actions
 interface MobileNavigationContextType {
-  // Current state
   state: MobileNavigationState;
   activeTab: MobileTab;
 
@@ -73,8 +156,8 @@ const MobileNavigationContext = createContext<MobileNavigationContextType | unde
   undefined
 );
 
-// Helper to determine active tab from screen
-const getTabFromScreen = (screen: ScreenType): MobileTab => {
+// Helper to determine active tab from screen (+ pathname for 'route' screens)
+const getTabFromScreen = (screen: ScreenType, pathname: string): MobileTab => {
   switch (screen) {
     case 'channels':
     case 'chat':
@@ -87,8 +170,16 @@ const getTabFromScreen = (screen: ScreenType): MobileTab => {
     case 'profile':
     case 'settings':
       return 'profile';
+    case 'route':
+      if (pathname.startsWith('/community')) return 'home';
+      if (pathname.startsWith('/profile') || pathname.startsWith('/settings')) return 'profile';
+      if (pathname.startsWith('/direct-messages')) return 'messages';
+      return 'home';
   }
 };
+
+const isDetailScreen = (screen: ScreenType): boolean =>
+  screen === 'chat' || screen === 'dm-chat' || screen === 'settings';
 
 export const MobileNavigationProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
@@ -96,115 +187,60 @@ export const MobileNavigationProvider: React.FC<{ children: React.ReactNode }> =
   const navigate = useNavigate();
   const location = useLocation();
 
-  // Navigation state
-  const [state, setState] = useState<MobileNavigationState>({
-    currentScreen: 'channels',
-    communityId: null,
-    channelId: null,
-    dmGroupId: null,
-    isDrawerOpen: false,
+  // Drawer is the only genuinely local UI state; screen is derived from the URL.
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  // Last community selected — persisted so the Home tab restores after reload.
+  const [lastCommunityId, setLastCommunityId] = useState<string | null>(() => {
+    try {
+      return localStorage.getItem(LAST_COMMUNITY_KEY);
+    } catch {
+      return null;
+    }
   });
 
-  // Track last community for returning from other tabs
-  const [lastCommunityId, setLastCommunityId] = useState<string | null>(null);
-
-  // Sync state from URL on location change
-  useEffect(() => {
-    const path = location.pathname;
-
-    // Parse URL to determine current screen
-    if (path.startsWith('/community/')) {
-      const segments = path.split('/');
-      const communityId = segments[2];
-      const channelId = segments[4]; // /community/:id/channel/:channelId
-
-      if (channelId) {
-        setState(prev => ({
-          ...prev,
-          currentScreen: 'chat',
-          communityId,
-          channelId,
-          dmGroupId: null,
-        }));
-      } else if (communityId) {
-        setState(prev => ({
-          ...prev,
-          currentScreen: 'channels',
-          communityId,
-          channelId: null,
-          dmGroupId: null,
-        }));
-        setLastCommunityId(communityId);
-      }
-    } else if (path.startsWith('/direct-messages')) {
-      const segments = path.split('/');
-      const dmGroupId = segments[2]; // /direct-messages/:dmGroupId
-
-      if (dmGroupId) {
-        setState(prev => ({
-          ...prev,
-          currentScreen: 'dm-chat',
-          dmGroupId,
-          communityId: null,
-          channelId: null,
-        }));
-      } else {
-        setState(prev => ({
-          ...prev,
-          currentScreen: 'dm-list',
-          dmGroupId: null,
-          communityId: null,
-          channelId: null,
-        }));
-      }
-    } else if (path === '/notifications') {
-      setState(prev => ({
-        ...prev,
-        currentScreen: 'notifications',
-        communityId: null,
-        channelId: null,
-        dmGroupId: null,
-      }));
-    } else if (path === '/settings' || path.startsWith('/settings/')) {
-      setState(prev => ({
-        ...prev,
-        currentScreen: 'settings',
-        communityId: null,
-        channelId: null,
-        dmGroupId: null,
-      }));
-    } else if (path === '/profile' || path.startsWith('/profile/')) {
-      setState(prev => ({
-        ...prev,
-        currentScreen: 'profile',
-        communityId: null,
-        channelId: null,
-        dmGroupId: null,
-      }));
-    } else if (path === '/' || path === '') {
-      // Home - show channels for last community or first community
-      setState(prev => ({
-        ...prev,
-        currentScreen: 'channels',
-        channelId: null,
-        dmGroupId: null,
-      }));
+  const persistLastCommunity = useCallback((id: string) => {
+    setLastCommunityId(id);
+    try {
+      localStorage.setItem(LAST_COMMUNITY_KEY, id);
+    } catch {
+      // ignore storage failures (private mode, etc.)
     }
-  }, [location.pathname]);
+  }, []);
 
-  // Derived active tab
-  const activeTab = getTabFromScreen(state.currentScreen);
+  // Derived screen state
+  const parsed = useMemo(() => parseScreenFromPath(location.pathname), [location.pathname]);
+
+  // Keep lastCommunityId in sync when we land on a community screen
+  useEffect(() => {
+    if (parsed.communityId && parsed.communityId !== lastCommunityId) {
+      persistLastCommunity(parsed.communityId);
+    }
+  }, [parsed.communityId, lastCommunityId, persistLastCommunity]);
+
+  const state: MobileNavigationState = useMemo(
+    () => ({
+      currentScreen: parsed.screen,
+      communityId: parsed.communityId,
+      channelId: parsed.channelId,
+      dmGroupId: parsed.dmGroupId,
+      isDrawerOpen,
+    }),
+    [parsed, isDrawerOpen]
+  );
+
+  const activeTab = getTabFromScreen(parsed.screen, location.pathname);
 
   // Navigation actions
   const navigateToChannels = useCallback((communityId: string) => {
-    setLastCommunityId(communityId);
+    persistLastCommunity(communityId);
     navigate(`/community/${communityId}`);
-  }, [navigate]);
+  }, [navigate, persistLastCommunity]);
 
   const navigateToChat = useCallback((communityId: string, channelId: string) => {
-    setLastCommunityId(communityId);
+    persistLastCommunity(communityId);
     navigate(`/community/${communityId}/channel/${channelId}`);
-  }, [navigate]);
+  }, [navigate, persistLastCommunity]);
 
   const navigateToDmList = useCallback(() => {
     navigate('/direct-messages');
@@ -228,30 +264,31 @@ export const MobileNavigationProvider: React.FC<{ children: React.ReactNode }> =
 
   // Back navigation
   const canGoBack = useCallback((): boolean => {
-    // Can go back if we're in a detail view
-    return state.currentScreen === 'chat' || state.currentScreen === 'dm-chat' || state.currentScreen === 'settings';
-  }, [state.currentScreen]);
+    if (isDetailScreen(parsed.screen) || parsed.screen === 'route') return true;
+    return (window.history.state?.idx ?? 0) > 0;
+  }, [parsed.screen]);
 
   const goBack = useCallback(() => {
-    if (state.currentScreen === 'chat' && state.communityId) {
-      // Go back from chat to channels
-      navigate(`/community/${state.communityId}`);
-    } else if (state.currentScreen === 'dm-chat') {
-      // Go back from DM chat to DM list
+    // Prefer real browser history when there's somewhere to go back to.
+    if ((window.history.state?.idx ?? 0) > 0) {
+      navigate(-1);
+      return;
+    }
+    // Fallback hierarchical targets for hard entry points (deep links, PWA launch).
+    if (parsed.screen === 'chat' && parsed.communityId) {
+      navigate(`/community/${parsed.communityId}`);
+    } else if (parsed.screen === 'dm-chat') {
       navigate('/direct-messages');
-    } else if (state.currentScreen === 'settings') {
-      // Go back from settings to profile
+    } else if (parsed.screen === 'settings') {
       navigate('/profile');
     } else {
-      // Use browser history for other cases
-      navigate(-1);
+      navigate('/');
     }
-  }, [state.currentScreen, state.communityId, navigate]);
+  }, [parsed.screen, parsed.communityId, navigate]);
 
   // Tab switching
   const setActiveTab = useCallback((tab: MobileTab) => {
-    // Close drawer when switching tabs
-    setState(prev => ({ ...prev, isDrawerOpen: false }));
+    setIsDrawerOpen(false);
 
     switch (tab) {
       case 'home':
@@ -274,25 +311,17 @@ export const MobileNavigationProvider: React.FC<{ children: React.ReactNode }> =
   }, [navigate, lastCommunityId]);
 
   // Drawer control
-  const openDrawer = useCallback(() => {
-    setState(prev => ({ ...prev, isDrawerOpen: true }));
-  }, []);
-
-  const closeDrawer = useCallback(() => {
-    setState(prev => ({ ...prev, isDrawerOpen: false }));
-  }, []);
-
-  const toggleDrawer = useCallback(() => {
-    setState(prev => ({ ...prev, isDrawerOpen: !prev.isDrawerOpen }));
-  }, []);
+  const openDrawer = useCallback(() => setIsDrawerOpen(true), []);
+  const closeDrawer = useCallback(() => setIsDrawerOpen(false), []);
+  const toggleDrawer = useCallback(() => setIsDrawerOpen((prev) => !prev), []);
 
   // Legacy compatibility
   const getCurrentScreen = useCallback(() => ({
-    type: state.currentScreen,
-    communityId: state.communityId || undefined,
-    channelId: state.channelId || undefined,
-    dmGroupId: state.dmGroupId || undefined,
-  }), [state]);
+    type: parsed.screen,
+    communityId: parsed.communityId || undefined,
+    channelId: parsed.channelId || undefined,
+    dmGroupId: parsed.dmGroupId || undefined,
+  }), [parsed]);
 
   const value: MobileNavigationContextType = {
     state,

--- a/frontend/src/components/Mobile/Screens/MobileScreenContainer.tsx
+++ b/frontend/src/components/Mobile/Screens/MobileScreenContainer.tsx
@@ -14,6 +14,7 @@
  */
 
 import React from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
 import { Box, Slide, Typography } from '@mui/material';
 import { useMobileNavigation, type ScreenType } from '../Navigation/MobileNavigationContext';
 import { LAYOUT_CONSTANTS, MOBILE_ANIMATIONS } from '../../../utils/breakpoints';
@@ -33,7 +34,17 @@ interface MobileScreenContainerProps {
 
 // Helper to determine if a screen is a "detail" view (slides in from right)
 const isDetailScreen = (screen: ScreenType): boolean => {
-  return screen === 'chat' || screen === 'dm-chat' || screen === 'settings';
+  return screen === 'chat' || screen === 'dm-chat' || screen === 'settings' || screen === 'route';
+};
+
+// Generic title for routed ('route' screen) pages, derived from the path.
+const getRouteTitle = (pathname: string): string => {
+  if (pathname === '/community/create') return 'Create Community';
+  if (/^\/community\/[^/]+\/edit$/.test(pathname)) return 'Edit Community';
+  if (pathname === '/profile/edit') return 'Edit Profile';
+  if (pathname.startsWith('/admin')) return 'Admin';
+  if (pathname.startsWith('/friends')) return 'Friends';
+  return 'Back';
 };
 
 
@@ -44,6 +55,7 @@ export const MobileScreenContainer: React.FC<MobileScreenContainerProps> = ({
   bottomOffset = 0,
 }) => {
   const { state } = useMobileNavigation();
+  const location = useLocation();
   const { currentScreen, communityId, channelId, dmGroupId } = state;
 
   // Track previous screen for transition direction
@@ -135,6 +147,18 @@ export const MobileScreenContainer: React.FC<MobileScreenContainerProps> = ({
           </Box>
         );
 
+      case 'route':
+        // Any non-screen route (edit forms, create pages, admin, friends, etc.)
+        // renders the matched React Router element via <Outlet/>.
+        return (
+          <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <MobileAppBar title={getRouteTitle(location.pathname)} showBack />
+            <Box sx={{ flex: 1, overflowY: 'auto' }}>
+              <Outlet />
+            </Box>
+          </Box>
+        );
+
       default:
         return null;
     }
@@ -150,7 +174,7 @@ export const MobileScreenContainer: React.FC<MobileScreenContainerProps> = ({
       }}
     >
       <Slide
-        key={currentScreen}
+        key={currentScreen === 'route' ? location.pathname : currentScreen}
         direction={slideIn ? 'left' : 'right'}
         in={true}
         timeout={MOBILE_ANIMATIONS.NORMAL}

--- a/frontend/src/components/Mobile/Screens/NotificationsScreen.tsx
+++ b/frontend/src/components/Mobile/Screens/NotificationsScreen.tsx
@@ -1,224 +1,25 @@
 /**
  * NotificationsScreen Component
  *
- * Shows list of notifications (mentions, DMs, etc.)
- * Allows marking as read, dismissing, and navigating to source.
+ * Mobile notifications tab — app bar + shared notification list.
  */
 
 import React from 'react';
-import {
-  Box,
-  Typography,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemAvatar,
-  ListItemText,
-  Avatar,
-  IconButton,
-  CircularProgress,
-  Button,
-  Chip,
-  Divider,
-} from '@mui/material';
-import {
-  CheckCircle as CheckIcon,
-  Close as DismissIcon,
-  AlternateEmail as MentionIcon,
-  Chat as DmIcon,
-  Tag as ChannelIcon,
-} from '@mui/icons-material';
-import { useMutation } from '@tanstack/react-query';
-import {
-  notificationsControllerDismissNotificationMutation,
-} from '../../../api-client/@tanstack/react-query.gen';
+import { Box, Chip } from '@mui/material';
 
-import { useMobileNavigation } from '../Navigation/MobileNavigationContext';
-import { TOUCH_TARGETS } from '../../../utils/breakpoints';
-import { NotificationType, Notification } from '../../../types/notification.type';
 import MobileAppBar from '../MobileAppBar';
-import { logger } from '../../../utils/logger';
 import { useNotifications } from '../../../hooks/useNotifications';
-import { getMessagePreview, getNotificationTypeLabel, getTimeAgo } from '../../../utils/notificationHelpers';
-
-/**
- * Get icon for notification type
- */
-const getNotificationIcon = (type: Notification['type']) => {
-  switch (type) {
-    case NotificationType.USER_MENTION:
-    case NotificationType.SPECIAL_MENTION:
-      return <MentionIcon />;
-    case NotificationType.DIRECT_MESSAGE:
-      return <DmIcon />;
-    case NotificationType.CHANNEL_MESSAGE:
-      return <ChannelIcon />;
-    default:
-      return <MentionIcon />;
-  }
-};
-
-interface NotificationItemProps {
-  notification: Notification;
-  onMarkRead: (id: string) => void;
-  onDismiss: (id: string) => void;
-  onClick: (notification: Notification) => void;
-}
-
-const NotificationItem: React.FC<NotificationItemProps> = ({
-  notification,
-  onMarkRead,
-  onDismiss,
-  onClick,
-}) => {
-  const preview = getMessagePreview(notification);
-  const timeAgo = getTimeAgo(notification.createdAt);
-
-  return (
-    <ListItem
-      disablePadding
-      secondaryAction={
-        <Box sx={{ display: 'flex', gap: 0.5 }}>
-          {!notification.read && (
-            <IconButton
-              edge="end"
-              size="small"
-              onClick={(e) => {
-                e.stopPropagation();
-                onMarkRead(notification.id);
-              }}
-              aria-label="Mark as read"
-            >
-              <CheckIcon fontSize="small" />
-            </IconButton>
-          )}
-          <IconButton
-            edge="end"
-            size="small"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDismiss(notification.id);
-            }}
-            aria-label="Dismiss"
-          >
-            <DismissIcon fontSize="small" />
-          </IconButton>
-        </Box>
-      }
-    >
-      <ListItemButton
-        onClick={() => onClick(notification)}
-        sx={{
-          minHeight: TOUCH_TARGETS.RECOMMENDED,
-          pr: 10, // Room for action buttons
-          backgroundColor: notification.read ? 'transparent' : 'action.hover',
-        }}
-      >
-        <ListItemAvatar>
-          <Avatar
-            src={notification.author?.avatarUrl || undefined}
-            sx={{
-              bgcolor: notification.read ? 'grey.500' : 'primary.main',
-              width: 44,
-              height: 44,
-            }}
-          >
-            {getNotificationIcon(notification.type)}
-          </Avatar>
-        </ListItemAvatar>
-        <ListItemText
-          primary={
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-              <Typography
-                component="span"
-                fontWeight={notification.read ? 400 : 600}
-                fontSize="0.9375rem"
-              >
-                {notification.author?.username || 'Someone'}
-              </Typography>
-              <Typography
-                component="span"
-                variant="body2"
-                color="text.secondary"
-              >
-                {getNotificationTypeLabel(notification.type as NotificationType)}
-              </Typography>
-            </Box>
-          }
-          secondary={
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-              {preview && (
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  {preview}
-                </Typography>
-              )}
-              <Typography variant="caption" color="text.secondary">
-                {timeAgo}
-              </Typography>
-            </Box>
-          }
-        />
-      </ListItemButton>
-    </ListItem>
-  );
-};
+import { NotificationList } from '../../Notifications/NotificationList';
 
 /**
  * Notifications screen - Shows list of notifications
  * Default screen for the Notifications tab
  */
 export const NotificationsScreen: React.FC = () => {
-  const { navigateToChat, navigateToDmChat } = useMobileNavigation();
-
-  const {
-    notifications,
-    unreadCount,
-    isLoading,
-    isMarkingAllRead,
-    refetch,
-    handleMarkAsRead,
-    handleMarkAllAsRead,
-    invalidateNotifications,
-  } = useNotifications();
-
-  const { mutateAsync: dismissNotification } = useMutation({
-    ...notificationsControllerDismissNotificationMutation(),
-    onSuccess: () => invalidateNotifications(),
-  });
-
-  const handleDismiss = async (notificationId: string) => {
-    try {
-      await dismissNotification({ path: { id: notificationId } });
-    } catch (error) {
-      logger.error('Failed to dismiss notification:', error);
-    }
-  };
-
-  const handleNotificationClick = (notification: Notification) => {
-    // Mark as read when clicked
-    if (!notification.read) {
-      handleMarkAsRead(notification.id);
-    }
-
-    // Navigate to the source
-    if (notification.communityId && notification.channelId) {
-      navigateToChat(notification.communityId, notification.channelId);
-    } else if (notification.directMessageGroupId) {
-      navigateToDmChat(notification.directMessageGroupId);
-    }
-  };
+  const { unreadCount } = useNotifications();
 
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      {/* App bar */}
       <MobileAppBar
         title="Notifications"
         actions={
@@ -232,78 +33,7 @@ export const NotificationsScreen: React.FC = () => {
           )
         }
       />
-
-      {/* Mark all as read button */}
-      {unreadCount > 0 && (
-        <Box sx={{ px: 2, py: 1, display: 'flex', justifyContent: 'flex-end' }}>
-          <Button
-            size="small"
-            onClick={handleMarkAllAsRead}
-            disabled={isMarkingAllRead}
-            startIcon={isMarkingAllRead ? <CircularProgress size={16} /> : <CheckIcon />}
-          >
-            Mark all as read
-          </Button>
-        </Box>
-      )}
-
-      {unreadCount > 0 && <Divider />}
-
-      {/* Notification list */}
-      {isLoading ? (
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            flex: 1,
-          }}
-        >
-          <CircularProgress />
-        </Box>
-      ) : notifications.length === 0 ? (
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            flex: 1,
-            gap: 2,
-            p: 3,
-          }}
-        >
-          <Box sx={{ fontSize: 64, opacity: 0.5 }}>🔔</Box>
-          <Typography variant="h6" color="text.secondary">
-            No notifications
-          </Typography>
-          <Typography variant="body2" color="text.secondary" textAlign="center">
-            You'll see mentions, replies, and direct messages here.
-          </Typography>
-          <Button variant="outlined" onClick={() => refetch()}>
-            Refresh
-          </Button>
-        </Box>
-      ) : (
-        <Box
-          sx={{
-            flex: 1,
-            overflowY: 'auto',
-          }}
-        >
-          <List disablePadding>
-            {notifications.map((notification) => (
-              <NotificationItem
-                key={notification.id}
-                notification={notification}
-                onMarkRead={handleMarkAsRead}
-                onDismiss={handleDismiss}
-                onClick={handleNotificationClick}
-              />
-            ))}
-          </List>
-        </Box>
-      )}
+      <NotificationList />
     </Box>
   );
 };

--- a/frontend/src/components/Mobile/Tablet/TabletContentArea.tsx
+++ b/frontend/src/components/Mobile/Tablet/TabletContentArea.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { Outlet } from 'react-router-dom';
 import { Box, Typography } from '@mui/material';
 import { useMobileNavigation } from '../Navigation/MobileNavigationContext';
 import { MobileChatPanel } from '../Panels/MobileChatPanel';
@@ -112,6 +113,17 @@ export const TabletContentArea: React.FC<TabletContentAreaProps> = ({
 
       case 'profile':
         return <MobileProfilePanel />;
+
+      case 'route':
+        // Non-screen routes render the matched router element via <Outlet/>.
+        return (
+          <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <MobileAppBar title="Back" showBack />
+            <Box sx={{ flex: 1, overflowY: 'auto' }}>
+              <Outlet />
+            </Box>
+          </Box>
+        );
 
       default:
         return null;

--- a/frontend/src/components/Mobile/Tablet/TabletContentArea.tsx
+++ b/frontend/src/components/Mobile/Tablet/TabletContentArea.tsx
@@ -13,6 +13,7 @@ import { MobileChatPanel } from '../Panels/MobileChatPanel';
 import { MobileMessagesPanel } from '../Panels/MobileMessagesPanel';
 import { MobileProfilePanel } from '../Panels/MobileProfilePanel';
 import { NotificationsScreen } from '../Screens/NotificationsScreen';
+import SettingsPage from '../../../pages/SettingsPage';
 import { LAYOUT_CONSTANTS } from '../../../utils/breakpoints';
 import MobileAppBar from '../MobileAppBar';
 
@@ -113,6 +114,17 @@ export const TabletContentArea: React.FC<TabletContentAreaProps> = ({
 
       case 'profile':
         return <MobileProfilePanel />;
+
+      case 'settings':
+        // Previously fell through to null, leaving a blank pane on tablets.
+        return (
+          <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <MobileAppBar title="Settings" showBack />
+            <Box sx={{ flex: 1, overflowY: 'auto' }}>
+              <SettingsPage />
+            </Box>
+          </Box>
+        );
 
       case 'route':
         // Non-screen routes render the matched router element via <Outlet/>.

--- a/frontend/src/components/Notifications/NotificationList.tsx
+++ b/frontend/src/components/Notifications/NotificationList.tsx
@@ -1,0 +1,271 @@
+/**
+ * NotificationList Component
+ *
+ * Shared notification list body (mark-all button, loading/empty states, list).
+ * Used by both the mobile NotificationsScreen and the desktop NotificationsPage.
+ * Navigation is handled via react-router, so it works on mobile (URL-derived
+ * screen state) and desktop alike.
+ */
+
+import React from 'react';
+import {
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemAvatar,
+  ListItemText,
+  Avatar,
+  IconButton,
+  CircularProgress,
+  Button,
+  Divider,
+} from '@mui/material';
+import {
+  CheckCircle as CheckIcon,
+  Close as DismissIcon,
+  AlternateEmail as MentionIcon,
+  Chat as DmIcon,
+  Tag as ChannelIcon,
+} from '@mui/icons-material';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { notificationsControllerDismissNotificationMutation } from '../../api-client/@tanstack/react-query.gen';
+
+import { TOUCH_TARGETS } from '../../utils/breakpoints';
+import { NotificationType, Notification } from '../../types/notification.type';
+import { logger } from '../../utils/logger';
+import { useNotifications } from '../../hooks/useNotifications';
+import { getMessagePreview, getNotificationTypeLabel, getTimeAgo } from '../../utils/notificationHelpers';
+
+const getNotificationIcon = (type: Notification['type']) => {
+  switch (type) {
+    case NotificationType.USER_MENTION:
+    case NotificationType.SPECIAL_MENTION:
+      return <MentionIcon />;
+    case NotificationType.DIRECT_MESSAGE:
+      return <DmIcon />;
+    case NotificationType.CHANNEL_MESSAGE:
+      return <ChannelIcon />;
+    default:
+      return <MentionIcon />;
+  }
+};
+
+interface NotificationItemProps {
+  notification: Notification;
+  onMarkRead: (id: string) => void;
+  onDismiss: (id: string) => void;
+  onClick: (notification: Notification) => void;
+}
+
+const NotificationItem: React.FC<NotificationItemProps> = ({
+  notification,
+  onMarkRead,
+  onDismiss,
+  onClick,
+}) => {
+  const preview = getMessagePreview(notification);
+  const timeAgo = getTimeAgo(notification.createdAt);
+
+  return (
+    <ListItem
+      disablePadding
+      secondaryAction={
+        <Box sx={{ display: 'flex', gap: 0.5 }}>
+          {!notification.read && (
+            <IconButton
+              edge="end"
+              size="small"
+              onClick={(e) => {
+                e.stopPropagation();
+                onMarkRead(notification.id);
+              }}
+              aria-label="Mark as read"
+            >
+              <CheckIcon fontSize="small" />
+            </IconButton>
+          )}
+          <IconButton
+            edge="end"
+            size="small"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDismiss(notification.id);
+            }}
+            aria-label="Dismiss"
+          >
+            <DismissIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      }
+    >
+      <ListItemButton
+        onClick={() => onClick(notification)}
+        sx={{
+          minHeight: TOUCH_TARGETS.RECOMMENDED,
+          pr: 10, // Room for action buttons
+          backgroundColor: notification.read ? 'transparent' : 'action.hover',
+        }}
+      >
+        <ListItemAvatar>
+          <Avatar
+            src={notification.author?.avatarUrl || undefined}
+            sx={{
+              bgcolor: notification.read ? 'grey.500' : 'primary.main',
+              width: 44,
+              height: 44,
+            }}
+          >
+            {getNotificationIcon(notification.type)}
+          </Avatar>
+        </ListItemAvatar>
+        <ListItemText
+          primary={
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+              <Typography
+                component="span"
+                fontWeight={notification.read ? 400 : 600}
+                fontSize="0.9375rem"
+              >
+                {notification.author?.username || 'Someone'}
+              </Typography>
+              <Typography component="span" variant="body2" color="text.secondary">
+                {getNotificationTypeLabel(notification.type as NotificationType)}
+              </Typography>
+            </Box>
+          }
+          secondary={
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+              {preview && (
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {preview}
+                </Typography>
+              )}
+              <Typography variant="caption" color="text.secondary">
+                {timeAgo}
+              </Typography>
+            </Box>
+          }
+        />
+      </ListItemButton>
+    </ListItem>
+  );
+};
+
+/**
+ * Notification list body — mark-all button, loading/empty states, and the list.
+ */
+export const NotificationList: React.FC = () => {
+  const navigate = useNavigate();
+
+  const {
+    notifications,
+    unreadCount,
+    isLoading,
+    isMarkingAllRead,
+    refetch,
+    handleMarkAsRead,
+    handleMarkAllAsRead,
+    invalidateNotifications,
+  } = useNotifications();
+
+  const { mutateAsync: dismissNotification } = useMutation({
+    ...notificationsControllerDismissNotificationMutation(),
+    onSuccess: () => invalidateNotifications(),
+  });
+
+  const handleDismiss = async (notificationId: string) => {
+    try {
+      await dismissNotification({ path: { id: notificationId } });
+    } catch (error) {
+      logger.error('Failed to dismiss notification:', error);
+    }
+  };
+
+  const handleNotificationClick = (notification: Notification) => {
+    if (!notification.read) {
+      handleMarkAsRead(notification.id);
+    }
+
+    if (notification.communityId && notification.channelId) {
+      navigate(`/community/${notification.communityId}/channel/${notification.channelId}`);
+    } else if (notification.directMessageGroupId) {
+      navigate(`/direct-messages/${notification.directMessageGroupId}`);
+    }
+  };
+
+  return (
+    <>
+      {/* Mark all as read button */}
+      {unreadCount > 0 && (
+        <Box sx={{ px: 2, py: 1, display: 'flex', justifyContent: 'flex-end' }}>
+          <Button
+            size="small"
+            onClick={handleMarkAllAsRead}
+            disabled={isMarkingAllRead}
+            startIcon={isMarkingAllRead ? <CircularProgress size={16} /> : <CheckIcon />}
+          >
+            Mark all as read
+          </Button>
+        </Box>
+      )}
+
+      {unreadCount > 0 && <Divider />}
+
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1, py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : notifications.length === 0 ? (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flex: 1,
+            gap: 2,
+            p: 3,
+          }}
+        >
+          <Box sx={{ fontSize: 64, opacity: 0.5 }}>🔔</Box>
+          <Typography variant="h6" color="text.secondary">
+            No notifications
+          </Typography>
+          <Typography variant="body2" color="text.secondary" textAlign="center">
+            You'll see mentions, replies, and direct messages here.
+          </Typography>
+          <Button variant="outlined" onClick={() => refetch()}>
+            Refresh
+          </Button>
+        </Box>
+      ) : (
+        <Box sx={{ flex: 1, overflowY: 'auto' }}>
+          <List disablePadding>
+            {notifications.map((notification) => (
+              <NotificationItem
+                key={notification.id}
+                notification={notification}
+                onMarkRead={handleMarkAsRead}
+                onDismiss={handleDismiss}
+                onClick={handleNotificationClick}
+              />
+            ))}
+          </List>
+        </Box>
+      )}
+    </>
+  );
+};
+
+export default NotificationList;

--- a/frontend/src/pages/DirectMessagesPage.tsx
+++ b/frontend/src/pages/DirectMessagesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { Box, Typography, IconButton, Tabs, Tab, Badge } from "@mui/material";
 import { Add as AddIcon, People as PeopleIcon, Chat as ChatIcon } from "@mui/icons-material";
@@ -59,12 +59,19 @@ const DirectMessagesPage: React.FC = () => {
     setSelectedDmGroupId(dmGroupId);
   };
 
-  // Path param (/direct-messages/:dmGroupId) wins over ?group= handling.
+  // Path param (/direct-messages/:dmGroupId) wins over ?group= handling —
+  // but only when the param itself changes. Re-asserting on every divergence
+  // would lock the selection to the deep-linked conversation (sidebar clicks
+  // set state without navigating).
+  const prevDmGroupIdParamRef = useRef(dmGroupIdParam);
   useEffect(() => {
-    if (dmGroupIdParam && dmGroupIdParam !== selectedDmGroupId) {
-      setSelectedDmGroupId(dmGroupIdParam);
+    if (dmGroupIdParam !== prevDmGroupIdParamRef.current) {
+      prevDmGroupIdParamRef.current = dmGroupIdParam;
+      if (dmGroupIdParam) {
+        setSelectedDmGroupId(dmGroupIdParam);
+      }
     }
-  }, [dmGroupIdParam, selectedDmGroupId]);
+  }, [dmGroupIdParam]);
 
   // Handle ?group=<id> query param for deep linking (e.g., from notifications)
   useEffect(() => {

--- a/frontend/src/pages/DirectMessagesPage.tsx
+++ b/frontend/src/pages/DirectMessagesPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import { Box, Typography, IconButton, Tabs, Tab, Badge } from "@mui/material";
 import { Add as AddIcon, People as PeopleIcon, Chat as ChatIcon } from "@mui/icons-material";
 import DirectMessageList from "../components/DirectMessages/DirectMessageList";
@@ -41,7 +41,8 @@ type SidebarTab = "messages" | "friends";
 
 const DirectMessagesPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [selectedDmGroupId, setSelectedDmGroupId] = useState<string | undefined>();
+  const { dmGroupId: dmGroupIdParam } = useParams();
+  const [selectedDmGroupId, setSelectedDmGroupId] = useState<string | undefined>(dmGroupIdParam);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>("messages");
   const { isMobile } = useResponsive();
@@ -57,6 +58,13 @@ const DirectMessagesPage: React.FC = () => {
     setSidebarTab("messages");
     setSelectedDmGroupId(dmGroupId);
   };
+
+  // Path param (/direct-messages/:dmGroupId) wins over ?group= handling.
+  useEffect(() => {
+    if (dmGroupIdParam && dmGroupIdParam !== selectedDmGroupId) {
+      setSelectedDmGroupId(dmGroupIdParam);
+    }
+  }, [dmGroupIdParam, selectedDmGroupId]);
 
   // Handle ?group=<id> query param for deep linking (e.g., from notifications)
   useEffect(() => {

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Box, Container, Typography } from '@mui/material';
+import { NotificationList } from '../components/Notifications/NotificationList';
+
+/**
+ * NotificationsPage
+ *
+ * Standalone notifications route (`/notifications`). Reuses the shared
+ * NotificationList body. Works on desktop and, via the mobile 'route' screen,
+ * as a deep-linkable notifications view.
+ */
+const NotificationsPage: React.FC = () => {
+  return (
+    <Container maxWidth="sm" sx={{ py: 2, height: '100%' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <Typography variant="h5" sx={{ fontWeight: 700, px: 1, pb: 1 }}>
+          Notifications
+        </Typography>
+        <NotificationList />
+      </Box>
+    </Container>
+  );
+};
+
+export default NotificationsPage;

--- a/frontend/src/sw-custom.ts
+++ b/frontend/src/sw-custom.ts
@@ -127,7 +127,7 @@ self.addEventListener('notificationclick', (event: NotificationEvent) => {
   if (data?.communityId && data?.channelId) {
     hash = `#/community/${data.communityId}/channel/${data.channelId}`;
   } else if (data?.directMessageGroupId) {
-    hash = `#/direct-messages?group=${data.directMessageGroupId}`;
+    hash = `#/direct-messages/${data.directMessageGroupId}`;
   }
 
   const targetUrl = new URL(`/${hash}`, self.location.origin).href;


### PR DESCRIPTION
## Summary

PR 1 of 7 in the mobile UX overhaul. Fixes the structural navigation gap on phones/tablets: the mobile layout mapped URLs to a screen enum and silently swallowed anything unmatched, so **Community Settings, Create Community, Edit Profile, and Admin pages were dead ends on mobile** — buttons navigated but nothing changed. Mobile nav also linked to routes that didn't exist in the router (`/notifications`, `/direct-messages/:dmGroupId`), breaking deep links, refresh, and PWA notification taps.

## Changes

- **`MobileNavigationContext`**: screen state is now a pure function of the URL (`parseScreenFromPath`, `matchPath`-based, exported for tests) via `useMemo` — replaces the `useState` + URL-sync effect. Public context API unchanged.
- **New `'route'` screen type**: any path that isn't a known mobile screen (community edit/create, profile edit, admin, friends, debug, 404) renders the matched router `<Outlet/>` with a back app bar, in both `MobileScreenContainer` (phone) and `TabletContentArea` (tablet). Slide transitions keyed by pathname for routed pages.
- **New routes**: `/notifications` (new `NotificationsPage` sharing a `NotificationList` extracted from the mobile screen), `/direct-messages/:dmGroupId`, and bare `/profile` → redirect to current user.
- **`DirectMessagesPage`** accepts the path param; legacy `?group=` still works.
- **Service worker** DM notification deep links now use `#/direct-messages/<id>`.
- **`goBack()`** prefers real browser history (`history.state.idx > 0`), hierarchical fallbacks only for hard entry points — hardware back and in-app back now agree.
- `lastCommunityId` persisted to localStorage (Home tab restores after reload); Messages tab badge wired to `totalDmUnreadCount` (was hardcoded `0`).

## Testing

- New table-driven tests for `parseScreenFromPath` (18 cases incl. all `'route'` fallthroughs) and an Outlet-rendering test for the route screen.
- `type-check` and `lint` clean; affected test files pass in isolation (41 tests: parser, screen container, bottom nav, chat panel, read receipts).
- Desktop and Electron untouched (desktop layout branch doesn't use the mobile context; Electron forces desktop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvVeRD4zf7UofaTfNDJm2Z