### PR TITLE
feat(mobile): composer emoji button, Enter-newline on touch, layout caps

### DIFF
--- a/frontend/src/__tests__/components/MessageInput.test.tsx
+++ b/frontend/src/__tests__/components/MessageInput.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import MessageInput from '../../components/Message/MessageInput';
+import { VoiceSessionType } from '../../contexts/VoiceContext';
+
+// Let MSW intercept API-client requests
+vi.mock('../../api-client/client.gen', async (importOriginal) => {
+  const { createClient, createConfig } = await import('../../api-client/client');
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    client: createClient(createConfig({ baseUrl: 'http://localhost:3000' })),
+  };
+});
+
+// Mock the emoji picker so we can trigger a selection deterministically.
+// When open, it renders a button that inserts a fixed emoji.
+vi.mock('../../components/Message/EmojiPicker', () => ({
+  EmojiPickerPopover: ({
+    open,
+    onEmojiSelect,
+  }: {
+    open: boolean;
+    onEmojiSelect: (emoji: string) => void;
+  }) =>
+    open ? (
+      <button
+        type="button"
+        data-testid="mock-emoji-pick"
+        onClick={() => onEmojiSelect('🎉')}
+      >
+        pick
+      </button>
+    ) : null,
+}));
+
+// Default: desktop (non-touch). Individual tests override isTouchDevice.
+const mockResponsive = vi.fn(() => ({
+  isTouchDevice: false,
+  shouldUseTouchUI: false,
+  isMobile: false,
+  isTablet: false,
+  isDesktop: true,
+  deviceType: 'desktop' as string,
+}));
+
+vi.mock('../../hooks/useResponsive', () => ({
+  useResponsive: () => mockResponsive(),
+}));
+
+function setup(onSendMessage = vi.fn()) {
+  const utils = renderWithProviders(
+    <MessageInput
+      contextType={VoiceSessionType.Dm}
+      contextId="dm-1"
+      userMentions={[]}
+      onSendMessage={onSendMessage}
+    />,
+  );
+  const input = screen.getByPlaceholderText(
+    'Type a message...',
+  ) as HTMLTextAreaElement;
+  return { ...utils, input, onSendMessage };
+}
+
+describe('MessageInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // clearAllMocks does not reset mockReturnValue/implementation
+    mockResponsive.mockReturnValue({
+      isTouchDevice: false,
+      shouldUseTouchUI: false,
+      isMobile: false,
+      isTablet: false,
+      isDesktop: true,
+      deviceType: 'desktop',
+    });
+  });
+
+  describe('emoji insertion', () => {
+    it('inserts the selected emoji at the current cursor position', async () => {
+      const { user, input } = setup();
+
+      await user.type(input, 'Hello');
+      // Place the caret between "He" and "llo"
+      input.setSelectionRange(2, 2);
+      fireEvent.select(input);
+
+      // Open the (mocked) picker and select an emoji
+      await user.click(screen.getByLabelText('add emoji'));
+      await user.click(screen.getByTestId('mock-emoji-pick'));
+
+      expect(input.value).toBe('He🎉llo');
+
+      // Caret should land immediately after the inserted emoji ("🎉".length === 2)
+      await waitFor(() => {
+        expect(input.selectionStart).toBe(4);
+      });
+    });
+
+    it('appends the emoji when the caret is at the end', async () => {
+      const { user, input } = setup();
+
+      await user.type(input, 'Hi');
+      // caret already at end (2)
+      await user.click(screen.getByLabelText('add emoji'));
+      await user.click(screen.getByTestId('mock-emoji-pick'));
+
+      expect(input.value).toBe('Hi🎉');
+    });
+  });
+
+  describe('Enter key behavior', () => {
+    it('sends on Enter on desktop', async () => {
+      const { user, input, onSendMessage } = setup();
+
+      await user.type(input, 'hi{Enter}');
+
+      await waitFor(() => {
+        expect(onSendMessage).toHaveBeenCalledTimes(1);
+      });
+      expect(onSendMessage).toHaveBeenCalledWith(
+        'hi',
+        expect.any(Array),
+        expect.any(Array),
+      );
+      // Newline should NOT have been inserted (send prevented default)
+      expect(input.value).toBe('');
+    });
+
+    it('inserts a newline (does not send) on Enter on touch devices', async () => {
+      mockResponsive.mockReturnValue({
+        isTouchDevice: true,
+        shouldUseTouchUI: true,
+        isMobile: true,
+        isTablet: false,
+        isDesktop: false,
+        deviceType: 'phone',
+      });
+
+      const { user, input, onSendMessage } = setup();
+
+      await user.type(input, 'hi{Enter}');
+
+      expect(onSendMessage).not.toHaveBeenCalled();
+      expect(input.value).toBe('hi\n');
+    });
+  });
+});

--- a/frontend/src/components/Channel/ChannelMessageContainer.tsx
+++ b/frontend/src/components/Channel/ChannelMessageContainer.tsx
@@ -229,7 +229,7 @@ const ChannelMessageContainer: React.FC<ChannelMessageContainerProps> = ({
         open={pinnedPanelOpen}
         onClose={() => setPinnedPanelOpen(false)}
         PaperProps={{
-          sx: { width: 360 },
+          sx: { width: 'min(360px, 100vw)' },
         }}
       >
         <PinnedMessagesPanel
@@ -257,7 +257,7 @@ const ChannelMessageContainer: React.FC<ChannelMessageContainerProps> = ({
         onClose={handleCloseThread}
         PaperProps={{
           sx: {
-            width: 400,
+            width: 'min(400px, 100vw)',
             height: '100dvh',
             overflow: 'hidden',
             paddingBottom: voiceConnected ? `${VOICE_BAR_HEIGHT}px` : 0,

--- a/frontend/src/components/Message/EmojiPicker.tsx
+++ b/frontend/src/components/Message/EmojiPicker.tsx
@@ -405,6 +405,10 @@ export const EmojiPickerPopover: React.FC<EmojiPickerPopoverProps> = ({
         open={open}
         anchorEl={anchorEl}
         onClose={onClose}
+        // Without this, the Modal's focus trap re-focuses the emoji BUTTON
+        // when the exit transition finishes — clobbering the composer's
+        // caret/focus restore after inserting an emoji.
+        disableRestoreFocus
         anchorOrigin={{
           vertical: 'top',
           horizontal: 'left',

--- a/frontend/src/components/Message/EmojiPicker.tsx
+++ b/frontend/src/components/Message/EmojiPicker.tsx
@@ -357,20 +357,29 @@ const EmojiPickerContent: React.FC<{
 
 export interface EmojiPickerPopoverProps {
   open: boolean;
-  anchorPosition: { top: number; left: number } | null;
+  /** Screen-coordinate anchor (used by MessageContextMenu). */
+  anchorPosition?: { top: number; left: number } | null;
+  /** Element anchor (used by the composer emoji button); opens above the anchor. */
+  anchorEl?: HTMLElement | null;
   onClose: () => void;
   onEmojiSelect: (emoji: string) => void;
+  /** Sheet title on touch devices. */
+  title?: string;
 }
 
 /**
- * Controlled emoji picker popover positioned at anchorPosition.
- * Used by MessageContextMenu to show emoji picker at arbitrary screen positions.
+ * Controlled emoji picker popover.
+ * - `anchorEl` anchors to an element and opens above it (composer emoji button).
+ * - `anchorPosition` positions at arbitrary screen coordinates (MessageContextMenu).
+ * On touch devices it renders as a full-width bottom sheet regardless.
  */
 export const EmojiPickerPopover: React.FC<EmojiPickerPopoverProps> = ({
   open,
   anchorPosition,
+  anchorEl,
   onClose,
   onEmojiSelect,
+  title = 'Add Reaction',
 }) => {
   const { shouldUseTouchUI } = useResponsive();
 
@@ -383,9 +392,30 @@ export const EmojiPickerPopover: React.FC<EmojiPickerPopoverProps> = ({
   // of a small anchored popover.
   if (shouldUseTouchUI) {
     return (
-      <MobileSheet open={open} onClose={onClose} title="Add Reaction" maxHeight="70vh">
+      <MobileSheet open={open} onClose={onClose} title={title} maxHeight="70vh">
         <EmojiPickerContent onEmojiClick={handleEmojiClick} touch />
       </MobileSheet>
+    );
+  }
+
+  // Element-anchored popover that opens upward (e.g. above a composer button).
+  if (anchorEl) {
+    return (
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={onClose}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+      >
+        <EmojiPickerContent onEmojiClick={handleEmojiClick} />
+      </Popover>
     );
   }
 

--- a/frontend/src/components/Message/MentionDropdown.tsx
+++ b/frontend/src/components/Message/MentionDropdown.tsx
@@ -94,7 +94,10 @@ export const MentionDropdown: React.FC<MentionDropdownProps> = ({
       elevation={8}
       sx={{
         ...position,
-        maxHeight: 320,
+        // Cap height so the dropdown can never overflow the top of small screens.
+        maxHeight: 'min(320px, 40vh)',
+        display: 'flex',
+        flexDirection: 'column',
         overflow: 'hidden',
       }}
     >
@@ -103,6 +106,7 @@ export const MentionDropdown: React.FC<MentionDropdownProps> = ({
         sx={{
           px: 2,
           py: 1.5,
+          flexShrink: 0,
           borderBottom: `1px solid ${alpha(theme.palette.divider, 0.08)}`,
           background: alpha(theme.palette.primary.main, 0.02),
         }}
@@ -132,6 +136,8 @@ export const MentionDropdown: React.FC<MentionDropdownProps> = ({
       <List
         sx={{
           p: 0.5,
+          flex: 1,
+          minHeight: 0,
           maxHeight: 260,
           overflow: 'auto',
           '&::-webkit-scrollbar': {
@@ -153,6 +159,9 @@ export const MentionDropdown: React.FC<MentionDropdownProps> = ({
             sx={{
               borderRadius: 2,
               mb: 0.25,
+              // Comfortable touch target (desktop rows already sit ~48px, so no
+              // visible density change there).
+              minHeight: 44,
               cursor: 'pointer',
               transition: 'all 0.15s ease-in-out',
               backgroundImage: index === selectedIndex
@@ -271,6 +280,7 @@ export const MentionDropdown: React.FC<MentionDropdownProps> = ({
         sx={{
           px: 2,
           py: 1,
+          flexShrink: 0,
           borderTop: `1px solid ${alpha(theme.palette.divider, 0.08)}`,
           background: alpha(theme.palette.background.paper, 0.3),
         }}

--- a/frontend/src/components/Message/MessageInput.tsx
+++ b/frontend/src/components/Message/MessageInput.tsx
@@ -10,7 +10,10 @@ import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Box, IconButton, CircularProgress } from "@mui/material";
 import SendIcon from "@mui/icons-material/Send";
 import AttachFileIcon from "@mui/icons-material/AttachFile";
+import EmojiEmotionsOutlinedIcon from "@mui/icons-material/EmojiEmotionsOutlined";
 import { StyledPaper, StyledTextField } from "./MessageInputStyles";
+import { EmojiPickerPopover } from "./EmojiPicker";
+import { useResponsive } from "../../hooks/useResponsive";
 import { FilePreview } from "./FilePreview";
 import { MentionDropdown } from "./MentionDropdown";
 import { useFileAttachments } from "./useFileAttachments";
@@ -73,6 +76,26 @@ export default function MessageInput({
   const inputRef = useRef<HTMLInputElement>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { showNotification } = useNotification();
+  const { isTouchDevice } = useResponsive();
+
+  // Emoji picker state + last-known selection (captured before the picker steals focus)
+  const [emojiAnchorEl, setEmojiAnchorEl] = useState<HTMLElement | null>(null);
+  const emojiPickerOpen = Boolean(emojiAnchorEl);
+  const lastSelectionRef = useRef<{ start: number; end: number }>({
+    start: 0,
+    end: 0,
+  });
+
+  const captureSelection = useCallback(() => {
+    const el = inputRef.current;
+    if (el) {
+      const len = el.value.length;
+      lastSelectionRef.current = {
+        start: el.selectionStart ?? len,
+        end: el.selectionEnd ?? len,
+      };
+    }
+  }, []);
 
   // Typing indicator emitter
   const { handleKeyPress: emitTypingKeyPress, sendTypingStop } = useTypingEmitter(
@@ -343,6 +366,47 @@ export default function MessageInput({
     }
   };
 
+  // --- Emoji picker handlers ---
+  const handleEmojiButtonClick = (event: React.MouseEvent<HTMLElement>) => {
+    // Capture the caret position before the picker takes focus so we can
+    // insert the emoji where the user left off.
+    captureSelection();
+    setEmojiAnchorEl(event.currentTarget);
+  };
+
+  const handleEmojiPickerClose = () => {
+    setEmojiAnchorEl(null);
+  };
+
+  const handleEmojiSelect = useCallback(
+    (emoji: string) => {
+      // Read the live controlled value instead of using a functional update:
+      // StrictMode double-invokes updaters, so side effects inside one
+      // (the ref mutation below) would misplace the caret in dev.
+      const el = inputRef.current;
+      const value = el?.value ?? "";
+      const start = Math.min(lastSelectionRef.current.start, value.length);
+      const end = Math.min(lastSelectionRef.current.end, value.length);
+      const newPos = start + emoji.length;
+      lastSelectionRef.current = { start: newPos, end: newPos };
+      setText(value.slice(0, start) + emoji + value.slice(end));
+
+      // On desktop, restore focus + caret to the input after inserting.
+      // On touch, don't force focus — it would pop the keyboard over the sheet.
+      if (!isTouchDevice) {
+        requestAnimationFrame(() => {
+          const input = inputRef.current;
+          if (input) {
+            input.focus();
+            input.setSelectionRange(newPos, newPos);
+          }
+        });
+      }
+      emitTypingKeyPress();
+    },
+    [isTouchDevice, emitTypingKeyPress]
+  );
+
   // --- Keyboard handler ---
   const handleKeyPress = (event: React.KeyboardEvent) => {
     if (isChannel) {
@@ -367,7 +431,9 @@ export default function MessageInput({
       }
     }
 
-    if (event.key === "Enter" && !event.shiftKey) {
+    // On touch devices, Enter inserts a newline (send is via the button only).
+    // On desktop, Enter sends and Shift+Enter inserts a newline.
+    if (event.key === "Enter" && !event.shiftKey && !isTouchDevice) {
       event.preventDefault();
       handleSend();
     }
@@ -418,17 +484,32 @@ export default function MessageInput({
             onChange={(e) => {
               setText(e.target.value);
               emitTypingKeyPress();
+              captureSelection();
             }}
             onKeyDown={handleKeyPress}
+            onKeyUp={captureSelection}
             onPaste={handlePaste}
-            onClick={updateCursorPosition}
-            onSelect={updateCursorPosition}
+            onClick={() => {
+              updateCursorPosition();
+              captureSelection();
+            }}
+            onSelect={() => {
+              updateCursorPosition();
+              captureSelection();
+            }}
             sx={{ flex: 1 }}
             inputRef={inputRef}
             autoComplete="off"
             multiline
             maxRows={4}
           />
+          <IconButton
+            onClick={handleEmojiButtonClick}
+            disabled={sending}
+            aria-label="add emoji"
+          >
+            <EmojiEmotionsOutlinedIcon />
+          </IconButton>
           <IconButton
             onClick={handleFileButtonClick}
             disabled={sending}
@@ -446,6 +527,14 @@ export default function MessageInput({
           </IconButton>
         </StyledPaper>
       </form>
+
+      <EmojiPickerPopover
+        open={emojiPickerOpen}
+        anchorEl={emojiAnchorEl}
+        onClose={handleEmojiPickerClose}
+        onEmojiSelect={handleEmojiSelect}
+        title="Add Emoji"
+      />
     </Box>
   );
 }

--- a/frontend/src/components/Thread/ThreadMessageInput.tsx
+++ b/frontend/src/components/Thread/ThreadMessageInput.tsx
@@ -5,7 +5,7 @@
  * Uses WebSocket to send messages in real-time.
  */
 
-import React, { useState, useContext } from "react";
+import React, { useState, useContext, useRef, useCallback } from "react";
 import {
   Box,
   TextField,
@@ -13,11 +13,14 @@ import {
   CircularProgress,
 } from "@mui/material";
 import SendIcon from "@mui/icons-material/Send";
+import EmojiEmotionsOutlinedIcon from "@mui/icons-material/EmojiEmotionsOutlined";
 import { useTheme } from "@mui/material/styles";
 import { SocketContext } from "../../utils/SocketContext";
 import { ClientEvents } from '@semaphore-chat/shared';
 import { SpanType } from "../../types/message.type";
 import { logger } from "../../utils/logger";
+import { EmojiPickerPopover } from "../Message/EmojiPicker";
+import { useResponsive } from "../../hooks/useResponsive";
 
 interface ThreadMessageInputProps {
   parentMessageId: string;
@@ -28,8 +31,63 @@ export const ThreadMessageInput: React.FC<ThreadMessageInputProps> = ({
 }) => {
   const theme = useTheme();
   const { socket } = useContext(SocketContext);
+  const { isTouchDevice } = useResponsive();
   const [content, setContent] = useState("");
   const [isSending, setIsSending] = useState(false);
+
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const [emojiAnchorEl, setEmojiAnchorEl] = useState<HTMLElement | null>(null);
+  const emojiPickerOpen = Boolean(emojiAnchorEl);
+  const lastSelectionRef = useRef<{ start: number; end: number }>({
+    start: 0,
+    end: 0,
+  });
+
+  const captureSelection = useCallback(() => {
+    const el = inputRef.current;
+    if (el) {
+      const len = el.value.length;
+      lastSelectionRef.current = {
+        start: el.selectionStart ?? len,
+        end: el.selectionEnd ?? len,
+      };
+    }
+  }, []);
+
+  const handleEmojiButtonClick = (event: React.MouseEvent<HTMLElement>) => {
+    captureSelection();
+    setEmojiAnchorEl(event.currentTarget);
+  };
+
+  const handleEmojiPickerClose = () => {
+    setEmojiAnchorEl(null);
+  };
+
+  const handleEmojiSelect = useCallback(
+    (emoji: string) => {
+      // Read the live controlled value instead of using a functional update:
+      // StrictMode double-invokes updaters, so side effects inside one
+      // (the ref mutation below) would misplace the caret in dev.
+      const el = inputRef.current;
+      const value = el?.value ?? "";
+      const start = Math.min(lastSelectionRef.current.start, value.length);
+      const end = Math.min(lastSelectionRef.current.end, value.length);
+      const newPos = start + emoji.length;
+      lastSelectionRef.current = { start: newPos, end: newPos };
+      setContent(value.slice(0, start) + emoji + value.slice(end));
+
+      if (!isTouchDevice) {
+        requestAnimationFrame(() => {
+          const input = inputRef.current;
+          if (input) {
+            input.focus();
+            input.setSelectionRange(newPos, newPos);
+          }
+        });
+      }
+    },
+    [isTouchDevice]
+  );
 
   const handleSend = async () => {
     const trimmedContent = content.trim();
@@ -67,7 +125,8 @@ export const ThreadMessageInput: React.FC<ThreadMessageInputProps> = ({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    // Touch: Enter inserts a newline (send via button only). Desktop: Enter sends.
+    if (e.key === "Enter" && !e.shiftKey && !isTouchDevice) {
       e.preventDefault();
       handleSend();
     }
@@ -90,10 +149,17 @@ export const ThreadMessageInput: React.FC<ThreadMessageInputProps> = ({
           maxRows={4}
           placeholder="Reply..."
           value={content}
-          onChange={(e) => setContent(e.target.value)}
+          onChange={(e) => {
+            setContent(e.target.value);
+            captureSelection();
+          }}
           onKeyDown={handleKeyDown}
+          onKeyUp={captureSelection}
+          onClick={captureSelection}
+          onSelect={captureSelection}
           disabled={isSending}
           size="small"
+          inputRef={inputRef}
           sx={{
             "& .MuiOutlinedInput-root": {
               borderRadius: 2,
@@ -101,9 +167,21 @@ export const ThreadMessageInput: React.FC<ThreadMessageInputProps> = ({
           }}
         />
         <IconButton
+          onClick={handleEmojiButtonClick}
+          disabled={isSending}
+          aria-label="add emoji"
+          sx={{
+            width: 40,
+            height: 40,
+          }}
+        >
+          <EmojiEmotionsOutlinedIcon />
+        </IconButton>
+        <IconButton
           color="primary"
           onClick={handleSend}
           disabled={!content.trim() || isSending}
+          aria-label="send"
           sx={{
             width: 40,
             height: 40,
@@ -116,6 +194,14 @@ export const ThreadMessageInput: React.FC<ThreadMessageInputProps> = ({
           )}
         </IconButton>
       </Box>
+
+      <EmojiPickerPopover
+        open={emojiPickerOpen}
+        anchorEl={emojiAnchorEl}
+        onClose={handleEmojiPickerClose}
+        onEmojiSelect={handleEmojiSelect}
+        title="Add Emoji"
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

PR 3 of 7 in the mobile UX overhaul (stacked on #389). The composer had no emoji entry at all (emoji were only reachable through the hover toolbar — invisible on touch), Enter-to-send made multiline messages impossible on phones, and several fixed-width surfaces overflowed narrow screens.

## Changes

- **Emoji button in the composer** (`MessageInput` + `ThreadMessageInput`): opens the emoji picker — anchored popover on desktop, bottom sheet on touch (from #389) — and inserts at the caret. Desktop restores focus and caret after insert; touch doesn't force-focus so the keyboard doesn't pop over the sheet.
- **Enter behavior on touch**: Enter inserts a newline; sending is via the send button only (Discord mobile behavior, owner-confirmed). Desktop unchanged.
- **MentionDropdown**: capped at `min(320px, 40vh)` with a scrollable list and 44px rows — can't overflow the top of small screens (no desktop density change; rows were already ~48px).
- **Thread/pinned drawers** in `ChannelMessageContainer` capped at `min(400px/360px, 100vw)` — they previously overflowed 360px phones.

Note: emoji insertion deliberately avoids a functional `setState` — StrictMode double-invokes updaters, and side effects inside one misplaced the caret in dev.

## Testing

- New `MessageInput` tests: insert-at-caret, append-at-end, Enter sends on desktop, Enter newlines (doesn't send) on touch.
- Thread suite, emoji picker, and MobileChatPanel suites pass; `type-check` + `lint` clean; no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvVeRD4zf7UofaTfNDJm2Z