### PR TITLE
feat(voice): touch support — hold-to-talk, volume popover, PiP pointer drag, wake lock

### DIFF
--- a/frontend/src/__tests__/components/ScreenShareVolumeControl.test.tsx
+++ b/frontend/src/__tests__/components/ScreenShareVolumeControl.test.tsx
@@ -5,6 +5,11 @@ import ScreenShareVolumeControl from '../../components/Voice/ScreenShareVolumeCo
 import { audioBoostManager } from '../../features/voice/audioBoostManager';
 
 let mockIsDeafened = false;
+let mockShouldUseTouchUI = false;
+
+vi.mock('../../hooks/useResponsive', () => ({
+  useResponsive: vi.fn(() => ({ shouldUseTouchUI: mockShouldUseTouchUI })),
+}));
 
 vi.mock('livekit-client', () => ({
   Track: {
@@ -91,6 +96,7 @@ describe('ScreenShareVolumeControl', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsDeafened = false;
+    mockShouldUseTouchUI = false;
     localStorageGetSpy = vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
     localStorageSetSpy = vi.spyOn(Storage.prototype, 'setItem');
   });
@@ -315,5 +321,59 @@ describe('ScreenShareVolumeControl', () => {
     renderControl();
 
     expect(screen.getByTestId('VolumeUpIcon')).toBeInTheDocument();
+  });
+
+  describe('touch UI', () => {
+    beforeEach(() => {
+      mockShouldUseTouchUI = true;
+    });
+
+    // On touch, the collapsed icon is relabelled "Screenshare volume" because
+    // its tap opens the slider popover rather than toggling mute directly.
+    function getVolumeButton() {
+      return screen.getByRole('button', { name: /screenshare volume/i });
+    }
+
+    it('tapping the icon opens a popover with an always-visible slider', async () => {
+      const user = userEvent.setup();
+      renderControl();
+
+      // No hover on touch → slider not rendered until the popover opens.
+      expect(screen.queryByRole('slider')).not.toBeInTheDocument();
+
+      await user.click(getVolumeButton());
+
+      expect(screen.getByRole('slider')).toBeInTheDocument();
+    });
+
+    it('keeps the mute toggle reachable inside the popover', async () => {
+      const user = userEvent.setup();
+      renderControl();
+
+      // Open the popover, then use its mute button.
+      await user.click(getVolumeButton());
+      await user.click(screen.getByRole('button', { name: /mute screenshare/i }));
+
+      // Muting applies a volume of 0.
+      expect(audioBoostManager.applyVolume).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        0,
+      );
+    });
+
+    it('does not toggle mute on the initial icon tap (opens popover instead)', async () => {
+      const user = userEvent.setup();
+      renderControl();
+
+      await user.click(getVolumeButton());
+
+      // Opening the popover must not mute the track.
+      expect(audioBoostManager.applyVolume).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        0,
+      );
+    });
   });
 });

--- a/frontend/src/__tests__/components/VoiceBottomBar.test.tsx
+++ b/frontend/src/__tests__/components/VoiceBottomBar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import { renderWithProviders } from '../test-utils';
 import { VoiceBottomBar } from '../../components/Voice/VoiceBottomBar';
 import { VoiceSessionType, type VoiceState } from '../../contexts/VoiceContext';
@@ -112,7 +112,13 @@ vi.mock('../../hooks/usePushToTalk', () => ({
     isKeyHeld: false,
     currentKeyDisplay: 'Space',
     inputMode: 'voice_activity',
+    pttPress: vi.fn(),
+    pttRelease: vi.fn(),
   })),
+}));
+
+vi.mock('../../hooks/useWakeLock', () => ({
+  useWakeLock: vi.fn(),
 }));
 
 vi.mock('../../hooks/useSpeaking', () => ({
@@ -177,6 +183,7 @@ const { useLocalMediaState } = await import('../../hooks/useLocalMediaState');
 const { useResponsive } = await import('../../hooks/useResponsive');
 const { useReplayBufferState } = await import('../../contexts/ReplayBufferContext');
 const { useScreenShare } = await import('../../hooks/useScreenShare');
+const { usePushToTalk } = await import('../../hooks/usePushToTalk');
 
 describe('VoiceBottomBar', () => {
   beforeEach(() => {
@@ -209,6 +216,15 @@ describe('VoiceBottomBar', () => {
       isTablet: false,
       isDesktop: true,
       deviceType: 'desktop',
+      shouldUseTouchUI: false,
+    } as never);
+    vi.mocked(usePushToTalk).mockReturnValue({
+      isActive: false,
+      isKeyHeld: false,
+      currentKeyDisplay: 'Space',
+      inputMode: 'voice_activity',
+      pttPress: vi.fn(),
+      pttRelease: vi.fn(),
     } as never);
     vi.mocked(useReplayBufferState).mockReturnValue({
       isReplayBufferActive: false,
@@ -574,6 +590,94 @@ describe('VoiceBottomBar', () => {
 
       expect(screen.queryByTestId('SpeakerPhoneIcon')).not.toBeInTheDocument();
       expect(screen.queryByTestId('PhoneInTalkIcon')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('hold-to-talk (touch PTT)', () => {
+    const mockPttPress = vi.fn();
+    const mockPttRelease = vi.fn();
+
+    function enableHoldToTalk() {
+      vi.mocked(usePushToTalk).mockReturnValue({
+        isActive: true,
+        isKeyHeld: false,
+        currentKeyDisplay: 'Space',
+        inputMode: 'push_to_talk',
+        pttPress: mockPttPress,
+        pttRelease: mockPttRelease,
+      } as never);
+      vi.mocked(useResponsive).mockReturnValue({
+        isMobile: true,
+        isTablet: false,
+        isDesktop: false,
+        deviceType: 'phone',
+        shouldUseTouchUI: true,
+      } as never);
+    }
+
+    it('pointerdown engages transmit and pointerup releases it', () => {
+      enableHoldToTalk();
+      renderWithProviders(<VoiceBottomBar />);
+
+      const micButton = screen.getByTestId('MicIcon').closest('button')!;
+
+      fireEvent.pointerDown(micButton, { pointerId: 1 });
+      expect(mockPttPress).toHaveBeenCalledTimes(1);
+
+      fireEvent.pointerUp(micButton, { pointerId: 1 });
+      expect(mockPttRelease).toHaveBeenCalledTimes(1);
+    });
+
+    it('exposes an accessible "Hold to talk" label', () => {
+      enableHoldToTalk();
+      renderWithProviders(<VoiceBottomBar />);
+
+      expect(screen.getByRole('button', { name: /hold to talk/i })).toBeInTheDocument();
+    });
+
+    it('does not engage transmit while server-muted', () => {
+      enableHoldToTalk();
+      voiceState = { ...defaultVoiceState, isServerMuted: true };
+      vi.mocked(useVoiceConnection).mockReturnValue({
+        state: voiceState,
+        actions: mockActions,
+      } as never);
+
+      renderWithProviders(<VoiceBottomBar />);
+
+      const micButton = screen.getByTestId('MicIcon').closest('button')!;
+      fireEvent.pointerDown(micButton, { pointerId: 1 });
+
+      expect(mockPttPress).not.toHaveBeenCalled();
+    });
+
+    it('does NOT attach hold-to-talk for desktop PTT (no touch UI regression)', () => {
+      // PTT active but desktop (keyboard) — mic button stays a keyboard-only
+      // control with no onClick and no pointer transmit.
+      vi.mocked(usePushToTalk).mockReturnValue({
+        isActive: true,
+        isKeyHeld: false,
+        currentKeyDisplay: 'Space',
+        inputMode: 'push_to_talk',
+        pttPress: mockPttPress,
+        pttRelease: mockPttRelease,
+      } as never);
+      vi.mocked(useResponsive).mockReturnValue({
+        isMobile: false,
+        isTablet: false,
+        isDesktop: true,
+        deviceType: 'desktop',
+        shouldUseTouchUI: false,
+      } as never);
+
+      renderWithProviders(<VoiceBottomBar />);
+
+      const micButton = screen.getByTestId('MicIcon').closest('button')!;
+      fireEvent.pointerDown(micButton, { pointerId: 1 });
+      fireEvent.click(micButton);
+
+      expect(mockPttPress).not.toHaveBeenCalled();
+      expect(mockActions.toggleMute).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/__tests__/hooks/usePushToTalk.test.ts
+++ b/frontend/src/__tests__/hooks/usePushToTalk.test.ts
@@ -165,4 +165,58 @@ describe('usePushToTalk', () => {
 
     expect(mockSetMicrophoneEnabled).toHaveBeenCalledTimes(1);
   });
+
+  describe('programmatic pttPress / pttRelease (touch hold-to-talk)', () => {
+    it('pttPress enables the microphone when not server-muted', async () => {
+      const { result } = renderHook(() => usePushToTalk());
+
+      await act(async () => {
+        await result.current.pttPress();
+      });
+
+      expect(mockSetMicrophoneEnabled).toHaveBeenCalledWith(true);
+      expect(result.current.isKeyHeld).toBe(true);
+    });
+
+    it('pttPress is a no-op while server-muted (same guard as keyboard)', async () => {
+      mockVoiceState = { isConnected: true, isServerMuted: true };
+      const { result } = renderHook(() => usePushToTalk());
+
+      await act(async () => {
+        await result.current.pttPress();
+      });
+
+      expect(mockSetMicrophoneEnabled).not.toHaveBeenCalled();
+      expect(result.current.isKeyHeld).toBe(false);
+    });
+
+    it('pttPress reads the CURRENT server-mute state (not a stale closure)', async () => {
+      const { result } = renderHook(() => usePushToTalk());
+
+      // Server mute arrives after render — the stateRef must still see it.
+      mockVoiceState.isServerMuted = true;
+
+      await act(async () => {
+        await result.current.pttPress();
+      });
+
+      expect(mockSetMicrophoneEnabled).not.toHaveBeenCalled();
+    });
+
+    it('pttRelease disables the microphone', async () => {
+      const { result } = renderHook(() => usePushToTalk());
+
+      await act(async () => {
+        await result.current.pttPress();
+      });
+      mockSetMicrophoneEnabled.mockClear();
+
+      await act(async () => {
+        await result.current.pttRelease();
+      });
+
+      expect(mockSetMicrophoneEnabled).toHaveBeenCalledWith(false);
+      expect(result.current.isKeyHeld).toBe(false);
+    });
+  });
 });

--- a/frontend/src/__tests__/hooks/useWakeLock.test.ts
+++ b/frontend/src/__tests__/hooks/useWakeLock.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useWakeLock } from '../../hooks/useWakeLock';
+
+let mockIsElectron = false;
+
+vi.mock('../../utils/platform', () => ({
+  isElectron: vi.fn(() => mockIsElectron),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { dev: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Fake WakeLockSentinel that records its 'release' listeners so tests can
+// simulate the browser auto-releasing the lock (e.g. when the tab is hidden).
+interface FakeSentinel {
+  release: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  fireRelease: () => void;
+}
+
+function makeSentinel(): FakeSentinel {
+  const listeners: Array<() => void> = [];
+  return {
+    release: vi.fn().mockResolvedValue(undefined),
+    addEventListener: vi.fn((type: string, cb: () => void) => {
+      if (type === 'release') listeners.push(cb);
+    }),
+    fireRelease: () => listeners.forEach((cb) => cb()),
+  };
+}
+
+let requestSpy: ReturnType<typeof vi.fn>;
+let sentinels: FakeSentinel[];
+
+const originalWakeLock = Object.getOwnPropertyDescriptor(navigator, 'wakeLock');
+
+function installWakeLock() {
+  sentinels = [];
+  requestSpy = vi.fn(async () => {
+    const s = makeSentinel();
+    sentinels.push(s);
+    return s;
+  });
+  Object.defineProperty(navigator, 'wakeLock', {
+    value: { request: requestSpy },
+    writable: true,
+    configurable: true,
+  });
+}
+
+function removeWakeLock() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (navigator as any).wakeLock;
+}
+
+describe('useWakeLock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsElectron = false;
+    installWakeLock();
+  });
+
+  afterEach(() => {
+    if (originalWakeLock) {
+      Object.defineProperty(navigator, 'wakeLock', originalWakeLock);
+    } else {
+      removeWakeLock();
+    }
+  });
+
+  it('acquires a screen wake lock when active', async () => {
+    renderHook(() => useWakeLock(true));
+
+    await waitFor(() => expect(requestSpy).toHaveBeenCalledWith('screen'));
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not acquire when inactive', () => {
+    renderHook(() => useWakeLock(false));
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  it('releases the wake lock on unmount', async () => {
+    const { unmount } = renderHook(() => useWakeLock(true));
+
+    await waitFor(() => expect(sentinels).toHaveLength(1));
+    unmount();
+
+    expect(sentinels[0].release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the wake lock when it becomes inactive', async () => {
+    const { rerender } = renderHook(({ active }) => useWakeLock(active), {
+      initialProps: { active: true },
+    });
+
+    await waitFor(() => expect(sentinels).toHaveLength(1));
+    rerender({ active: false });
+
+    expect(sentinels[0].release).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-acquires the wake lock when the page becomes visible again', async () => {
+    renderHook(() => useWakeLock(true));
+
+    await waitFor(() => expect(sentinels).toHaveLength(1));
+
+    // Simulate the browser auto-releasing the lock while hidden.
+    act(() => {
+      sentinels[0].fireRelease();
+    });
+
+    // Page becomes visible again → hook should request a fresh lock.
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await waitFor(() => expect(requestSpy).toHaveBeenCalledTimes(2));
+  });
+
+  it('no-ops when the Wake Lock API is unsupported', () => {
+    removeWakeLock();
+    expect(() => renderHook(() => useWakeLock(true))).not.toThrow();
+  });
+
+  it('no-ops in Electron', () => {
+    mockIsElectron = true;
+    renderHook(() => useWakeLock(true));
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/Voice/PersistentVideoOverlay.tsx
+++ b/frontend/src/components/Voice/PersistentVideoOverlay.tsx
@@ -188,7 +188,7 @@ export const PersistentVideoOverlay: React.FC = () => {
   }, [constrainPosition]);
 
   // Drag handlers
-  const handleDragStart = useCallback((e: React.MouseEvent) => {
+  const handleDragStart = useCallback((e: React.PointerEvent) => {
     if (settings.isMaximized) return;
     if ((e.target as HTMLElement).closest('.pip-controls')) return;
     e.preventDefault();
@@ -199,7 +199,7 @@ export const PersistentVideoOverlay: React.FC = () => {
     });
   }, [settings.position, settings.isMaximized]);
 
-  const handleDragMove = useCallback((e: MouseEvent) => {
+  const handleDragMove = useCallback((e: PointerEvent) => {
     if (!isDragging) return;
     const newX = e.clientX - dragOffset.x;
     const newY = e.clientY - dragOffset.y;
@@ -215,7 +215,7 @@ export const PersistentVideoOverlay: React.FC = () => {
   }, [isDragging, settings, saveSettings]);
 
   // Resize handlers
-  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+  const handleResizeStart = useCallback((e: React.PointerEvent) => {
     if (settings.isMaximized) return;
     e.preventDefault();
     e.stopPropagation();
@@ -228,7 +228,7 @@ export const PersistentVideoOverlay: React.FC = () => {
     });
   }, [settings.size, settings.isMaximized]);
 
-  const handleResizeMove = useCallback((e: MouseEvent) => {
+  const handleResizeMove = useCallback((e: PointerEvent) => {
     if (!isResizing) return;
     const deltaX = e.clientX - resizeStart.x;
     const deltaY = e.clientY - resizeStart.y;
@@ -259,25 +259,26 @@ export const PersistentVideoOverlay: React.FC = () => {
     }
   }, [isResizing, settings, constrainPosition, saveSettings]);
 
-  // Global mouse event listeners for drag/resize
+  // Global pointer event listeners for drag/resize (pointer events unify mouse
+  // and touch, so this works for touch tablets as well as mouse users)
   useEffect(() => {
     if (isDragging) {
-      window.addEventListener('mousemove', handleDragMove);
-      window.addEventListener('mouseup', handleDragEnd);
+      window.addEventListener('pointermove', handleDragMove);
+      window.addEventListener('pointerup', handleDragEnd);
       return () => {
-        window.removeEventListener('mousemove', handleDragMove);
-        window.removeEventListener('mouseup', handleDragEnd);
+        window.removeEventListener('pointermove', handleDragMove);
+        window.removeEventListener('pointerup', handleDragEnd);
       };
     }
   }, [isDragging, handleDragMove, handleDragEnd]);
 
   useEffect(() => {
     if (isResizing) {
-      window.addEventListener('mousemove', handleResizeMove);
-      window.addEventListener('mouseup', handleResizeEnd);
+      window.addEventListener('pointermove', handleResizeMove);
+      window.addEventListener('pointerup', handleResizeEnd);
       return () => {
-        window.removeEventListener('mousemove', handleResizeMove);
-        window.removeEventListener('mouseup', handleResizeEnd);
+        window.removeEventListener('pointermove', handleResizeMove);
+        window.removeEventListener('pointerup', handleResizeEnd);
       };
     }
   }, [isResizing, handleResizeMove, handleResizeEnd]);
@@ -450,8 +451,10 @@ export const PersistentVideoOverlay: React.FC = () => {
           px: 1,
           cursor: settings.isMaximized ? 'default' : (isDragging ? 'grabbing' : 'grab'),
           flexShrink: 0,
+          // Prevent the browser treating a touch-drag on the header as a scroll
+          touchAction: settings.isMaximized ? 'auto' : 'none',
         }}
-        onMouseDown={handleDragStart}
+        onPointerDown={handleDragStart}
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
           {!settings.isMaximized && (
@@ -498,6 +501,7 @@ export const PersistentVideoOverlay: React.FC = () => {
             width: 20,
             height: 20,
             cursor: 'se-resize',
+            touchAction: 'none',
             '&::after': {
               content: '""',
               position: 'absolute',
@@ -509,7 +513,7 @@ export const PersistentVideoOverlay: React.FC = () => {
               borderBottom: `2px solid ${theme.palette.text.secondary}`,
             },
           }}
-          onMouseDown={handleResizeStart}
+          onPointerDown={handleResizeStart}
         />
       )}
     </Paper>

--- a/frontend/src/components/Voice/PersistentVideoOverlay.tsx
+++ b/frontend/src/components/Voice/PersistentVideoOverlay.tsx
@@ -265,9 +265,13 @@ export const PersistentVideoOverlay: React.FC = () => {
     if (isDragging) {
       window.addEventListener('pointermove', handleDragMove);
       window.addEventListener('pointerup', handleDragEnd);
+      // Touch can end with pointercancel (OS gesture / scroll takeover);
+      // without this the drag state would stick.
+      window.addEventListener('pointercancel', handleDragEnd);
       return () => {
         window.removeEventListener('pointermove', handleDragMove);
         window.removeEventListener('pointerup', handleDragEnd);
+        window.removeEventListener('pointercancel', handleDragEnd);
       };
     }
   }, [isDragging, handleDragMove, handleDragEnd]);
@@ -276,9 +280,11 @@ export const PersistentVideoOverlay: React.FC = () => {
     if (isResizing) {
       window.addEventListener('pointermove', handleResizeMove);
       window.addEventListener('pointerup', handleResizeEnd);
+      window.addEventListener('pointercancel', handleResizeEnd);
       return () => {
         window.removeEventListener('pointermove', handleResizeMove);
         window.removeEventListener('pointerup', handleResizeEnd);
+        window.removeEventListener('pointercancel', handleResizeEnd);
       };
     }
   }, [isResizing, handleResizeMove, handleResizeEnd]);

--- a/frontend/src/components/Voice/PersistentVideoOverlay.tsx
+++ b/frontend/src/components/Voice/PersistentVideoOverlay.tsx
@@ -89,6 +89,10 @@ export const PersistentVideoOverlay: React.FC = () => {
   const [isResizing, setIsResizing] = useState(false);
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
   const [resizeStart, setResizeStart] = useState({ x: 0, y: 0, width: 0, height: 0 });
+  // The pointer that started the active drag/resize. On touch, a second
+  // finger produces its own pointer events on the window listeners — without
+  // this filter it would teleport the overlay or end the gesture.
+  const activePointerIdRef = useRef<number | null>(null);
   // Track window size for maximized mode re-renders
   const [, setWindowSize] = useState({ width: window.innerWidth, height: window.innerHeight });
 
@@ -191,7 +195,9 @@ export const PersistentVideoOverlay: React.FC = () => {
   const handleDragStart = useCallback((e: React.PointerEvent) => {
     if (settings.isMaximized) return;
     if ((e.target as HTMLElement).closest('.pip-controls')) return;
+    if (activePointerIdRef.current !== null) return;
     e.preventDefault();
+    activePointerIdRef.current = e.pointerId;
     setIsDragging(true);
     setDragOffset({
       x: e.clientX - settings.position.x,
@@ -201,13 +207,16 @@ export const PersistentVideoOverlay: React.FC = () => {
 
   const handleDragMove = useCallback((e: PointerEvent) => {
     if (!isDragging) return;
+    if (e.pointerId !== activePointerIdRef.current) return;
     const newX = e.clientX - dragOffset.x;
     const newY = e.clientY - dragOffset.y;
     const constrained = constrainPosition(newX, newY, settings.size.width, settings.size.height);
     setSettings(prev => ({ ...prev, position: constrained }));
   }, [isDragging, dragOffset, settings.size, constrainPosition]);
 
-  const handleDragEnd = useCallback(() => {
+  const handleDragEnd = useCallback((e: PointerEvent) => {
+    if (e.pointerId !== activePointerIdRef.current) return;
+    activePointerIdRef.current = null;
     if (isDragging) {
       setIsDragging(false);
       saveSettings(settings);
@@ -217,8 +226,10 @@ export const PersistentVideoOverlay: React.FC = () => {
   // Resize handlers
   const handleResizeStart = useCallback((e: React.PointerEvent) => {
     if (settings.isMaximized) return;
+    if (activePointerIdRef.current !== null) return;
     e.preventDefault();
     e.stopPropagation();
+    activePointerIdRef.current = e.pointerId;
     setIsResizing(true);
     setResizeStart({
       x: e.clientX,
@@ -230,6 +241,7 @@ export const PersistentVideoOverlay: React.FC = () => {
 
   const handleResizeMove = useCallback((e: PointerEvent) => {
     if (!isResizing) return;
+    if (e.pointerId !== activePointerIdRef.current) return;
     const deltaX = e.clientX - resizeStart.x;
     const deltaY = e.clientY - resizeStart.y;
     setSettings(prev => {
@@ -244,7 +256,9 @@ export const PersistentVideoOverlay: React.FC = () => {
     });
   }, [isResizing, resizeStart]);
 
-  const handleResizeEnd = useCallback(() => {
+  const handleResizeEnd = useCallback((e: PointerEvent) => {
+    if (e.pointerId !== activePointerIdRef.current) return;
+    activePointerIdRef.current = null;
     if (isResizing) {
       setIsResizing(false);
       // Constrain position after resize

--- a/frontend/src/components/Voice/ScreenShareVolumeControl.tsx
+++ b/frontend/src/components/Voice/ScreenShareVolumeControl.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef } from 'react';
-import { IconButton, Slider, Box, Tooltip } from '@mui/material';
+import { IconButton, Slider, Box, Tooltip, Popover } from '@mui/material';
 import { useTheme, alpha } from '@mui/material/styles';
 import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 import VolumeDownIcon from '@mui/icons-material/VolumeDown';
@@ -7,6 +7,7 @@ import VolumeOffIcon from '@mui/icons-material/VolumeOff';
 import { Track, type RemoteParticipant } from 'livekit-client';
 import { SCREENSHARE_VOLUME_STORAGE_PREFIX } from '../../constants/voice';
 import { useVoice } from '../../contexts/VoiceContext';
+import { useResponsive } from '../../hooks/useResponsive';
 import { audioBoostManager, boostKey } from '../../features/voice/audioBoostManager';
 import { isBoostableAudioTrack } from '../../features/voice/isBoostableAudioTrack';
 
@@ -49,10 +50,13 @@ interface ScreenShareVolumeControlProps {
 const ScreenShareVolumeControl: React.FC<ScreenShareVolumeControlProps> = ({ participant }) => {
   const theme = useTheme();
   const { isDeafened } = useVoice();
+  const { shouldUseTouchUI } = useResponsive();
   const [isHovered, setIsHovered] = useState(false);
   // Keep the slider reachable for keyboard users: expand on focus too
   const [isFocused, setIsFocused] = useState(false);
   const isExpanded = isHovered || isFocused;
+  // Touch devices can't hover: tapping the icon opens a Popover slider instead.
+  const [popoverAnchor, setPopoverAnchor] = useState<HTMLElement | null>(null);
 
   const [volume, setVolume] = useState<number>(() => {
     const stored = getStoredScreenShareVolume(participant.identity);
@@ -129,6 +133,19 @@ const ScreenShareVolumeControl: React.FC<ScreenShareVolumeControlProps> = ({ par
     }
   };
 
+  // On touch, the collapsed icon opens the slider popover (there is no hover to
+  // reveal it). On pointer-fine devices it keeps the original mute-toggle tap.
+  const handleIconClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (shouldUseTouchUI) {
+      e.stopPropagation();
+      setPopoverAnchor(e.currentTarget);
+      return;
+    }
+    handleMuteToggle(e);
+  };
+
+  const handlePopoverClose = () => setPopoverAnchor(null);
+
   const VolumeIcon = volume === 0 ? VolumeOffIcon : volume <= 50 ? VolumeDownIcon : VolumeUpIcon;
 
   return (
@@ -182,10 +199,19 @@ const ScreenShareVolumeControl: React.FC<ScreenShareVolumeControlProps> = ({ par
           />
         )}
       </Box>
-      <Tooltip title={isDeafened ? 'Deafened' : isMuted ? 'Unmute' : `Mute · ${volume}%`}>
+      <Tooltip
+        title={isDeafened ? 'Deafened' : isMuted ? 'Unmute' : `Mute · ${volume}%`}
+        disableTouchListener={shouldUseTouchUI}
+      >
         <span>
           <IconButton
-            aria-label={isMuted ? 'Unmute screenshare' : 'Mute screenshare'}
+            aria-label={
+              shouldUseTouchUI
+                ? 'Screenshare volume'
+                : isMuted
+                  ? 'Unmute screenshare'
+                  : 'Mute screenshare'
+            }
             sx={{
               color: theme.palette.common.white,
               width: 32,
@@ -193,12 +219,57 @@ const ScreenShareVolumeControl: React.FC<ScreenShareVolumeControlProps> = ({ par
             }}
             size="small"
             disabled={isDeafened}
-            onClick={handleMuteToggle}
+            onClick={handleIconClick}
           >
             <VolumeIcon fontSize="small" />
           </IconButton>
         </span>
       </Tooltip>
+
+      {/* Touch: tap-to-open volume popover with an always-visible, comfortably
+          sized slider plus a mute toggle. */}
+      {shouldUseTouchUI && (
+        <Popover
+          open={Boolean(popoverAnchor)}
+          anchorEl={popoverAnchor}
+          onClose={handlePopoverClose}
+          onClick={(e) => e.stopPropagation()}
+          anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+          transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.5,
+              px: 2,
+              py: 1.5,
+              minWidth: 220,
+            }}
+          >
+            <IconButton
+              aria-label={isMuted ? 'Unmute screenshare' : 'Mute screenshare'}
+              size="medium"
+              disabled={isDeafened}
+              onClick={handleMuteToggle}
+            >
+              <VolumeIcon />
+            </IconButton>
+            <Slider
+              value={volume}
+              onChange={handleVolumeChange}
+              onChangeCommitted={handleVolumeChangeCommitted}
+              min={0}
+              max={200}
+              step={1}
+              valueLabelDisplay="auto"
+              disabled={isDeafened}
+              aria-label="Screenshare volume"
+              sx={{ flex: 1 }}
+            />
+          </Box>
+        </Popover>
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/Voice/ScreenShareVolumeControl.tsx
+++ b/frontend/src/components/Voice/ScreenShareVolumeControl.tsx
@@ -54,7 +54,9 @@ const ScreenShareVolumeControl: React.FC<ScreenShareVolumeControlProps> = ({ par
   const [isHovered, setIsHovered] = useState(false);
   // Keep the slider reachable for keyboard users: expand on focus too
   const [isFocused, setIsFocused] = useState(false);
-  const isExpanded = isHovered || isFocused;
+  // Never expand inline on touch — the tap-focus would render the inline
+  // slider alongside the popover slider (duplicate controls, layout jitter).
+  const isExpanded = !shouldUseTouchUI && (isHovered || isFocused);
   // Touch devices can't hover: tapping the icon opens a Popover slider instead.
   const [popoverAnchor, setPopoverAnchor] = useState<HTMLElement | null>(null);
 

--- a/frontend/src/components/Voice/VoiceBottomBar.tsx
+++ b/frontend/src/components/Voice/VoiceBottomBar.tsx
@@ -43,6 +43,8 @@ import { ScreenSourcePicker } from "./ScreenSourcePicker";
 import { VoiceDebugPanel } from "./VoiceDebugPanel";
 import { CaptureReplayModal } from "./CaptureReplayModal";
 import { useResponsive } from "../../hooks/useResponsive";
+import { useHapticFeedback } from "../../hooks/useHapticFeedback";
+import { useWakeLock } from "../../hooks/useWakeLock";
 import { logger } from "../../utils/logger";
 import { LAYOUT_CONSTANTS } from "../../utils/breakpoints";
 import { useSpeaking } from "../../hooks/useSpeaking";
@@ -61,7 +63,8 @@ export const VoiceBottomBar: React.FC = () => {
   const { state, actions } = useVoiceConnection();
   const screenShare = useScreenShare();
   const { isCameraEnabled, isMicrophoneEnabled } = useLocalMediaState();
-  const { isMobile } = useResponsive();
+  const { isMobile, shouldUseTouchUI } = useResponsive();
+  const haptic = useHapticFeedback();
   const { user: currentUser } = useCurrentUser();
   const { isSpeaking } = useSpeaking();
   const [settingsAnchor, setSettingsAnchor] = useState<null | HTMLElement>(
@@ -73,10 +76,25 @@ export const VoiceBottomBar: React.FC = () => {
 
   // Use extracted hooks for cleaner organization
   const { showDebugPanel } = useDebugPanelShortcut();
-  const { isActive: isPTTActive, isKeyHeld: isPTTKeyHeld, currentKeyDisplay: pttKeyDisplay } = usePushToTalk();
+  const {
+    isActive: isPTTActive,
+    isKeyHeld: isPTTKeyHeld,
+    currentKeyDisplay: pttKeyDisplay,
+    pttPress,
+    pttRelease,
+  } = usePushToTalk();
+
+  // On touch devices the PTT key can't be pressed, so the mic button becomes a
+  // hold-to-talk control. Desktop PTT (keyboard) and non-PTT tap-to-mute are
+  // unaffected.
+  const isHoldToTalk = isPTTActive && shouldUseTouchUI;
 
   // Prevent tab freeze / OS suspension while in voice
   useBackgroundVoiceKeepAlive({ isConnected: state.isConnected });
+
+  // Keep the screen awake while connected (touch devices / web); no-op in
+  // Electron and where the Wake Lock API is unsupported.
+  useWakeLock(state.isConnected);
 
   // Surface the call via the Media Session API (Android ongoing-call
   // notification + higher background process priority, see #350)
@@ -159,6 +177,21 @@ export const VoiceBottomBar: React.FC = () => {
   const handleToggleScreenShare = useCallback(() => {
     screenShare.toggleScreenShare();
   }, [screenShare]);
+
+  // Hold-to-talk (touch): press engages the mic through the shared PTT logic
+  // (which enforces the server-mute guard), release re-mutes. Pointer capture
+  // keeps transmit tied to this button even if the finger slides off it.
+  const handlePttPointerDown = useCallback((e: React.PointerEvent<HTMLButtonElement>) => {
+    if (state.isServerMuted) return;
+    e.currentTarget.setPointerCapture?.(e.pointerId);
+    haptic.medium();
+    void pttPress?.();
+  }, [state.isServerMuted, haptic, pttPress]);
+
+  const handlePttPointerUp = useCallback(() => {
+    haptic.light();
+    void pttRelease?.();
+  }, [haptic, pttRelease]);
 
   // Check if browser supports audio output switching (setSinkId)
   const supportsSpeakerToggle = isMobile && 'setSinkId' in HTMLMediaElement.prototype;
@@ -261,17 +294,28 @@ export const VoiceBottomBar: React.FC = () => {
               title={
                 state.isServerMuted
                   ? "Server Muted — contact a moderator"
-                  : isPTTActive
-                    ? (isPTTKeyHeld ? "Transmitting..." : `Hold ${pttKeyDisplay} to talk`)
-                    : (!isMicrophoneEnabled ? "Unmute" : "Mute")
+                  : isHoldToTalk
+                    ? (isPTTKeyHeld ? "Transmitting..." : "Hold to talk")
+                    : isPTTActive
+                      ? (isPTTKeyHeld ? "Transmitting..." : `Hold ${pttKeyDisplay} to talk`)
+                      : (!isMicrophoneEnabled ? "Unmute" : "Mute")
               }
               arrow={!isMobile}
+              disableTouchListener={isHoldToTalk}
             >
               <IconButton
                 onClick={isPTTActive || state.isServerMuted ? undefined : actions.toggleMute}
+                onPointerDown={isHoldToTalk ? handlePttPointerDown : undefined}
+                onPointerUp={isHoldToTalk ? handlePttPointerUp : undefined}
+                onPointerCancel={isHoldToTalk ? handlePttPointerUp : undefined}
+                onPointerLeave={isHoldToTalk ? handlePttPointerUp : undefined}
+                onContextMenu={isHoldToTalk ? (e) => e.preventDefault() : undefined}
                 color={!isMicrophoneEnabled && !isPTTKeyHeld ? "error" : "default"}
                 size={isMobile ? "medium" : "medium"}
                 sx={{
+                  touchAction: isHoldToTalk ? "none" : undefined,
+                  userSelect: isHoldToTalk ? "none" : undefined,
+                  WebkitUserSelect: isHoldToTalk ? "none" : undefined,
                   backgroundColor: isPTTKeyHeld
                     ? theme.palette.semantic.status.positive
                     : state.isServerMuted

--- a/frontend/src/components/Voice/VoiceBottomBar.tsx
+++ b/frontend/src/components/Voice/VoiceBottomBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef } from "react";
 import {
   Box,
   Paper,
@@ -180,15 +180,22 @@ export const VoiceBottomBar: React.FC = () => {
 
   // Hold-to-talk (touch): press engages the mic through the shared PTT logic
   // (which enforces the server-mute guard), release re-mutes. Pointer capture
-  // keeps transmit tied to this button even if the finger slides off it.
+  // keeps transmit tied to this button even if the finger slides off it, so
+  // release is driven by pointerup / pointercancel / lostpointercapture — not
+  // pointerleave, which would end the hold mid-slide. holdEngagedRef makes the
+  // release path idempotent across those overlapping events.
+  const holdEngagedRef = useRef(false);
   const handlePttPointerDown = useCallback((e: React.PointerEvent<HTMLButtonElement>) => {
     if (state.isServerMuted) return;
     e.currentTarget.setPointerCapture?.(e.pointerId);
+    holdEngagedRef.current = true;
     haptic.medium();
     void pttPress?.();
   }, [state.isServerMuted, haptic, pttPress]);
 
   const handlePttPointerUp = useCallback(() => {
+    if (!holdEngagedRef.current) return;
+    holdEngagedRef.current = false;
     haptic.light();
     void pttRelease?.();
   }, [haptic, pttRelease]);
@@ -308,7 +315,7 @@ export const VoiceBottomBar: React.FC = () => {
                 onPointerDown={isHoldToTalk ? handlePttPointerDown : undefined}
                 onPointerUp={isHoldToTalk ? handlePttPointerUp : undefined}
                 onPointerCancel={isHoldToTalk ? handlePttPointerUp : undefined}
-                onPointerLeave={isHoldToTalk ? handlePttPointerUp : undefined}
+                onLostPointerCapture={isHoldToTalk ? handlePttPointerUp : undefined}
                 onContextMenu={isHoldToTalk ? (e) => e.preventDefault() : undefined}
                 color={!isMicrophoneEnabled && !isPTTKeyHeld ? "error" : "default"}
                 size={isMobile ? "medium" : "medium"}

--- a/frontend/src/hooks/usePushToTalk.ts
+++ b/frontend/src/hooks/usePushToTalk.ts
@@ -25,8 +25,49 @@ export function usePushToTalk() {
   // Track if PTT is active (connected to voice AND in PTT mode)
   const isActive = voiceState.isConnected && isPushToTalk;
 
+  // Core "start transmitting" logic, shared by the keyboard handler and the
+  // programmatic (touch hold-to-talk) path. Keeping a single implementation
+  // means both routes honor the same guards — notably the server-mute check
+  // read via stateRef (#380) so we always see the CURRENT value, never a
+  // stale closure.
+  const pttPress = useCallback(async () => {
+    const room = getRoom();
+    if (!room) return;
+
+    // Block transmit when server-muted — mirrors the guard in toggleMicrophone.
+    if (stateRef.current.isServerMuted) {
+      logger.dev('[PTT] Press while server muted, ignoring');
+      return;
+    }
+
+    try {
+      isKeyHeldRef.current = true;
+      setIsKeyHeld(true);
+      await room.localParticipant.setMicrophoneEnabled(true);
+      logger.dev('[PTT] Pressed, microphone enabled');
+    } catch (error) {
+      logger.error('[PTT] Failed to enable microphone:', error);
+    }
+  }, [getRoom, stateRef]);
+
+  // Core "stop transmitting" logic, shared by keyboard keyup, window blur, and
+  // the programmatic (touch) release path.
+  const pttRelease = useCallback(async () => {
+    const room = getRoom();
+    if (!room) return;
+
+    try {
+      isKeyHeldRef.current = false;
+      setIsKeyHeld(false);
+      await room.localParticipant.setMicrophoneEnabled(false);
+      logger.dev('[PTT] Released, microphone disabled');
+    } catch (error) {
+      logger.error('[PTT] Failed to disable microphone:', error);
+    }
+  }, [getRoom]);
+
   // Handle keydown - enable microphone
-  const handleKeyDown = useCallback(async (event: KeyboardEvent) => {
+  const handleKeyDown = useCallback((event: KeyboardEvent) => {
     // Check if this is our PTT key
     if (event.code !== pushToTalkKey) return;
 
@@ -40,61 +81,21 @@ export function usePushToTalk() {
     }
 
     event.preventDefault();
-
-    const room = getRoom();
-    if (!room) return;
-
-    // Block transmit when server-muted — mirrors the guard in toggleMicrophone.
-    // Read via stateRef so we see the CURRENT value, not a stale closure.
-    if (stateRef.current.isServerMuted) {
-      logger.dev('[PTT] Key pressed while server muted, ignoring');
-      return;
-    }
-
-    try {
-      isKeyHeldRef.current = true;
-      setIsKeyHeld(true);
-      await room.localParticipant.setMicrophoneEnabled(true);
-      logger.dev('[PTT] Key pressed, microphone enabled');
-    } catch (error) {
-      logger.error('[PTT] Failed to enable microphone:', error);
-    }
-  }, [pushToTalkKey, getRoom, stateRef]);
+    void pttPress();
+  }, [pushToTalkKey, pttPress]);
 
   // Handle keyup - disable microphone
-  const handleKeyUp = useCallback(async (event: KeyboardEvent) => {
+  const handleKeyUp = useCallback((event: KeyboardEvent) => {
     // Check if this is our PTT key
     if (event.code !== pushToTalkKey) return;
-
-    const room = getRoom();
-    if (!room) return;
-
-    try {
-      isKeyHeldRef.current = false;
-      setIsKeyHeld(false);
-      await room.localParticipant.setMicrophoneEnabled(false);
-      logger.dev('[PTT] Key released, microphone disabled');
-    } catch (error) {
-      logger.error('[PTT] Failed to disable microphone:', error);
-    }
-  }, [pushToTalkKey, getRoom]);
+    void pttRelease();
+  }, [pushToTalkKey, pttRelease]);
 
   // Handle window blur - release mic if user switches tabs while holding key
-  const handleBlur = useCallback(async () => {
+  const handleBlur = useCallback(() => {
     if (!isKeyHeldRef.current) return;
-
-    const room = getRoom();
-    if (!room) return;
-
-    try {
-      isKeyHeldRef.current = false;
-      setIsKeyHeld(false);
-      await room.localParticipant.setMicrophoneEnabled(false);
-      logger.dev('[PTT] Window blur, microphone disabled');
-    } catch (error) {
-      logger.error('[PTT] Failed to disable microphone on blur:', error);
-    }
-  }, [getRoom]);
+    void pttRelease();
+  }, [pttRelease]);
 
   // Set up event listeners when PTT is active
   useEffect(() => {
@@ -177,5 +178,10 @@ export function usePushToTalk() {
 
     // Current input mode
     inputMode,
+
+    // Programmatic transmit controls, sharing the exact guards/state the
+    // keyboard path uses. Used by touch "hold-to-talk" UI.
+    pttPress,
+    pttRelease,
   };
 }

--- a/frontend/src/hooks/usePushToTalk.ts
+++ b/frontend/src/hooks/usePushToTalk.ts
@@ -31,6 +31,12 @@ export function usePushToTalk() {
   // read via stateRef (#380) so we always see the CURRENT value, never a
   // stale closure.
   const pttPress = useCallback(async () => {
+    // Only meaningful while connected and in PTT mode, and ignore re-entrant
+    // presses while already held (the keyboard path filters these via
+    // event.repeat; programmatic callers get the same protection here).
+    if (!isActive) return;
+    if (isKeyHeldRef.current) return;
+
     const room = getRoom();
     if (!room) return;
 
@@ -48,7 +54,7 @@ export function usePushToTalk() {
     } catch (error) {
       logger.error('[PTT] Failed to enable microphone:', error);
     }
-  }, [getRoom, stateRef]);
+  }, [isActive, getRoom, stateRef]);
 
   // Core "stop transmitting" logic, shared by keyboard keyup, window blur, and
   // the programmatic (touch) release path.

--- a/frontend/src/hooks/useWakeLock.ts
+++ b/frontend/src/hooks/useWakeLock.ts
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from 'react';
+import { isElectron } from '../utils/platform';
+import { logger } from '../utils/logger';
+
+/**
+ * useWakeLock Hook
+ *
+ * Keeps the device screen awake while `active` is true using the Screen Wake
+ * Lock API (`navigator.wakeLock`). This prevents the phone/tablet screen from
+ * locking mid-call.
+ *
+ * - Feature-detects `navigator.wakeLock` and no-ops where unsupported.
+ * - No-ops in Electron: the desktop app already keeps the machine awake via
+ *   the `powerSaveBlocker` (see useBackgroundVoiceKeepAlive).
+ * - Wake locks are automatically released by the browser when the page is
+ *   hidden, so we re-acquire on `visibilitychange` back to visible.
+ *
+ * @param active Whether the wake lock should currently be held.
+ */
+export function useWakeLock(active: boolean): void {
+  const sentinelRef = useRef<WakeLockSentinel | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    // Electron keeps the screen awake through the OS power-save blocker.
+    if (isElectron()) return;
+    if (typeof navigator === 'undefined' || !('wakeLock' in navigator)) return;
+
+    let released = false;
+
+    const requestLock = async () => {
+      try {
+        const sentinel = await navigator.wakeLock.request('screen');
+        if (released) {
+          // Cleanup ran before the request resolved — release immediately so
+          // we don't leak a lock.
+          void sentinel.release().catch(() => {});
+          return;
+        }
+        sentinelRef.current = sentinel;
+        // The browser auto-releases when the page is hidden; clear our ref so
+        // the visibilitychange handler knows to re-acquire.
+        sentinel.addEventListener('release', () => {
+          sentinelRef.current = null;
+        });
+        logger.dev('[WakeLock] Screen wake lock acquired');
+      } catch {
+        // Requests can reject (page not visible, user setting, etc.) — the
+        // wake lock is a nice-to-have, so failure is non-critical.
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      // Re-acquire when the page becomes visible again if the lock was
+      // auto-released while hidden.
+      if (document.visibilityState === 'visible' && sentinelRef.current === null) {
+        void requestLock();
+      }
+    };
+
+    void requestLock();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      released = true;
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      if (sentinelRef.current) {
+        void sentinelRef.current.release().catch(() => {});
+        sentinelRef.current = null;
+      }
+    };
+  }, [active]);
+}
+
+export default useWakeLock;


### PR DESCRIPTION
## Summary

PR 4 of 7 in the mobile UX overhaul (independent of the #388/#389/#390 stack — based on main, disjoint files). The headline fix: **push-to-talk mode made it impossible to speak on mobile** — `usePushToTalk` is keyboard-only and the mic button's `onClick` is deliberately disabled in PTT mode, so a touch user in PTT mode had no way to transmit at all.

## Changes

- **Hold-to-talk (owner-confirmed design)**: `usePushToTalk` now exports programmatic `pttPress()`/`pttRelease()` that share the exact guards of the keyboard path (server-mute check via `stateRef` from #380, same LiveKit calls). Under touch UI with PTT active, the mic button becomes press-and-hold: pointer capture keeps transmit tied to the button if the finger slides off, haptic ticks on engage/release, the existing green "transmitting" visual, and context-menu suppression on long-hold. Desktop keyboard PTT and non-PTT tap-to-mute are unchanged (regression-tested).
- **Screen-share volume on touch**: the slider was hover-expand only (width 0 until `mouseenter`). On touch, tapping the icon now opens a popover with an always-visible slider and the mute toggle. Mouse behavior unchanged.
- **PiP video overlay**: desktop drag/resize converted from mouse to pointer events (+ `touchAction: none` on drag surfaces) so touch tablets — which get the desktop branch at 768–1199px — can actually move it. Mouse logic identical; the mobile full-screen branch untouched.
- **`useWakeLock` (new)**: holds a screen wake lock while voice-connected, re-acquires on `visibilitychange`, feature-detected, no-op in Electron. Mounted in `VoiceBottomBar`.

## Testing

- New `useWakeLock` suite (7 tests); `usePushToTalk` extended (press/release guards, server-muted no-op); `VoiceBottomBar` extended (pointerdown→press, pointerup→release, "Hold to talk" label, server-muted blocked, desktop no-regression); `ScreenShareVolumeControl` touch popover tests.
- All 7 affected suites: 96 passed / 0 failed. `type-check` + `lint` clean. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvVeRD4zf7UofaTfNDJm2Z