### PR TITLE
feat(mobile): long-press message actions sheet + touch moderation menus

### DIFF
--- a/frontend/src/__tests__/components/MessageActionsSheet.test.tsx
+++ b/frontend/src/__tests__/components/MessageActionsSheet.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import MessageActionsSheet, {
+  type MessageActionsSheetProps,
+} from '../../components/Message/MessageActionsSheet';
+import { createMessage } from '../test-utils/factories';
+import { SpanType } from '../../types/message.type';
+
+vi.mock('../../utils/clipboard', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(undefined),
+}));
+
+function defaultProps(
+  overrides: Partial<MessageActionsSheetProps> = {},
+): MessageActionsSheetProps {
+  return {
+    anchorPosition: null,
+    open: true,
+    onClose: vi.fn(),
+    message: createMessage({
+      spans: [{ type: SpanType.PLAINTEXT, text: 'Hello world' }],
+    }),
+    canEdit: false,
+    canDelete: false,
+    canPin: false,
+    canReact: false,
+    canThread: false,
+    isPinned: false,
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    onPin: vi.fn(),
+    onUnpin: vi.fn(),
+    onReplyInThread: vi.fn(),
+    onAddReaction: vi.fn(),
+    onEmojiSelect: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('MessageActionsSheet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all action rows for an owner with full permissions', () => {
+    const props = defaultProps({
+      canEdit: true,
+      canDelete: true,
+      canPin: true,
+      canReact: true,
+      canThread: true,
+      onQuoteReply: vi.fn(),
+    });
+    renderWithProviders(<MessageActionsSheet {...props} />);
+
+    expect(screen.getByText('Reply')).toBeInTheDocument();
+    expect(screen.getByText('Reply in Thread')).toBeInTheDocument();
+    expect(screen.getByText('Pin Message')).toBeInTheDocument();
+    expect(screen.getByText('Edit Message')).toBeInTheDocument();
+    expect(screen.getByText('Delete Message')).toBeInTheDocument();
+    expect(screen.getByText('Copy Message Content')).toBeInTheDocument();
+    // Reaction is served by the quick-reaction row, not a list row
+    expect(screen.queryByText('Add Reaction')).not.toBeInTheDocument();
+  });
+
+  it('shows the quick-reaction row (and + button) only when canReact', () => {
+    const { rerender } = renderWithProviders(
+      <MessageActionsSheet {...defaultProps({ canReact: true })} />,
+    );
+    expect(screen.getByLabelText('React with 👍')).toBeInTheDocument();
+    expect(screen.getByLabelText('More reactions')).toBeInTheDocument();
+
+    rerender(<MessageActionsSheet {...defaultProps({ canReact: false })} />);
+    expect(screen.queryByLabelText('React with 👍')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('More reactions')).not.toBeInTheDocument();
+  });
+
+  it('hides Edit/Delete/Pin for a non-owner without permissions', () => {
+    renderWithProviders(<MessageActionsSheet {...defaultProps()} />);
+
+    expect(screen.queryByText('Edit Message')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delete Message')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pin Message')).not.toBeInTheDocument();
+    // Copy is always available
+    expect(screen.getByText('Copy Message Content')).toBeInTheDocument();
+  });
+
+  it('shows "Unpin Message" when the message is pinned', () => {
+    renderWithProviders(
+      <MessageActionsSheet {...defaultProps({ canPin: true, isPinned: true })} />,
+    );
+    expect(screen.getByText('Unpin Message')).toBeInTheDocument();
+    expect(screen.queryByText('Pin Message')).not.toBeInTheDocument();
+  });
+
+  it('invokes the delete handler and closes on tap', async () => {
+    const onDelete = vi.fn();
+    const onClose = vi.fn();
+    const { user } = renderWithProviders(
+      <MessageActionsSheet
+        {...defaultProps({ canDelete: true, onDelete, onClose })}
+      />,
+    );
+
+    await user.click(screen.getByText('Delete Message'));
+    expect(onDelete).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('adds a quick reaction and closes the sheet', async () => {
+    const onEmojiSelect = vi.fn();
+    const onClose = vi.fn();
+    const { user } = renderWithProviders(
+      <MessageActionsSheet
+        {...defaultProps({ canReact: true, onEmojiSelect, onClose })}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('React with ❤️'));
+    expect(onEmojiSelect).toHaveBeenCalledWith('❤️');
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('opens the full picker via the + button', async () => {
+    const onAddReaction = vi.fn();
+    const onClose = vi.fn();
+    const { user } = renderWithProviders(
+      <MessageActionsSheet
+        {...defaultProps({ canReact: true, onAddReaction, onClose })}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('More reactions'));
+    expect(onAddReaction).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('copies message content on tap', async () => {
+    const { copyToClipboard } = await import('../../utils/clipboard');
+    vi.mocked(copyToClipboard).mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    const { user } = renderWithProviders(
+      <MessageActionsSheet
+        {...defaultProps({
+          message: createMessage({
+            spans: [{ type: SpanType.PLAINTEXT, text: 'Copy me' }],
+          }),
+          onClose,
+        })}
+      />,
+    );
+
+    await user.click(screen.getByText('Copy Message Content'));
+    expect(copyToClipboard).toHaveBeenCalledWith('Copy me');
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/__tests__/hooks/useLongPress.test.ts
+++ b/frontend/src/__tests__/hooks/useLongPress.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLongPress } from '../../hooks/useSwipeGesture';
+
+/** Build a touch-like event object accepted by the hook's handlers. */
+function touchEvent(
+  target: EventTarget,
+  currentTarget: EventTarget,
+  x = 0,
+  y = 0,
+) {
+  const point = { clientX: x, clientY: y };
+  return {
+    target,
+    currentTarget,
+    touches: [point],
+    changedTouches: [point],
+  } as unknown as React.TouchEvent;
+}
+
+describe('useLongPress', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires onLongPress with the origin point after the delay', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const el = document.createElement('div');
+    const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+    act(() => result.current.onTouchStart(touchEvent(el, el, 12, 34)));
+    expect(onLongPress).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+    expect(onLongPress).toHaveBeenCalledWith({ x: 12, y: 34 });
+  });
+
+  it('cancels when the pointer moves beyond the slop threshold', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const el = document.createElement('div');
+    const { result } = renderHook(() =>
+      useLongPress(onLongPress, { delay: 500, slop: 10 }),
+    );
+
+    act(() => result.current.onTouchStart(touchEvent(el, el, 0, 0)));
+    act(() => result.current.onTouchMove(touchEvent(el, el, 25, 0)));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('does not cancel on small movements within the slop threshold', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const el = document.createElement('div');
+    const { result } = renderHook(() =>
+      useLongPress(onLongPress, { delay: 500, slop: 10 }),
+    );
+
+    act(() => result.current.onTouchStart(touchEvent(el, el, 0, 0)));
+    act(() => result.current.onTouchMove(touchEvent(el, el, 5, 5)));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels on early release', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const el = document.createElement('div');
+    const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+    act(() => result.current.onTouchStart(touchEvent(el, el)));
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    act(() => result.current.onTouchEnd());
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('skips gestures that start on a nested interactive element', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const wrapper = document.createElement('div');
+    const button = document.createElement('button');
+    wrapper.appendChild(button);
+    const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+    // target is the nested <button>, currentTarget is the bound wrapper
+    act(() => result.current.onTouchStart(touchEvent(button, wrapper)));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('still fires when the bound element itself is a role=button row', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const row = document.createElement('div');
+    row.setAttribute('role', 'button');
+    const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+    // target === currentTarget === the role=button row
+    act(() => result.current.onTouchStart(touchEvent(row, row)));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when disabled', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const el = document.createElement('div');
+    const { result } = renderHook(() =>
+      useLongPress(onLongPress, { delay: 500, enabled: false }),
+    );
+
+    act(() => result.current.onTouchStart(touchEvent(el, el)));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('suppresses the native context menu only right after a long-press fires', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const el = document.createElement('div');
+    const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+    // Before any long-press, a context menu event passes through
+    const passthrough = { preventDefault: vi.fn() } as unknown as React.MouseEvent;
+    act(() => result.current.onContextMenu(passthrough));
+    expect(passthrough.preventDefault).not.toHaveBeenCalled();
+
+    // After a long-press fires, the following context menu is suppressed
+    act(() => result.current.onTouchStart(touchEvent(el, el)));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    const suppressed = { preventDefault: vi.fn() } as unknown as React.MouseEvent;
+    act(() => result.current.onContextMenu(suppressed));
+    expect(suppressed.preventDefault).toHaveBeenCalledTimes(1);
+
+    // Only suppressed once (flag resets)
+    const next = { preventDefault: vi.fn() } as unknown as React.MouseEvent;
+    act(() => result.current.onContextMenu(next));
+    expect(next.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/hooks/useLongPress.test.ts
+++ b/frontend/src/__tests__/hooks/useLongPress.test.ts
@@ -160,9 +160,17 @@ describe('useLongPress', () => {
     act(() => result.current.onContextMenu(suppressed));
     expect(suppressed.preventDefault).toHaveBeenCalledTimes(1);
 
-    // Only suppressed once (flag resets)
+    // The triggered flag persists until the next press starts (consumers read
+    // isLongPressTriggered() in onClick to swallow post-long-press ghost
+    // clicks on browsers that never fire the synthetic contextmenu)
+    expect(result.current.isLongPressTriggered()).toBe(true);
+
+    // A new press resets the flag, so its context menu passes through again
+    act(() => result.current.onTouchStart(touchEvent(el, el)));
+    act(() => result.current.onTouchEnd());
     const next = { preventDefault: vi.fn() } as unknown as React.MouseEvent;
     act(() => result.current.onContextMenu(next));
     expect(next.preventDefault).not.toHaveBeenCalled();
+    expect(result.current.isLongPressTriggered()).toBe(false);
   });
 });

--- a/frontend/src/components/Message/EmojiPicker.tsx
+++ b/frontend/src/components/Message/EmojiPicker.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useMemo } from 'react';
 import { IconButton, Popover, Box, Typography, TextField, InputAdornment } from '@mui/material';
 import { AddReaction as AddReactionIcon, Search as SearchIcon, Clear as ClearIcon } from '@mui/icons-material';
+import { useResponsive } from '../../hooks/useResponsive';
+import { MobileSheet } from '../Mobile/common/MobileSheet';
 
 // Emoji names for search functionality
 export const EMOJI_NAMES: Record<string, string[]> = {
@@ -145,7 +147,9 @@ export const EMOJI_CATEGORIES: Record<string, string[]> = {
  */
 const EmojiPickerContent: React.FC<{
   onEmojiClick: (emoji: string) => void;
-}> = ({ onEmojiClick }) => {
+  /** Touch variant: full-width, taller, larger tap targets (for MobileSheet). */
+  touch?: boolean;
+}> = ({ onEmojiClick, touch = false }) => {
   const [searchQuery, setSearchQuery] = useState('');
 
   // Filter emojis based on search query
@@ -183,8 +187,8 @@ const EmojiPickerContent: React.FC<{
 
   return (
     <Box sx={{
-      width: '300px',
-      height: '400px',
+      width: touch ? '100%' : '300px',
+      height: touch ? '60vh' : '400px',
       display: 'flex',
       flexDirection: 'column',
     }}>
@@ -305,8 +309,8 @@ const EmojiPickerContent: React.FC<{
                     size="small"
                     onClick={() => onEmojiClick(emoji)}
                     sx={{
-                      fontSize: '16px',
-                      padding: '4px',
+                      fontSize: touch ? '24px' : '16px',
+                      padding: touch ? '8px' : '4px',
                       borderRadius: '4px',
                       aspectRatio: '1',
                       minWidth: 'unset',
@@ -368,10 +372,22 @@ export const EmojiPickerPopover: React.FC<EmojiPickerPopoverProps> = ({
   onClose,
   onEmojiSelect,
 }) => {
+  const { shouldUseTouchUI } = useResponsive();
+
   const handleEmojiClick = (emoji: string) => {
     onEmojiSelect(emoji);
     onClose();
   };
+
+  // On touch devices, present the picker as a full-width bottom sheet instead
+  // of a small anchored popover.
+  if (shouldUseTouchUI) {
+    return (
+      <MobileSheet open={open} onClose={onClose} title="Add Reaction" maxHeight="70vh">
+        <EmojiPickerContent onEmojiClick={handleEmojiClick} touch />
+      </MobileSheet>
+    );
+  }
 
   return (
     <Popover

--- a/frontend/src/components/Message/MemberList.tsx
+++ b/frontend/src/components/Message/MemberList.tsx
@@ -105,6 +105,7 @@ const MemberRow: React.FC<{
         onTouchStart: longPress.onTouchStart,
         onTouchMove: longPress.onTouchMove,
         onTouchEnd: longPress.onTouchEnd,
+        onTouchCancel: longPress.onTouchCancel,
         onContextMenu: longPress.onContextMenu,
       }
     : {

--- a/frontend/src/components/Message/MemberList.tsx
+++ b/frontend/src/components/Message/MemberList.tsx
@@ -15,6 +15,8 @@ import { alpha, useTheme } from "@mui/material/styles";
 import UserAvatar from "../Common/UserAvatar";
 import { UserModerationMenu } from "../Moderation";
 import { useUserProfile } from "../../contexts/UserProfileContext";
+import { useResponsive } from "../../hooks/useResponsive";
+import { useLongPress } from "../../hooks/useSwipeGesture";
 
 export interface MemberData {
   id: string;
@@ -79,6 +81,96 @@ const SectionHeader: React.FC<{ label: string; count: number }> = ({ label, coun
   </ListItem>
 );
 
+/**
+ * A single member row. Left-click / tap opens the profile; right-click (desktop)
+ * or long-press (touch) opens the moderation menu anchored at the pointer.
+ */
+const MemberRow: React.FC<{
+  member: MemberData;
+  onOpenProfile: (userId: string) => void;
+  onOpenMenu: (position: { top: number; left: number }, member: MemberData) => void;
+}> = ({ member, onOpenProfile, onOpenMenu }) => {
+  const theme = useTheme();
+  const { shouldUseTouchUI } = useResponsive();
+
+  const longPress = useLongPress(
+    (point) => {
+      if (point) onOpenMenu({ top: point.y, left: point.x }, member);
+    },
+    { enabled: shouldUseTouchUI },
+  );
+
+  const interactionProps = shouldUseTouchUI
+    ? {
+        onTouchStart: longPress.onTouchStart,
+        onTouchMove: longPress.onTouchMove,
+        onTouchEnd: longPress.onTouchEnd,
+        onContextMenu: longPress.onContextMenu,
+      }
+    : {
+        onContextMenu: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+          onOpenMenu({ top: e.clientY, left: e.clientX }, member);
+        },
+      };
+
+  return (
+    <ListItemButton
+      onClick={() => onOpenProfile(member.id)}
+      {...interactionProps}
+      sx={{
+        px: 2,
+        py: 0.5,
+        "&:hover": {
+          backgroundColor: theme.palette.semantic.overlay.light,
+        },
+      }}
+    >
+      <ListItemAvatar sx={{ minWidth: 40 }}>
+        <UserAvatar
+          userId={member.id}
+          size="small"
+          showStatus={true}
+          isOnline={member.isOnline}
+        />
+      </ListItemAvatar>
+      <ListItemText
+        primary={
+          <Typography
+            variant="body2"
+            sx={{
+              fontWeight: 500,
+              fontSize: "14px",
+              lineHeight: 1.2,
+            }}
+          >
+            {member.displayName || member.username}
+          </Typography>
+        }
+        secondary={
+          member.status ? (
+            <Typography
+              variant="caption"
+              sx={{
+                color: "text.secondary",
+                fontSize: "11px",
+                lineHeight: 1.2,
+                display: "block",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                maxWidth: 150,
+              }}
+            >
+              {member.status}
+            </Typography>
+          ) : null
+        }
+      />
+    </ListItemButton>
+  );
+};
+
 const MemberList: React.FC<MemberListProps> = ({
   members,
   isLoading = false,
@@ -86,20 +178,18 @@ const MemberList: React.FC<MemberListProps> = ({
   title = "Members",
   communityId,
 }) => {
-  const theme = useTheme();
   const { openProfile } = useUserProfile();
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     position: null,
     member: null,
   });
 
-  const handleContextMenu = (event: React.MouseEvent<HTMLElement>, member: MemberData) => {
-    event.preventDefault();
-    setContextMenu({
-      position: { top: event.clientY, left: event.clientX },
-      member,
-    });
-  };
+  const openMenu = React.useCallback(
+    (position: { top: number; left: number }, member: MemberData) => {
+      setContextMenu({ position, member });
+    },
+    [],
+  );
 
   const handleCloseContextMenu = () => {
     setContextMenu({ position: null, member: null });
@@ -160,60 +250,12 @@ const MemberList: React.FC<MemberListProps> = ({
   }, [members]);
 
   const renderMember = (member: MemberData) => (
-    <ListItemButton
+    <MemberRow
       key={member.id}
-      onClick={() => openProfile(member.id)}
-      onContextMenu={(e) => handleContextMenu(e, member)}
-      sx={{
-        px: 2,
-        py: 0.5,
-        "&:hover": {
-          backgroundColor: theme.palette.semantic.overlay.light,
-        },
-      }}
-    >
-      <ListItemAvatar sx={{ minWidth: 40 }}>
-        <UserAvatar
-          userId={member.id}
-          size="small"
-          showStatus={true}
-          isOnline={member.isOnline}
-        />
-      </ListItemAvatar>
-      <ListItemText
-        primary={
-          <Typography
-            variant="body2"
-            sx={{
-              fontWeight: 500,
-              fontSize: "14px",
-              lineHeight: 1.2,
-            }}
-          >
-            {member.displayName || member.username}
-          </Typography>
-        }
-        secondary={
-          member.status ? (
-            <Typography
-              variant="caption"
-              sx={{
-                color: "text.secondary",
-                fontSize: "11px",
-                lineHeight: 1.2,
-                display: "block",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-                maxWidth: 150,
-              }}
-            >
-              {member.status}
-            </Typography>
-          ) : null
-        }
-      />
-    </ListItemButton>
+      member={member}
+      onOpenProfile={openProfile}
+      onOpenMenu={openMenu}
+    />
   );
 
   if (error) {

--- a/frontend/src/components/Message/MemberList.tsx
+++ b/frontend/src/components/Message/MemberList.tsx
@@ -117,7 +117,12 @@ const MemberRow: React.FC<{
 
   return (
     <ListItemButton
-      onClick={() => onOpenProfile(member.id)}
+      onClick={() => {
+        // Ignore the ghost click some browsers (iOS) fire after a long-press —
+        // otherwise the profile opens on top of the moderation menu.
+        if (longPress.isLongPressTriggered()) return;
+        onOpenProfile(member.id);
+      }}
       {...interactionProps}
       sx={{
         px: 2,

--- a/frontend/src/components/Message/MessageActionsSheet.tsx
+++ b/frontend/src/components/Message/MessageActionsSheet.tsx
@@ -1,0 +1,167 @@
+/**
+ * MessageActionsSheet
+ *
+ * Mobile bottom-sheet equivalent of MessageContextMenu. Shows a quick-reaction
+ * row on top and the shared, data-driven message action list below as large,
+ * touch-friendly rows.
+ */
+
+import React, { useCallback } from 'react';
+import {
+  Box,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  IconButton,
+  Divider,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import { MobileSheet } from '../Mobile/common/MobileSheet';
+import { TOUCH_TARGETS } from '../../utils/breakpoints';
+import { getMessageActions, type MessageAction } from './messageActions';
+import { EMOJI_CATEGORIES } from './EmojiPicker';
+import type { MessageContextMenuProps } from './MessageContextMenu';
+
+/** Common emoji for the quick-reaction row (first row of "Frequently Used"). */
+export const QUICK_REACTIONS = EMOJI_CATEGORIES['Frequently Used'].slice(0, 8);
+
+export interface MessageActionsSheetProps extends MessageContextMenuProps {
+  /** Add a specific reaction from the quick-reaction row. */
+  onEmojiSelect: (emoji: string) => void;
+}
+
+const MessageActionsSheet: React.FC<MessageActionsSheetProps> = ({
+  open,
+  onClose,
+  message,
+  canEdit,
+  canDelete,
+  canPin,
+  canReact,
+  canThread,
+  isPinned,
+  onEdit,
+  onDelete,
+  onPin,
+  onUnpin,
+  onReplyInThread,
+  onQuoteReply,
+  onAddReaction,
+  onEmojiSelect,
+}) => {
+  const actions = getMessageActions({
+    message,
+    canEdit,
+    canDelete,
+    canPin,
+    canReact,
+    canThread,
+    isPinned,
+    handlers: {
+      onEdit,
+      onDelete,
+      onPin,
+      onUnpin,
+      onReplyInThread,
+      onQuoteReply,
+      onAddReaction,
+    },
+  });
+
+  // The quick-reaction row + "+" cover reactions, so drop the redundant
+  // "Add Reaction" list row.
+  const listActions = actions.filter((a) => a.group !== 'reaction');
+
+  const handleSelect = useCallback(
+    (action: MessageAction) => {
+      void action.run();
+      onClose();
+    },
+    [onClose],
+  );
+
+  const handleQuickReaction = useCallback(
+    (emoji: string) => {
+      onEmojiSelect(emoji);
+      onClose();
+    },
+    [onEmojiSelect, onClose],
+  );
+
+  const handleOpenPicker = useCallback(() => {
+    onAddReaction();
+    onClose();
+  }, [onAddReaction, onClose]);
+
+  return (
+    <MobileSheet open={open} onClose={onClose} maxHeight="70vh" showCloseButton={false}>
+      {canReact && (
+        <>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              flexWrap: 'wrap',
+              pb: 1.5,
+            }}
+          >
+            {QUICK_REACTIONS.map((emoji) => (
+              <IconButton
+                key={emoji}
+                aria-label={`React with ${emoji}`}
+                onClick={() => handleQuickReaction(emoji)}
+                sx={{
+                  minWidth: TOUCH_TARGETS.MINIMUM,
+                  minHeight: TOUCH_TARGETS.MINIMUM,
+                  fontSize: '1.5rem',
+                }}
+              >
+                {emoji}
+              </IconButton>
+            ))}
+            <IconButton
+              aria-label="More reactions"
+              onClick={handleOpenPicker}
+              sx={{
+                minWidth: TOUCH_TARGETS.MINIMUM,
+                minHeight: TOUCH_TARGETS.MINIMUM,
+              }}
+            >
+              <AddIcon />
+            </IconButton>
+          </Box>
+          <Divider />
+        </>
+      )}
+
+      <List disablePadding>
+        {listActions.map((action) => (
+          <ListItemButton
+            key={action.key}
+            onClick={() => handleSelect(action)}
+            sx={{
+              minHeight: TOUCH_TARGETS.RECOMMENDED,
+              borderRadius: 1,
+              color: action.destructive ? 'error.main' : undefined,
+            }}
+          >
+            <ListItemIcon
+              sx={{ color: action.destructive ? 'error.main' : undefined }}
+            >
+              {action.icon}
+            </ListItemIcon>
+            <ListItemText
+              primaryTypographyProps={{ fontSize: '1rem' }}
+            >
+              {action.label}
+            </ListItemText>
+          </ListItemButton>
+        ))}
+      </List>
+    </MobileSheet>
+  );
+};
+
+export default MessageActionsSheet;

--- a/frontend/src/components/Message/MessageComponent.tsx
+++ b/frontend/src/components/Message/MessageComponent.tsx
@@ -30,7 +30,10 @@ import { useUserProfile } from "../../contexts/UserProfileContext";
 import { SeenByTooltip } from "./SeenByTooltip";
 import { VoiceSessionType } from "../../contexts/VoiceContext";
 import MessageContextMenu from "./MessageContextMenu";
+import MessageActionsSheet from "./MessageActionsSheet";
 import { EmojiPickerPopover } from "./EmojiPicker";
+import { useResponsive } from "../../hooks/useResponsive";
+import { useLongPress } from "../../hooks/useSwipeGesture";
 
 interface MessageProps {
   message: MessageType;
@@ -108,9 +111,13 @@ function MessageComponentInner({
     handleUnpin,
   } = useMessageActions(message, currentUser?.id);
 
+  const { shouldUseTouchUI } = useResponsive();
+
   // Context menu state
   const [contextMenuPosition, setContextMenuPosition] = useState<{ top: number; left: number } | null>(null);
   const [emojiPickerPosition, setEmojiPickerPosition] = useState<{ top: number; left: number } | null>(null);
+  const [emojiPickerOpen, setEmojiPickerOpen] = useState(false);
+  const [actionsSheetOpen, setActionsSheetOpen] = useState(false);
 
   const handleContextMenu = useCallback((event: React.MouseEvent) => {
     event.preventDefault();
@@ -127,13 +134,44 @@ function MessageComponentInner({
     setContextMenuPosition(null);
   }, [contextMenuPosition]);
 
+  // Touch: long-press opens the mobile actions sheet
+  const handleOpenActionsSheet = useCallback(() => {
+    setActionsSheetOpen(true);
+  }, []);
+
+  const longPress = useLongPress(handleOpenActionsSheet, {
+    enabled: shouldUseTouchUI && !isEditing,
+  });
+
+  // Touch: "Add Reaction" / "+" opens the emoji picker (as a bottom sheet)
+  const handleSheetAddReaction = useCallback(() => {
+    setEmojiPickerOpen(true);
+  }, []);
+
+  const handleCloseEmojiPicker = useCallback(() => {
+    setEmojiPickerPosition(null);
+    setEmojiPickerOpen(false);
+  }, []);
+
+  // Under touch UI, wire long-press handlers and suppress native selection /
+  // context menu; otherwise keep desktop right-click behavior untouched.
+  const containerInteractionProps = shouldUseTouchUI
+    ? {
+        onTouchStart: longPress.onTouchStart,
+        onTouchMove: longPress.onTouchMove,
+        onTouchEnd: longPress.onTouchEnd,
+        onContextMenu: longPress.onContextMenu,
+        style: { WebkitTouchCallout: "none", userSelect: "none" } as React.CSSProperties,
+      }
+    : { onContextMenu: handleContextMenu };
+
   return (
     <Container
       stagedForDelete={stagedForDelete}
       isDeleting={isDeleting}
       isHighlighted={isMentioned}
       isSearchHighlight={isSearchHighlight}
-      onContextMenu={handleContextMenu}
+      {...containerInteractionProps}
     >
       <div style={{ marginRight: 12, marginTop: 4 }}>
         <UserAvatar
@@ -288,13 +326,35 @@ function MessageComponentInner({
         onQuoteReply={onQuoteReply && !message.deletedAt ? () => onQuoteReply(message) : undefined}
         onAddReaction={handleAddReaction}
       />
+      {shouldUseTouchUI && (
+        <MessageActionsSheet
+          open={actionsSheetOpen}
+          onClose={() => setActionsSheetOpen(false)}
+          anchorPosition={null}
+          message={message}
+          canEdit={canEdit}
+          canDelete={canDelete}
+          canPin={canPin}
+          canReact={canReact}
+          canThread={canThread}
+          isPinned={isPinned}
+          onEdit={handleEditClick}
+          onDelete={handleDeleteClick}
+          onPin={handlePin}
+          onUnpin={handleUnpin}
+          onReplyInThread={handleOpenThread}
+          onQuoteReply={onQuoteReply && !message.deletedAt ? () => onQuoteReply(message) : undefined}
+          onAddReaction={handleSheetAddReaction}
+          onEmojiSelect={handleEmojiSelect}
+        />
+      )}
       <EmojiPickerPopover
-        open={Boolean(emojiPickerPosition)}
+        open={Boolean(emojiPickerPosition) || emojiPickerOpen}
         anchorPosition={emojiPickerPosition}
-        onClose={() => setEmojiPickerPosition(null)}
+        onClose={handleCloseEmojiPicker}
         onEmojiSelect={(emoji) => {
           handleEmojiSelect(emoji);
-          setEmojiPickerPosition(null);
+          handleCloseEmojiPicker();
         }}
       />
     </Container>

--- a/frontend/src/components/Message/MessageComponent.tsx
+++ b/frontend/src/components/Message/MessageComponent.tsx
@@ -155,14 +155,19 @@ function MessageComponentInner({
 
   // Under touch UI, wire long-press handlers and suppress native selection /
   // context menu; otherwise keep desktop right-click behavior untouched.
+  // While editing on touch, attach nothing so native text selection and the
+  // clipboard callout work inside the edit form.
   const containerInteractionProps = shouldUseTouchUI
-    ? {
-        onTouchStart: longPress.onTouchStart,
-        onTouchMove: longPress.onTouchMove,
-        onTouchEnd: longPress.onTouchEnd,
-        onContextMenu: longPress.onContextMenu,
-        style: { WebkitTouchCallout: "none", userSelect: "none" } as React.CSSProperties,
-      }
+    ? isEditing
+      ? {}
+      : {
+          onTouchStart: longPress.onTouchStart,
+          onTouchMove: longPress.onTouchMove,
+          onTouchEnd: longPress.onTouchEnd,
+          onTouchCancel: longPress.onTouchCancel,
+          onContextMenu: longPress.onContextMenu,
+          style: { WebkitTouchCallout: "none", userSelect: "none" } as React.CSSProperties,
+        }
     : { onContextMenu: handleContextMenu };
 
   return (

--- a/frontend/src/components/Message/MessageComponentStyles.tsx
+++ b/frontend/src/components/Message/MessageComponentStyles.tsx
@@ -78,4 +78,12 @@ export const Container = styled("div", {
       opacity: 1,
     },
   },
+  // On touch devices there is no real hover; a tap can produce a sticky :hover
+  // state, so keep the hover toolbar hidden (actions come from the long-press
+  // sheet instead).
+  "@media (hover: none)": {
+    "&:hover .message-tools": {
+      opacity: 0,
+    },
+  },
 }));

--- a/frontend/src/components/Message/MessageContextMenu.tsx
+++ b/frontend/src/components/Message/MessageContextMenu.tsx
@@ -13,16 +13,8 @@ import {
   ListItemText,
   Divider,
 } from '@mui/material';
-import FormatQuoteIcon from '@mui/icons-material/FormatQuote';
-import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
-import AddReactionIcon from '@mui/icons-material/AddReaction';
-import PushPinIcon from '@mui/icons-material/PushPin';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import type { Message } from '../../types/message.type';
-import { spansToText } from '../../utils/mentionParser';
-import { copyToClipboard } from '../../utils/clipboard';
+import { getMessageActions, type MessageAction } from './messageActions';
 
 export interface MessageContextMenuProps {
   anchorPosition: { top: number; left: number } | null;
@@ -65,52 +57,53 @@ const MessageContextMenu: React.FC<MessageContextMenuProps> = ({
   onQuoteReply,
   onAddReaction,
 }) => {
-  const handleCopyContent = useCallback(async () => {
-    const text = spansToText(message.spans);
-    try {
-      await copyToClipboard(text);
-    } catch {
-      // Clipboard write can fail in non-secure contexts; fail silently
-    }
-    onClose();
-  }, [message.spans, onClose]);
+  const actions = getMessageActions({
+    message,
+    canEdit,
+    canDelete,
+    canPin,
+    canReact,
+    canThread,
+    isPinned,
+    handlers: {
+      onEdit,
+      onDelete,
+      onPin,
+      onUnpin,
+      onReplyInThread,
+      onQuoteReply,
+      onAddReaction,
+    },
+  });
 
-  const handleQuoteReply = useCallback(() => {
-    onQuoteReply?.();
-    onClose();
-  }, [onQuoteReply, onClose]);
+  const handleSelect = useCallback(
+    (action: MessageAction) => {
+      void action.run();
+      onClose();
+    },
+    [onClose],
+  );
 
-  const handleReplyInThread = useCallback(() => {
-    onReplyInThread();
-    onClose();
-  }, [onReplyInThread, onClose]);
+  const renderItem = (action: MessageAction) => (
+    <MenuItem
+      key={action.key}
+      onClick={() => handleSelect(action)}
+      sx={action.destructive ? { color: 'error.main' } : undefined}
+    >
+      <ListItemIcon sx={action.destructive ? { color: 'error.main' } : undefined}>
+        {action.icon}
+      </ListItemIcon>
+      <ListItemText>{action.label}</ListItemText>
+    </MenuItem>
+  );
 
-  const handleAddReaction = useCallback(() => {
-    onAddReaction();
-    onClose();
-  }, [onAddReaction, onClose]);
+  const replyActions = actions.filter((a) => a.group === 'reply');
+  const reactionActions = actions.filter((a) => a.group === 'reaction');
+  const moderationActions = actions.filter((a) => a.group === 'moderation');
+  const copyActions = actions.filter((a) => a.group === 'copy');
 
-  const handlePin = useCallback(() => {
-    if (isPinned) {
-      onUnpin();
-    } else {
-      onPin();
-    }
-    onClose();
-  }, [isPinned, onPin, onUnpin, onClose]);
-
-  const handleEdit = useCallback(() => {
-    onEdit();
-    onClose();
-  }, [onEdit, onClose]);
-
-  const handleDelete = useCallback(() => {
-    onDelete();
-    onClose();
-  }, [onDelete, onClose]);
-
-  const hasReplyItems = !!onQuoteReply || canThread;
-  const hasMiddleItems = canPin || canEdit || canDelete;
+  const hasReplyItems = replyActions.length > 0;
+  const hasMiddleItems = moderationActions.length > 0;
 
   return (
     <Menu
@@ -119,80 +112,22 @@ const MessageContextMenu: React.FC<MessageContextMenuProps> = ({
       open={open}
       onClose={onClose}
     >
-      {/* Reply actions */}
-      {onQuoteReply && (
-        <MenuItem onClick={handleQuoteReply}>
-          <ListItemIcon>
-            <FormatQuoteIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Reply</ListItemText>
-        </MenuItem>
-      )}
-      {canThread && (
-        <MenuItem onClick={handleReplyInThread}>
-          <ListItemIcon>
-            <ChatBubbleOutlineIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Reply in Thread</ListItemText>
-        </MenuItem>
-      )}
+      {replyActions.map(renderItem)}
 
       {/* Divider between reply actions and reaction */}
       {hasReplyItems && <Divider />}
 
-      {/* Add Reaction */}
-      {canReact && (
-        <MenuItem onClick={handleAddReaction}>
-          <ListItemIcon>
-            <AddReactionIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Add Reaction</ListItemText>
-        </MenuItem>
-      )}
+      {reactionActions.map(renderItem)}
 
       {/* Divider between reaction and moderation/edit actions */}
-      {canReact && hasMiddleItems && <Divider />}
+      {reactionActions.length > 0 && hasMiddleItems && <Divider />}
 
-      {/* Pin/Unpin */}
-      {canPin && (
-        <MenuItem onClick={handlePin}>
-          <ListItemIcon>
-            <PushPinIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>{isPinned ? 'Unpin Message' : 'Pin Message'}</ListItemText>
-        </MenuItem>
-      )}
-
-      {/* Edit */}
-      {canEdit && (
-        <MenuItem onClick={handleEdit}>
-          <ListItemIcon>
-            <EditIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Edit Message</ListItemText>
-        </MenuItem>
-      )}
-
-      {/* Delete */}
-      {canDelete && (
-        <MenuItem onClick={handleDelete} sx={{ color: 'error.main' }}>
-          <ListItemIcon sx={{ color: 'error.main' }}>
-            <DeleteIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Delete Message</ListItemText>
-        </MenuItem>
-      )}
+      {moderationActions.map(renderItem)}
 
       {/* Divider before copy */}
       <Divider />
 
-      {/* Copy Message Content — always shown */}
-      <MenuItem onClick={handleCopyContent}>
-        <ListItemIcon>
-          <ContentCopyIcon fontSize="small" />
-        </ListItemIcon>
-        <ListItemText>Copy Message Content</ListItemText>
-      </MenuItem>
+      {copyActions.map(renderItem)}
     </Menu>
   );
 };

--- a/frontend/src/components/Message/messageActions.ts
+++ b/frontend/src/components/Message/messageActions.ts
@@ -1,0 +1,155 @@
+/**
+ * messageActions
+ *
+ * Data-driven model of the actions available on a message. Shared by the
+ * desktop right-click menu (MessageContextMenu) and the mobile bottom sheet
+ * (MessageActionsSheet) so both stay in lock-step.
+ */
+
+import React from 'react';
+import FormatQuoteIcon from '@mui/icons-material/FormatQuote';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import AddReactionIcon from '@mui/icons-material/AddReaction';
+import PushPinIcon from '@mui/icons-material/PushPin';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import type { Message } from '../../types/message.type';
+import { spansToText } from '../../utils/mentionParser';
+import { copyToClipboard } from '../../utils/clipboard';
+
+/** Logical grouping used to lay out dividers between sections. */
+export type MessageActionGroup = 'reply' | 'reaction' | 'moderation' | 'copy';
+
+export interface MessageAction {
+  /** Stable identifier for keys/tests. */
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  group: MessageActionGroup;
+  /** Destructive actions render in the error color. */
+  destructive?: boolean;
+  /** Performs the action. Does NOT close the surrounding menu/sheet. */
+  run: () => void | Promise<void>;
+}
+
+export interface MessageActionHandlers {
+  onEdit: () => void;
+  onDelete: () => void;
+  onPin: () => void;
+  onUnpin: () => void;
+  onReplyInThread: () => void;
+  onQuoteReply?: () => void;
+  onAddReaction: () => void;
+}
+
+export interface MessageActionConfig {
+  message: Message;
+  canEdit: boolean;
+  canDelete: boolean;
+  canPin: boolean;
+  canReact: boolean;
+  canThread: boolean;
+  isPinned: boolean;
+  handlers: MessageActionHandlers;
+}
+
+/**
+ * Build the ordered list of actions for a message given the caller's
+ * permissions and handlers. Order and inclusion mirror the original
+ * MessageContextMenu exactly.
+ */
+export function getMessageActions(config: MessageActionConfig): MessageAction[] {
+  const {
+    message,
+    canEdit,
+    canDelete,
+    canPin,
+    canReact,
+    canThread,
+    isPinned,
+    handlers,
+  } = config;
+
+  const actions: MessageAction[] = [];
+
+  // Reply actions
+  if (handlers.onQuoteReply) {
+    const onQuoteReply = handlers.onQuoteReply;
+    actions.push({
+      key: 'reply',
+      label: 'Reply',
+      icon: React.createElement(FormatQuoteIcon, { fontSize: 'small' }),
+      group: 'reply',
+      run: () => onQuoteReply(),
+    });
+  }
+  if (canThread) {
+    actions.push({
+      key: 'reply-in-thread',
+      label: 'Reply in Thread',
+      icon: React.createElement(ChatBubbleOutlineIcon, { fontSize: 'small' }),
+      group: 'reply',
+      run: () => handlers.onReplyInThread(),
+    });
+  }
+
+  // Reaction
+  if (canReact) {
+    actions.push({
+      key: 'add-reaction',
+      label: 'Add Reaction',
+      icon: React.createElement(AddReactionIcon, { fontSize: 'small' }),
+      group: 'reaction',
+      run: () => handlers.onAddReaction(),
+    });
+  }
+
+  // Moderation / edit
+  if (canPin) {
+    actions.push({
+      key: 'pin',
+      label: isPinned ? 'Unpin Message' : 'Pin Message',
+      icon: React.createElement(PushPinIcon, { fontSize: 'small' }),
+      group: 'moderation',
+      run: () => (isPinned ? handlers.onUnpin() : handlers.onPin()),
+    });
+  }
+  if (canEdit) {
+    actions.push({
+      key: 'edit',
+      label: 'Edit Message',
+      icon: React.createElement(EditIcon, { fontSize: 'small' }),
+      group: 'moderation',
+      run: () => handlers.onEdit(),
+    });
+  }
+  if (canDelete) {
+    actions.push({
+      key: 'delete',
+      label: 'Delete Message',
+      icon: React.createElement(DeleteIcon, { fontSize: 'small' }),
+      group: 'moderation',
+      destructive: true,
+      run: () => handlers.onDelete(),
+    });
+  }
+
+  // Copy — always available
+  actions.push({
+    key: 'copy',
+    label: 'Copy Message Content',
+    icon: React.createElement(ContentCopyIcon, { fontSize: 'small' }),
+    group: 'copy',
+    run: async () => {
+      const text = spansToText(message.spans);
+      try {
+        await copyToClipboard(text);
+      } catch {
+        // Clipboard write can fail in non-secure contexts; fail silently
+      }
+    },
+  });
+
+  return actions;
+}

--- a/frontend/src/components/Voice/components/CompactUserItem.tsx
+++ b/frontend/src/components/Voice/components/CompactUserItem.tsx
@@ -103,7 +103,12 @@ const CompactUserItem: React.FC<CompactUserItemProps> = React.memo(({
           backgroundColor: theme.palette.semantic.overlay.light,
         },
       }}
-      onClick={() => onClickUser(user.id)}
+      onClick={() => {
+        // Ignore the post-long-press ghost click (iOS) so the profile
+        // doesn't open on top of the moderation menu.
+        if (longPress.isLongPressTriggered()) return;
+        onClickUser(user.id);
+      }}
       {...interactionProps}
     >
       <ListItemAvatar sx={{ minWidth: 40 }}>

--- a/frontend/src/components/Voice/components/CompactUserItem.tsx
+++ b/frontend/src/components/Voice/components/CompactUserItem.tsx
@@ -20,6 +20,8 @@ import { useParticipantTracks } from "../../../hooks/useParticipantTracks";
 import UserAvatar from "../../Common/UserAvatar";
 import { VOLUME_STORAGE_PREFIX } from "../../../constants/voice";
 import { deriveUserState } from "./voiceUserState";
+import { useResponsive } from "../../../hooks/useResponsive";
+import { useLongPress } from "../../../hooks/useSwipeGesture";
 
 interface CompactUserItemProps {
   user: VoicePresenceUserDto;
@@ -56,6 +58,28 @@ const CompactUserItem: React.FC<CompactUserItemProps> = React.memo(({
   const livekitState = useParticipantTracks(user.id);
   const userState = deriveUserState(livekitState, user);
   const speaking = isSpeaking(user.id) && !userState.isMuted && !userState.isServerMuted && !userState.isDeafened;
+  const { shouldUseTouchUI } = useResponsive();
+
+  const longPress = useLongPress(
+    (point) => {
+      if (point) {
+        onContextMenu(
+          { preventDefault: () => {}, clientX: point.x, clientY: point.y } as React.MouseEvent<HTMLElement>,
+          user,
+        );
+      }
+    },
+    { enabled: shouldUseTouchUI },
+  );
+
+  const interactionProps = shouldUseTouchUI
+    ? {
+        onTouchStart: longPress.onTouchStart,
+        onTouchMove: longPress.onTouchMove,
+        onTouchEnd: longPress.onTouchEnd,
+        onContextMenu: longPress.onContextMenu,
+      }
+    : { onContextMenu: (e: React.MouseEvent<HTMLElement>) => onContextMenu(e, user) };
 
   // Check if locally muted (volume = 0 in localStorage)
   const isLocalUser = localParticipantIdentity === user.id;
@@ -79,7 +103,7 @@ const CompactUserItem: React.FC<CompactUserItemProps> = React.memo(({
         },
       }}
       onClick={() => onClickUser(user.id)}
-      onContextMenu={(e) => onContextMenu(e, user)}
+      {...interactionProps}
     >
       <ListItemAvatar sx={{ minWidth: 40 }}>
         <Box sx={{ position: "relative", display: "flex", alignItems: "center" }}>

--- a/frontend/src/components/Voice/components/CompactUserItem.tsx
+++ b/frontend/src/components/Voice/components/CompactUserItem.tsx
@@ -77,6 +77,7 @@ const CompactUserItem: React.FC<CompactUserItemProps> = React.memo(({
         onTouchStart: longPress.onTouchStart,
         onTouchMove: longPress.onTouchMove,
         onTouchEnd: longPress.onTouchEnd,
+        onTouchCancel: longPress.onTouchCancel,
         onContextMenu: longPress.onContextMenu,
       }
     : { onContextMenu: (e: React.MouseEvent<HTMLElement>) => onContextMenu(e, user) };

--- a/frontend/src/components/Voice/components/InlineUserAvatar.tsx
+++ b/frontend/src/components/Voice/components/InlineUserAvatar.tsx
@@ -41,6 +41,7 @@ const InlineUserAvatar: React.FC<InlineUserAvatarProps> = ({
         onTouchStart: longPress.onTouchStart,
         onTouchMove: longPress.onTouchMove,
         onTouchEnd: longPress.onTouchEnd,
+        onTouchCancel: longPress.onTouchCancel,
         onContextMenu: longPress.onContextMenu,
       }
     : { onContextMenu: (e: React.MouseEvent<HTMLElement>) => onContextMenu(e, user) };

--- a/frontend/src/components/Voice/components/InlineUserAvatar.tsx
+++ b/frontend/src/components/Voice/components/InlineUserAvatar.tsx
@@ -3,6 +3,8 @@ import { Box, Tooltip } from "@mui/material";
 import type { VoicePresenceUserDto } from "../../../api-client/types.gen";
 import { useParticipantTracks } from "../../../hooks/useParticipantTracks";
 import UserAvatar from "../../Common/UserAvatar";
+import { useResponsive } from "../../../hooks/useResponsive";
+import { useLongPress } from "../../../hooks/useSwipeGesture";
 
 interface InlineUserAvatarProps {
   /** WS presence payloads layer isVideoEnabled on top of the REST DTO */
@@ -20,6 +22,28 @@ const InlineUserAvatar: React.FC<InlineUserAvatarProps> = ({
   const isVideoEnabled = livekitState.participant
     ? livekitState.isCameraEnabled
     : Boolean(user.isVideoEnabled);
+  const { shouldUseTouchUI } = useResponsive();
+
+  const longPress = useLongPress(
+    (point) => {
+      if (point) {
+        onContextMenu(
+          { preventDefault: () => {}, clientX: point.x, clientY: point.y } as React.MouseEvent<HTMLElement>,
+          user,
+        );
+      }
+    },
+    { enabled: shouldUseTouchUI },
+  );
+
+  const interactionProps = shouldUseTouchUI
+    ? {
+        onTouchStart: longPress.onTouchStart,
+        onTouchMove: longPress.onTouchMove,
+        onTouchEnd: longPress.onTouchEnd,
+        onContextMenu: longPress.onContextMenu,
+      }
+    : { onContextMenu: (e: React.MouseEvent<HTMLElement>) => onContextMenu(e, user) };
 
   return (
     <Tooltip key={user.id} title={user.displayName || user.username}>
@@ -37,7 +61,7 @@ const InlineUserAvatar: React.FC<InlineUserAvatarProps> = ({
           cursor: "pointer",
         }}
         onClick={() => onClickUser(user.id)}
-        onContextMenu={(e) => onContextMenu(e, user)}
+        {...interactionProps}
       >
         <UserAvatar userId={user.id} size="small" />
       </Box>

--- a/frontend/src/components/Voice/components/InlineUserAvatar.tsx
+++ b/frontend/src/components/Voice/components/InlineUserAvatar.tsx
@@ -61,7 +61,12 @@ const InlineUserAvatar: React.FC<InlineUserAvatarProps> = ({
           justifyContent: "center",
           cursor: "pointer",
         }}
-        onClick={() => onClickUser(user.id)}
+        onClick={() => {
+          // Ignore the post-long-press ghost click (iOS) so the profile
+          // doesn't open on top of the moderation menu.
+          if (longPress.isLongPressTriggered()) return;
+          onClickUser(user.id);
+        }}
         {...interactionProps}
       >
         <UserAvatar userId={user.id} size="small" />

--- a/frontend/src/components/Voice/components/UserItem.tsx
+++ b/frontend/src/components/Voice/components/UserItem.tsx
@@ -60,6 +60,7 @@ const UserItem: React.FC<UserItemProps> = React.memo(({
         onTouchStart: longPress.onTouchStart,
         onTouchMove: longPress.onTouchMove,
         onTouchEnd: longPress.onTouchEnd,
+        onTouchCancel: longPress.onTouchCancel,
         onContextMenu: longPress.onContextMenu,
       }
     : { onContextMenu: (e: React.MouseEvent<HTMLElement>) => onContextMenu(e, user) };

--- a/frontend/src/components/Voice/components/UserItem.tsx
+++ b/frontend/src/components/Voice/components/UserItem.tsx
@@ -19,6 +19,8 @@ import { useParticipantTracks } from "../../../hooks/useParticipantTracks";
 import UserAvatar from "../../Common/UserAvatar";
 import { formatDistanceToNow } from "date-fns";
 import { deriveUserState } from "./voiceUserState";
+import { useResponsive } from "../../../hooks/useResponsive";
+import { useLongPress } from "../../../hooks/useSwipeGesture";
 
 interface UserItemProps {
   user: VoicePresenceUserDto;
@@ -39,6 +41,28 @@ const UserItem: React.FC<UserItemProps> = React.memo(({
 }) => {
   const livekitState = useParticipantTracks(user.id);
   const userState = deriveUserState(livekitState, user);
+  const { shouldUseTouchUI } = useResponsive();
+
+  const longPress = useLongPress(
+    (point) => {
+      if (point) {
+        onContextMenu(
+          { preventDefault: () => {}, clientX: point.x, clientY: point.y } as React.MouseEvent<HTMLElement>,
+          user,
+        );
+      }
+    },
+    { enabled: shouldUseTouchUI },
+  );
+
+  const interactionProps = shouldUseTouchUI
+    ? {
+        onTouchStart: longPress.onTouchStart,
+        onTouchMove: longPress.onTouchMove,
+        onTouchEnd: longPress.onTouchEnd,
+        onContextMenu: longPress.onContextMenu,
+      }
+    : { onContextMenu: (e: React.MouseEvent<HTMLElement>) => onContextMenu(e, user) };
 
   const statusIcons = [];
 
@@ -68,7 +92,7 @@ const UserItem: React.FC<UserItemProps> = React.memo(({
           },
         }}
         onClick={() => onClickUser(user.id)}
-        onContextMenu={(e) => onContextMenu(e, user)}
+        {...interactionProps}
       >
         <ListItemAvatar>
           <UserAvatar userId={user.id} size="small" />

--- a/frontend/src/components/Voice/components/UserItem.tsx
+++ b/frontend/src/components/Voice/components/UserItem.tsx
@@ -92,7 +92,12 @@ const UserItem: React.FC<UserItemProps> = React.memo(({
             backgroundColor: "action.hover",
           },
         }}
-        onClick={() => onClickUser(user.id)}
+        onClick={() => {
+          // Ignore the post-long-press ghost click (iOS) so the profile
+          // doesn't open on top of the moderation menu.
+          if (longPress.isLongPressTriggered()) return;
+          onClickUser(user.id);
+        }}
         {...interactionProps}
       >
         <ListItemAvatar>

--- a/frontend/src/hooks/useSwipeGesture.ts
+++ b/frontend/src/hooks/useSwipeGesture.ts
@@ -338,6 +338,7 @@ export const useLongPress = (
     onTouchStart: start,
     onTouchMove: move,
     onTouchEnd: cancel,
+    onTouchCancel: cancel,
     onContextMenu,
     isLongPressTriggered: () => isLongPressTriggered.current,
   };

--- a/frontend/src/hooks/useSwipeGesture.ts
+++ b/frontend/src/hooks/useSwipeGesture.ts
@@ -314,11 +314,14 @@ export const useLongPress = (
 
   // Suppress the native context menu / iOS callout that fires immediately after
   // a long-press. Only preventDefault when our long-press just fired so a real
-  // desktop right-click still passes through.
+  // desktop right-click still passes through (right-click's mousedown runs
+  // start(), which clears the flag before contextmenu fires). The flag is NOT
+  // reset here: browsers that skip the synthetic contextmenu (iOS) still fire
+  // a ghost click afterwards, and consumers guard their onClick by reading
+  // isLongPressTriggered(). It resets at the start of the next press.
   const onContextMenu = useCallback((e: React.MouseEvent) => {
     if (isLongPressTriggered.current) {
       e.preventDefault();
-      isLongPressTriggered.current = false;
     }
   }, []);
 

--- a/frontend/src/hooks/useSwipeGesture.ts
+++ b/frontend/src/hooks/useSwipeGesture.ts
@@ -7,6 +7,7 @@
 
 import { useRef, useEffect, TouchEvent, useCallback } from 'react';
 import { MOBILE_CONSTANTS } from '../utils/breakpoints';
+import { useHapticFeedback } from './useHapticFeedback';
 
 export type SwipeDirection = 'left' | 'right' | 'up' | 'down';
 
@@ -204,45 +205,122 @@ export const useSwipeGesture = (options: SwipeGestureOptions = {}) => {
   };
 };
 
+export interface LongPressPoint {
+  x: number;
+  y: number;
+}
+
+const INTERACTIVE_TARGET_SELECTOR = 'a, button, input, textarea, select, [role="button"]';
+
 /**
- * Hook for handling long press gestures
+ * Extract the pointer coordinates from a touch or mouse event.
+ */
+const getEventPoint = (e: TouchEvent | React.MouseEvent): LongPressPoint | null => {
+  if ('touches' in e) {
+    const touch = e.touches[0] ?? e.changedTouches[0];
+    return touch ? { x: touch.clientX, y: touch.clientY } : null;
+  }
+  return { x: e.clientX, y: e.clientY };
+};
+
+/**
+ * Whether the gesture started on a *nested* interactive element (link, button,
+ * input, etc.) — one below the element the long-press is bound to. The bound
+ * element itself is allowed even if it is a button/role=button (e.g. a
+ * ListItemButton row), so long-press still works while nested controls keep
+ * their own behavior.
+ */
+const startedOnInteractiveElement = (
+  target: EventTarget | null,
+  currentTarget: EventTarget | null,
+): boolean => {
+  if (!(target instanceof Element)) return false;
+  const interactive = target.closest(INTERACTIVE_TARGET_SELECTOR);
+  return !!interactive && interactive !== currentTarget;
+};
+
+/**
+ * Hook for handling long press gestures.
+ *
+ * Fires `onLongPress` (with the originating point) after `delay` ms of a
+ * stationary press. Movement beyond the slop threshold, an early release, or a
+ * press that begins on an interactive element all cancel the gesture. Also
+ * returns an `onContextMenu` handler consumers can attach to suppress the
+ * browser's native context menu / iOS callout right after a long-press fires.
  */
 export const useLongPress = (
-  onLongPress: () => void,
-  options: { delay?: number; enabled?: boolean; onPressStart?: () => void; onPressEnd?: () => void } = {}
+  onLongPress: (point: LongPressPoint | null) => void,
+  options: {
+    delay?: number;
+    enabled?: boolean;
+    slop?: number;
+    onPressStart?: () => void;
+    onPressEnd?: () => void;
+  } = {}
 ) => {
   const {
     delay = MOBILE_CONSTANTS.LONG_PRESS_DURATION,
     enabled = true,
+    slop = MOBILE_CONSTANTS.LONG_PRESS_SLOP,
     onPressStart,
     onPressEnd,
   } = options;
 
+  const haptics = useHapticFeedback();
   const timeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const isLongPressTriggered = useRef(false);
+  const startPoint = useRef<LongPressPoint | null>(null);
 
-  const start = useCallback((_e: TouchEvent | React.MouseEvent) => {
+  const clearTimer = useCallback(() => {
+    if (timeout.current) {
+      clearTimeout(timeout.current);
+      timeout.current = undefined;
+    }
+  }, []);
+
+  const start = useCallback((e: TouchEvent | React.MouseEvent) => {
     if (!enabled) return;
+    if (startedOnInteractiveElement(e.target, e.currentTarget)) return;
 
     isLongPressTriggered.current = false;
+    startPoint.current = getEventPoint(e);
     onPressStart?.();
 
     timeout.current = setTimeout(() => {
       isLongPressTriggered.current = true;
-      onLongPress();
-      // Haptic feedback
-      if ('vibrate' in navigator) {
-        navigator.vibrate(10);
-      }
+      haptics.longPress();
+      onLongPress(startPoint.current);
     }, delay);
-  }, [enabled, delay, onLongPress, onPressStart]);
+  }, [enabled, delay, onLongPress, onPressStart, haptics]);
+
+  const move = useCallback((e: TouchEvent | React.MouseEvent) => {
+    if (!timeout.current || !startPoint.current) return;
+
+    const point = getEventPoint(e);
+    if (!point) return;
+
+    const dx = Math.abs(point.x - startPoint.current.x);
+    const dy = Math.abs(point.y - startPoint.current.y);
+    if (dx > slop || dy > slop) {
+      clearTimer();
+    }
+  }, [slop, clearTimer]);
 
   const cancel = useCallback(() => {
-    if (timeout.current) {
-      clearTimeout(timeout.current);
-    }
+    clearTimer();
+    startPoint.current = null;
     onPressEnd?.();
-  }, [onPressEnd]);
+  }, [clearTimer, onPressEnd]);
+
+  // Suppress the native context menu / iOS callout that fires immediately after
+  // a long-press. Only preventDefault when our long-press just fired so a real
+  // desktop right-click still passes through.
+  const onContextMenu = useCallback((e: React.MouseEvent) => {
+    if (isLongPressTriggered.current) {
+      e.preventDefault();
+      isLongPressTriggered.current = false;
+    }
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -254,10 +332,13 @@ export const useLongPress = (
 
   return {
     onMouseDown: start,
+    onMouseMove: move,
     onMouseUp: cancel,
     onMouseLeave: cancel,
     onTouchStart: start,
+    onTouchMove: move,
     onTouchEnd: cancel,
+    onContextMenu,
     isLongPressTriggered: () => isLongPressTriggered.current,
   };
 };

--- a/frontend/src/utils/breakpoints.ts
+++ b/frontend/src/utils/breakpoints.ts
@@ -54,6 +54,7 @@ export const MOBILE_CONSTANTS = {
   SWIPE_THRESHOLD: 50, // pixels
   EDGE_SWIPE_ZONE: 20, // pixels from edge to trigger drawer
   LONG_PRESS_DURATION: 500, // milliseconds
+  LONG_PRESS_SLOP: 10, // pixels of movement that cancels a pending long-press
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

PR 2 of 7 in the mobile UX overhaul (stacked on #388). On touch devices, **message actions were unreachable**: the action toolbar only appears on `:hover` and the context menu only opens on right-click. Member-list and voice-user moderation menus had the same right-click-only problem. This PR wires the previously dead touch toolkit (`useLongPress`, `useHapticFeedback`, `MobileSheet`) into all of them.

## Changes

- **`useLongPress` hardened** (was dead code): cancels on >10px movement slop (scroll-safe), skips presses starting on nested interactive elements, haptic feedback via `useHapticFeedback`, suppresses the native context menu/iOS callout only right after a long-press fires, and passes the touch point to the callback (used to anchor menus).
- **Shared action model** `getMessageActions()` — `MessageContextMenu` refactored to consume it with identical behavior (its 17 existing tests pass unchanged).
- **`MessageActionsSheet`** (new) — Discord-style bottom sheet on long-press: quick-reaction row (first 8 "Frequently Used" emoji, 44px targets, "+" opens the full picker) above the full action list; destructive actions in error color.
- **`MessageComponent`**: under touch UI, long-press opens the sheet; native text-selection callout suppressed on touch only (copy stays available via the sheet). Desktop right-click behavior untouched. Hover-toolbar reveal disabled under `(hover: none)` so it never flashes on tap.
- **`EmojiPicker`**: renders as a bottom sheet (~70vh, larger targets) under touch UI instead of the fixed 300×400 popover.
- **Moderation menus**: long-press on member rows (`MemberList`) and voice user tiles (`UserItem`/`CompactUserItem`/`InlineUserAvatar`) opens the existing moderation menus anchored at the touch point.

## Testing

- New: `useLongPress` fake-timer suite (8 tests — fire/slop-cancel/early-release/interactive-guard/suppression) and `MessageActionsSheet` permission matrix (8 tests).
- Isolated runs of all affected suites: 81 tests passing (context menu, message component, member list, voice user lists, emoji picker, toolbar, reactions).
- `type-check` + `lint` clean. No new dependencies. Desktop/Electron gated behind `shouldUseTouchUI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvVeRD4zf7UofaTfNDJm2Z