### PR TITLE
feat(mobile): ResponsiveDialog + mobile-ready management surfaces

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -88,7 +88,7 @@ function App() {
       <AutoUpdater />
       <PWAInstallPrompt />
       <Suspense fallback={
-        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100dvh' }}>
           <CircularProgress />
         </Box>
       }>

--- a/frontend/src/__tests__/components/ResponsiveDialog.test.tsx
+++ b/frontend/src/__tests__/components/ResponsiveDialog.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { DialogContent, DialogActions, Button } from '@mui/material';
+import { renderWithProviders } from '../test-utils';
+import ResponsiveDialog from '../../components/Common/ResponsiveDialog';
+
+// Mock the breakpoint hook so we can toggle mobile vs desktop deterministically.
+const { mockUseMobileBreakpoint } = vi.hoisted(() => ({
+  mockUseMobileBreakpoint: vi.fn(() => false),
+}));
+
+vi.mock('../../hooks/useResponsive', () => ({
+  useMobileBreakpoint: mockUseMobileBreakpoint,
+}));
+
+const renderDialog = (onClose = vi.fn()) =>
+  renderWithProviders(
+    <ResponsiveDialog open onClose={onClose} title="My Dialog Title" maxWidth="md" fullWidth>
+      <DialogContent>
+        <div>Dialog body content</div>
+      </DialogContent>
+      <DialogActions>
+        <Button>Save</Button>
+      </DialogActions>
+    </ResponsiveDialog>
+  );
+
+describe('ResponsiveDialog', () => {
+  beforeEach(() => {
+    mockUseMobileBreakpoint.mockReset();
+    mockUseMobileBreakpoint.mockReturnValue(false);
+  });
+
+  it('renders the title and children on desktop without a close button', () => {
+    mockUseMobileBreakpoint.mockReturnValue(false);
+    renderDialog();
+
+    expect(screen.getByText('My Dialog Title')).toBeInTheDocument();
+    expect(screen.getByText('Dialog body content')).toBeInTheDocument();
+    // No fullscreen app-bar close button on desktop
+    expect(screen.queryByLabelText('close')).not.toBeInTheDocument();
+  });
+
+  it('renders fullScreen with a title bar and close button below the breakpoint', () => {
+    mockUseMobileBreakpoint.mockReturnValue(true);
+    renderDialog();
+
+    expect(screen.getByText('My Dialog Title')).toBeInTheDocument();
+    expect(screen.getByText('Dialog body content')).toBeInTheDocument();
+
+    const closeButton = screen.getByLabelText('close');
+    expect(closeButton).toBeInTheDocument();
+
+    // MUI applies the fullScreen paper class to the dialog paper when active
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveClass('MuiDialog-paperFullScreen');
+  });
+
+  it('fires onClose when the mobile close button is clicked', async () => {
+    mockUseMobileBreakpoint.mockReturnValue(true);
+    const onClose = vi.fn();
+    const { user } = renderDialog(onClose);
+
+    await user.click(screen.getByLabelText('close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -130,7 +130,7 @@ export function AuthGate() {
           flexDirection: "column",
           justifyContent: "center",
           alignItems: "center",
-          minHeight: "100vh",
+          minHeight: "100dvh",
           gap: 2,
         }}
       >

--- a/frontend/src/components/Common/ResponsiveDialog.tsx
+++ b/frontend/src/components/Common/ResponsiveDialog.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  AppBar,
+  Toolbar,
+  Typography,
+  IconButton,
+  Slide,
+} from '@mui/material';
+import type { DialogProps } from '@mui/material';
+import type { TransitionProps } from '@mui/material/transitions';
+import CloseIcon from '@mui/icons-material/Close';
+import { useMobileBreakpoint } from '../../hooks/useResponsive';
+
+/**
+ * Slide-up transition used for the fullScreen (mobile) presentation.
+ */
+const SlideUpTransition = React.forwardRef(function SlideUpTransition(
+  props: TransitionProps & { children: React.ReactElement },
+  ref: React.Ref<unknown>,
+) {
+  return <Slide direction="up" ref={ref} {...props} />;
+});
+
+export interface ResponsiveDialogProps extends Omit<DialogProps, 'title'> {
+  /** Dialog heading. Rendered in a DialogTitle on desktop and in an app-bar on mobile. */
+  title?: React.ReactNode;
+  /**
+   * Optional element rendered on the right side of the mobile title bar,
+   * before the close button (e.g. an extra action icon).
+   */
+  titleActions?: React.ReactNode;
+  /**
+   * The dialog body — typically a `<DialogContent>` followed by `<DialogActions>`.
+   * The title is provided via the `title` prop, not as a child.
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * ResponsiveDialog
+ *
+ * A thin wrapper around MUI's `Dialog` that becomes fullScreen (with a slide-up
+ * transition and an app-bar-style title bar containing a close button) below the
+ * phone breakpoint, while rendering an ordinary centered dialog on desktop.
+ *
+ * Desktop appearance is unchanged from a plain `<Dialog>` — pass `title` instead
+ * of an explicit `<DialogTitle>` and it renders identically above the breakpoint.
+ */
+export const ResponsiveDialog: React.FC<ResponsiveDialogProps> = ({
+  title,
+  titleActions,
+  children,
+  onClose,
+  fullScreen: fullScreenProp,
+  TransitionComponent,
+  PaperProps,
+  ...dialogProps
+}) => {
+  const isMobile = useMobileBreakpoint();
+  const fullScreen = fullScreenProp ?? isMobile;
+
+  const handleCloseClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClose?.(event, 'escapeKeyDown');
+  };
+
+  // On mobile, honor top/bottom safe-area insets so the title bar clears the
+  // notch/status bar and the action buttons clear the home indicator.
+  const mobilePaperSx = fullScreen
+    ? {
+        '& .MuiDialogActions-root': {
+          paddingBottom: 'calc(8px + env(safe-area-inset-bottom))',
+        },
+      }
+    : undefined;
+
+  return (
+    <Dialog
+      {...dialogProps}
+      onClose={onClose}
+      fullScreen={fullScreen}
+      TransitionComponent={fullScreen ? SlideUpTransition : TransitionComponent}
+      PaperProps={{
+        ...PaperProps,
+        sx: [
+          mobilePaperSx,
+          ...(Array.isArray(PaperProps?.sx) ? PaperProps.sx : [PaperProps?.sx]),
+        ],
+      }}
+    >
+      {fullScreen ? (
+        <AppBar
+          position="sticky"
+          color="default"
+          elevation={0}
+          sx={{
+            paddingTop: 'env(safe-area-inset-top)',
+            borderBottom: 1,
+            borderColor: 'divider',
+            backgroundColor: 'background.paper',
+          }}
+        >
+          <Toolbar>
+            <Typography variant="h6" component="div" sx={{ flex: 1, minWidth: 0 }} noWrap>
+              {title}
+            </Typography>
+            {titleActions}
+            <IconButton
+              edge="end"
+              color="inherit"
+              onClick={handleCloseClick}
+              aria-label="close"
+            >
+              <CloseIcon />
+            </IconButton>
+          </Toolbar>
+        </AppBar>
+      ) : (
+        title != null && <DialogTitle>{title}</DialogTitle>
+      )}
+      {children}
+    </Dialog>
+  );
+};
+
+export default ResponsiveDialog;

--- a/frontend/src/components/Community/CommunityFormLayout.tsx
+++ b/frontend/src/components/Community/CommunityFormLayout.tsx
@@ -15,7 +15,7 @@ const Root = styled(Box)(({ theme }) => ({
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
-  minHeight: "100vh",
+  minHeight: "100dvh",
   padding: theme.spacing(2),
   background: theme.palette.background.default,
 }));

--- a/frontend/src/components/Community/CreateChannelDialog.tsx
+++ b/frontend/src/components/Community/CreateChannelDialog.tsx
@@ -8,13 +8,12 @@ import {
   InputLabel,
   Select,
   MenuItem,
-  Dialog,
-  DialogTitle,
   DialogContent,
   DialogActions,
   Typography,
   CircularProgress,
 } from "@mui/material";
+import ResponsiveDialog from "../Common/ResponsiveDialog";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { channelsControllerCreateMutation } from "../../api-client/@tanstack/react-query.gen";
 import { logger } from "../../utils/logger";
@@ -76,8 +75,7 @@ const CreateChannelDialog: React.FC<CreateChannelDialogProps> = ({
   }, [formData, communityId, createChannel, handleClose]);
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Create New Channel</DialogTitle>
+    <ResponsiveDialog open={open} onClose={handleClose} maxWidth="sm" fullWidth title="Create New Channel">
       <DialogContent>
         <TextField
           autoFocus
@@ -124,7 +122,7 @@ const CreateChannelDialog: React.FC<CreateChannelDialogProps> = ({
           {creatingChannel ? <CircularProgress size={20} /> : "Create Channel"}
         </Button>
       </DialogActions>
-    </Dialog>
+    </ResponsiveDialog>
   );
 };
 

--- a/frontend/src/components/Community/EditChannelDialog.tsx
+++ b/frontend/src/components/Community/EditChannelDialog.tsx
@@ -4,12 +4,11 @@ import {
   TextField,
   FormControlLabel,
   Switch,
-  Dialog,
-  DialogTitle,
   DialogContent,
   DialogActions,
   CircularProgress,
 } from "@mui/material";
+import ResponsiveDialog from "../Common/ResponsiveDialog";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { channelsControllerUpdateMutation } from "../../api-client/@tanstack/react-query.gen";
 import type { Channel } from "../../types/channel.type";
@@ -80,8 +79,7 @@ const EditChannelDialog: React.FC<EditChannelDialogProps> = ({
   }, [channel, formData, updateChannel, handleClose]);
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Edit Channel</DialogTitle>
+    <ResponsiveDialog open={open} onClose={handleClose} maxWidth="sm" fullWidth title="Edit Channel">
       <DialogContent>
         <TextField
           autoFocus
@@ -111,7 +109,7 @@ const EditChannelDialog: React.FC<EditChannelDialogProps> = ({
           {updatingChannel ? <CircularProgress size={20} /> : "Update Channel"}
         </Button>
       </DialogActions>
-    </Dialog>
+    </ResponsiveDialog>
   );
 };
 

--- a/frontend/src/components/Community/InviteManagement.tsx
+++ b/frontend/src/components/Community/InviteManagement.tsx
@@ -11,14 +11,13 @@ import {
   Divider,
   IconButton,
   alpha,
-  Dialog,
-  DialogTitle,
   DialogContent,
   DialogContentText,
   DialogActions,
   TextField,
   Tooltip,
 } from "@mui/material";
+import ResponsiveDialog from "../Common/ResponsiveDialog";
 import { useTheme } from "@mui/material/styles";
 import { 
   Delete as DeleteIcon, 
@@ -308,13 +307,13 @@ const InviteManagement: React.FC<InviteManagementProps> = ({ communityId }) => {
       </Card>
 
       {/* Create Invite Dialog */}
-      <Dialog
+      <ResponsiveDialog
         open={createDialogOpen}
         onClose={() => setCreateDialogOpen(false)}
         maxWidth="sm"
         fullWidth
+        title="Create Community Invite"
       >
-        <DialogTitle>Create Community Invite</DialogTitle>
         <DialogContent>
           <DialogContentText sx={{ mb: 3 }}>
             Create a new invite link for users to join this community.
@@ -354,7 +353,7 @@ const InviteManagement: React.FC<InviteManagementProps> = ({ communityId }) => {
             {creatingInvite ? <CircularProgress size={20} /> : "Create Invite"}
           </Button>
         </DialogActions>
-      </Dialog>
+      </ResponsiveDialog>
 
       {/* Delete Confirmation Dialog */}
       <ConfirmDialog

--- a/frontend/src/components/Community/RoleAssignmentDialog.tsx
+++ b/frontend/src/components/Community/RoleAssignmentDialog.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from "react";
 import {
-  Dialog,
-  DialogTitle,
   DialogContent,
   DialogActions,
   Button,
@@ -15,6 +13,7 @@ import {
   Chip,
   Divider,
 } from "@mui/material";
+import ResponsiveDialog from "../Common/ResponsiveDialog";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   rolesControllerGetCommunityRolesOptions,
@@ -135,16 +134,13 @@ const RoleAssignmentDialog: React.FC<RoleAssignmentDialogProps> = ({
   const error = rolesError || userRolesError;
 
   return (
-    <Dialog
+    <ResponsiveDialog
       open={open}
       onClose={onClose}
       maxWidth="md"
       fullWidth
+      title={`Manage Roles for ${userName}`}
     >
-      <DialogTitle>
-        Manage Roles for {userName}
-      </DialogTitle>
-      
       <DialogContent>
         {isLoading ? (
           <Box display="flex" justifyContent="center" py={4}>
@@ -244,7 +240,7 @@ const RoleAssignmentDialog: React.FC<RoleAssignmentDialogProps> = ({
           )}
         </Button>
       </DialogActions>
-    </Dialog>
+    </ResponsiveDialog>
   );
 };
 

--- a/frontend/src/components/Community/RoleManagement.tsx
+++ b/frontend/src/components/Community/RoleManagement.tsx
@@ -16,12 +16,11 @@ import {
   Paper,
   IconButton,
   Chip,
-  Dialog,
-  DialogTitle,
   DialogContent,
   DialogActions,
   Tooltip,
 } from "@mui/material";
+import ResponsiveDialog from "../Common/ResponsiveDialog";
 import {
   Add as AddIcon,
   Edit as EditIcon,
@@ -500,15 +499,13 @@ const RoleManagement: React.FC<RoleManagementProps> = ({ communityId }) => {
       />
 
       {/* Role Users Dialog */}
-      <Dialog
+      <ResponsiveDialog
         open={Boolean(viewingRoleUsers)}
         onClose={handleCloseUsersDialog}
         maxWidth="md"
         fullWidth
+        title={`Role Members: ${communityRoles?.roles.find(r => r.id === viewingRoleUsers)?.name ?? ""}`}
       >
-        <DialogTitle>
-          Role Members: {communityRoles?.roles.find(r => r.id === viewingRoleUsers)?.name}
-        </DialogTitle>
         <DialogContent>
           {loadingRoleUsers ? (
             <Box display="flex" justifyContent="center" p={2}>
@@ -550,7 +547,7 @@ const RoleManagement: React.FC<RoleManagementProps> = ({ communityId }) => {
             Close
           </Button>
         </DialogActions>
-      </Dialog>
+      </ResponsiveDialog>
     </>
   );
 };

--- a/frontend/src/components/CommunityList/CommunityToggle.tsx
+++ b/frontend/src/components/CommunityList/CommunityToggle.tsx
@@ -43,13 +43,13 @@ const Sidebar = styled(Drawer, {
     paddingTop: 16,
     paddingBottom: 16,
     top: appBarHeight,
-    height: `calc(100vh - ${appBarHeight}px)`,
+    height: `calc(100dvh - ${appBarHeight}px)`,
     transition: "width 0.3s cubic-bezier(0.4,0,0.2,1)",
     overflowX: "hidden",
   },
   "&.MuiDrawer-root": {
     top: appBarHeight,
-    height: `calc(100vh - ${appBarHeight}px)`,
+    height: `calc(100dvh - ${appBarHeight}px)`,
   },
 }));
 

--- a/frontend/src/components/DirectMessages/CreateDmDialog.tsx
+++ b/frontend/src/components/DirectMessages/CreateDmDialog.tsx
@@ -8,14 +8,13 @@
 import React, { useState } from "react";
 import {
   Box,
-  Dialog,
-  DialogTitle,
   DialogContent,
   DialogActions,
   Button,
   TextField,
   CircularProgress,
 } from "@mui/material";
+import ResponsiveDialog from "../Common/ResponsiveDialog";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { directMessagesControllerCreateDmGroupMutation } from "../../api-client/@tanstack/react-query.gen";
 import { invalidateDmGroupQueries } from "../../utils/queryInvalidation";
@@ -70,8 +69,7 @@ const CreateDmDialog: React.FC<CreateDmDialogProps> = ({
   };
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Start a Direct Message</DialogTitle>
+    <ResponsiveDialog open={open} onClose={handleClose} maxWidth="sm" fullWidth title="Start a Direct Message">
       <DialogContent>
         <Box sx={{ mb: 2 }}>
           <UserSearchAutocomplete
@@ -103,7 +101,7 @@ const CreateDmDialog: React.FC<CreateDmDialogProps> = ({
           {isCreating ? <CircularProgress size={20} /> : "Create"}
         </Button>
       </DialogActions>
-    </Dialog>
+    </ResponsiveDialog>
   );
 };
 

--- a/frontend/src/components/Friends/AddFriendDialog.tsx
+++ b/frontend/src/components/Friends/AddFriendDialog.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useMemo } from "react";
+import ResponsiveDialog from "../Common/ResponsiveDialog";
 import {
-  Dialog,
-  DialogTitle,
   DialogContent,
   DialogActions,
   Button,
@@ -111,8 +110,7 @@ const AddFriendDialog: React.FC<AddFriendDialogProps> = ({ open, onClose }) => {
   };
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Add Friend</DialogTitle>
+    <ResponsiveDialog open={open} onClose={handleClose} maxWidth="sm" fullWidth title="Add Friend">
       <DialogContent>
         {success && (
           <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(false)}>
@@ -152,7 +150,7 @@ const AddFriendDialog: React.FC<AddFriendDialogProps> = ({ open, onClose }) => {
           {isSending ? <CircularProgress size={20} /> : "Send Friend Request"}
         </Button>
       </DialogActions>
-    </Dialog>
+    </ResponsiveDialog>
   );
 };
 

--- a/frontend/src/components/Mobile/Panels/MobileChatPanel.tsx
+++ b/frontend/src/components/Mobile/Panels/MobileChatPanel.tsx
@@ -23,6 +23,7 @@ import {
   Close as CloseIcon,
   PushPin as PushPinIcon,
 } from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import {
   channelsControllerFindOneOptions,
@@ -58,6 +59,7 @@ export const MobileChatPanel: React.FC<MobileChatPanelProps> = ({
   dmGroupId,
 }) => {
   const { goBack } = useMobileNavigation();
+  const navigate = useNavigate();
   const { state: voiceState } = useVoiceConnection();
 
   // Fetch channel or DM data
@@ -97,9 +99,15 @@ export const MobileChatPanel: React.FC<MobileChatPanelProps> = ({
     handleMenuClose();
   };
 
+  // Community that owns this channel (prop takes precedence, fall back to the
+  // channel's own communityId). Undefined for DMs.
+  const effectiveCommunityId = communityId || channel?.communityId;
+
   const handleChannelSettings = () => {
-    // TODO: Navigate to channel settings
     handleMenuClose();
+    if (effectiveCommunityId) {
+      navigate(`/community/${effectiveCommunityId}/edit`);
+    }
   };
 
   // Determine title
@@ -196,12 +204,14 @@ export const MobileChatPanel: React.FC<MobileChatPanelProps> = ({
                 <ListItemText>Pinned Messages</ListItemText>
               </MenuItem>
             )}
-            <MenuItem onClick={handleChannelSettings}>
-              <ListItemIcon>
-                <SettingsIcon fontSize="small" />
-              </ListItemIcon>
-              <ListItemText>Channel Settings</ListItemText>
-            </MenuItem>
+            {effectiveCommunityId && (
+              <MenuItem onClick={handleChannelSettings}>
+                <ListItemIcon>
+                  <SettingsIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText>Community Settings</ListItemText>
+              </MenuItem>
+            )}
           </Menu>
         }
       />

--- a/frontend/src/components/Moderation/BanDialog.tsx
+++ b/frontend/src/components/Moderation/BanDialog.tsx
@@ -6,9 +6,8 @@
  */
 
 import React, { useState } from "react";
+import ResponsiveDialog from "../Common/ResponsiveDialog";
 import {
-  Dialog,
-  DialogTitle,
   DialogContent,
   DialogActions,
   Button,
@@ -96,8 +95,7 @@ const BanDialog: React.FC<BanDialogProps> = ({
   };
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Ban {userName}</DialogTitle>
+    <ResponsiveDialog open={open} onClose={handleClose} maxWidth="sm" fullWidth title={`Ban ${userName}`}>
       <DialogContent>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
           {error && (
@@ -178,7 +176,7 @@ const BanDialog: React.FC<BanDialogProps> = ({
           {isLoading ? "Banning..." : "Ban User"}
         </Button>
       </DialogActions>
-    </Dialog>
+    </ResponsiveDialog>
   );
 };
 

--- a/frontend/src/components/Moderation/TimeoutDialog.tsx
+++ b/frontend/src/components/Moderation/TimeoutDialog.tsx
@@ -6,9 +6,8 @@
  */
 
 import React, { useState } from "react";
+import ResponsiveDialog from "../Common/ResponsiveDialog";
 import {
-  Dialog,
-  DialogTitle,
   DialogContent,
   DialogActions,
   Button,
@@ -90,8 +89,7 @@ const TimeoutDialog: React.FC<TimeoutDialogProps> = ({
   };
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Timeout {userName}</DialogTitle>
+    <ResponsiveDialog open={open} onClose={handleClose} maxWidth="sm" fullWidth title={`Timeout ${userName}`}>
       <DialogContent>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
           {error && (
@@ -149,7 +147,7 @@ const TimeoutDialog: React.FC<TimeoutDialogProps> = ({
           {isLoading ? "Timing out..." : "Timeout User"}
         </Button>
       </DialogActions>
-    </Dialog>
+    </ResponsiveDialog>
   );
 };
 

--- a/frontend/src/components/Profile/ShareClipDialog.tsx
+++ b/frontend/src/components/Profile/ShareClipDialog.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import ResponsiveDialog from '../Common/ResponsiveDialog';
 import {
-  Dialog,
-  DialogTitle,
   DialogContent,
   DialogActions,
   Button,
@@ -94,8 +93,7 @@ const ShareClipDialog: React.FC<ShareClipDialogProps> = ({ open, onClose, clipId
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Share Clip</DialogTitle>
+    <ResponsiveDialog open={open} onClose={onClose} maxWidth="sm" fullWidth title="Share Clip">
       <DialogContent>
         <RadioGroup
           value={shareDestination}
@@ -164,7 +162,7 @@ const ShareClipDialog: React.FC<ShareClipDialogProps> = ({ open, onClose, clipId
           Share
         </Button>
       </DialogActions>
-    </Dialog>
+    </ResponsiveDialog>
   );
 };
 

--- a/frontend/src/components/Voice/DeviceSettingsDialog.tsx
+++ b/frontend/src/components/Voice/DeviceSettingsDialog.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import {
-  Dialog,
-  DialogTitle,
   DialogContent,
   DialogActions,
   Button,
 } from '@mui/material';
+import ResponsiveDialog from '../Common/ResponsiveDialog';
 import AudioVideoSettingsPanel from '../Settings/AudioVideoSettingsPanel';
 
 interface DeviceSettingsDialogProps {
@@ -19,14 +18,14 @@ export const DeviceSettingsDialog: React.FC<DeviceSettingsDialogProps> = ({
   onClose,
   onDeviceChange,
 }) => (
-  <Dialog
+  <ResponsiveDialog
     open={open}
     onClose={onClose}
     maxWidth="md"
     fullWidth
+    title="Voice & Video Settings"
     PaperProps={{ sx: { minHeight: '500px' } }}
   >
-    <DialogTitle>Voice & Video Settings</DialogTitle>
     <DialogContent dividers>
       <AudioVideoSettingsPanel
         onDeviceChange={onDeviceChange}
@@ -37,5 +36,5 @@ export const DeviceSettingsDialog: React.FC<DeviceSettingsDialogProps> = ({
     <DialogActions>
       <Button onClick={onClose}>Done</Button>
     </DialogActions>
-  </Dialog>
+  </ResponsiveDialog>
 );

--- a/frontend/src/components/admin/AdminLayout.tsx
+++ b/frontend/src/components/admin/AdminLayout.tsx
@@ -10,10 +10,13 @@ import {
   ListItemText,
   Typography,
   Divider,
+  IconButton,
   useTheme,
 } from "@mui/material";
 import { APPBAR_HEIGHT } from "../../constants/layout";
+import { useMobileBreakpoint } from "../../hooks/useResponsive";
 import {
+  Menu as MenuIcon,
   Dashboard as DashboardIcon,
   People as PeopleIcon,
   Groups as CommunitiesIcon,
@@ -47,6 +50,8 @@ const AdminLayout: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const theme = useTheme();
+  const isMobile = useMobileBreakpoint();
+  const [mobileOpen, setMobileOpen] = React.useState(false);
 
   const isActive = (path: string) => {
     if (path === "/admin") {
@@ -55,71 +60,115 @@ const AdminLayout: React.FC = () => {
     return location.pathname.startsWith(path);
   };
 
-  return (
-    <Box sx={{ display: "flex", minHeight: `calc(100vh - ${APPBAR_HEIGHT}px)` }}>
-      {/* Sidebar */}
-      <Drawer
-        variant="permanent"
-        sx={{
-          width: DRAWER_WIDTH,
-          flexShrink: 0,
-          "& .MuiDrawer-paper": {
-            width: DRAWER_WIDTH,
-            boxSizing: "border-box",
-            position: "relative",
-            minHeight: `calc(100vh - ${APPBAR_HEIGHT}px)`,
-            backgroundColor: theme.palette.background.paper,
-          },
-        }}
-      >
-        {/* Header */}
-        <Box sx={{ p: 2 }}>
-          <Typography variant="h6" fontWeight="bold">
-            Instance Admin
-          </Typography>
-        </Box>
-        <Divider />
+  const handleNavigate = (path: string) => {
+    navigate(path);
+    setMobileOpen(false);
+  };
 
-        {/* Navigation */}
-        <List sx={{ flex: 1 }}>
-          {navItems.map((item) => (
-            <ListItem key={item.path} disablePadding>
-              <ListItemButton
-                selected={isActive(item.path)}
-                onClick={() => navigate(item.path)}
+  const drawerContent = (
+    <>
+      {/* Header */}
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6" fontWeight="bold">
+          Instance Admin
+        </Typography>
+      </Box>
+      <Divider />
+
+      {/* Navigation */}
+      <List sx={{ flex: 1 }}>
+        {navItems.map((item) => (
+          <ListItem key={item.path} disablePadding>
+            <ListItemButton
+              selected={isActive(item.path)}
+              onClick={() => handleNavigate(item.path)}
+              sx={{
+                "&.Mui-selected": {
+                  backgroundColor: theme.palette.action.selected,
+                  borderRight: `3px solid ${theme.palette.primary.main}`,
+                },
+              }}
+            >
+              <ListItemIcon
                 sx={{
-                  "&.Mui-selected": {
-                    backgroundColor: theme.palette.action.selected,
-                    borderRight: `3px solid ${theme.palette.primary.main}`,
-                  },
+                  color: isActive(item.path)
+                    ? theme.palette.primary.main
+                    : "inherit",
                 }}
               >
-                <ListItemIcon
-                  sx={{
-                    color: isActive(item.path)
-                      ? theme.palette.primary.main
-                      : "inherit",
-                  }}
-                >
-                  {item.icon}
-                </ListItemIcon>
-                <ListItemText primary={item.label} />
-              </ListItemButton>
-            </ListItem>
-          ))}
-        </List>
-      </Drawer>
+                {item.icon}
+              </ListItemIcon>
+              <ListItemText primary={item.label} />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+    </>
+  );
+
+  return (
+    <Box sx={{ display: "flex", minHeight: `calc(100dvh - ${APPBAR_HEIGHT}px)` }}>
+      {/* Sidebar */}
+      {isMobile ? (
+        <Drawer
+          variant="temporary"
+          open={mobileOpen}
+          onClose={() => setMobileOpen(false)}
+          ModalProps={{ keepMounted: true }}
+          sx={{
+            "& .MuiDrawer-paper": {
+              width: DRAWER_WIDTH,
+              boxSizing: "border-box",
+              backgroundColor: theme.palette.background.paper,
+            },
+          }}
+        >
+          {drawerContent}
+        </Drawer>
+      ) : (
+        <Drawer
+          variant="permanent"
+          sx={{
+            width: DRAWER_WIDTH,
+            flexShrink: 0,
+            "& .MuiDrawer-paper": {
+              width: DRAWER_WIDTH,
+              boxSizing: "border-box",
+              position: "relative",
+              minHeight: `calc(100dvh - ${APPBAR_HEIGHT}px)`,
+              backgroundColor: theme.palette.background.paper,
+            },
+          }}
+        >
+          {drawerContent}
+        </Drawer>
+      )}
 
       {/* Main content */}
       <Box
         component="main"
         sx={{
           flexGrow: 1,
+          minWidth: 0,
           p: 3,
           overflow: "auto",
           backgroundColor: theme.palette.background.default,
         }}
       >
+        {isMobile && (
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+            <IconButton
+              edge="start"
+              onClick={() => setMobileOpen(true)}
+              aria-label="open admin navigation"
+            >
+              <MenuIcon />
+            </IconButton>
+            <Typography variant="h6" fontWeight="bold">
+              Instance Admin
+            </Typography>
+          </Box>
+        )}
         <Outlet />
       </Box>
     </Box>

--- a/frontend/src/hooks/useResponsive.ts
+++ b/frontend/src/hooks/useResponsive.ts
@@ -92,10 +92,13 @@ export const useResponsive = () => {
 
 /**
  * Simple hook for just mobile detection
- * Returns true for phone and phone landscape (< 768px)
+ * Returns true for phone and phone landscape (< 768px).
+ * Always false in Electron — a narrow desktop window is not a phone
+ * (mirrors the Electron gate in useResponsive).
  */
 export const useMobileBreakpoint = (): boolean => {
-  return useMediaQuery(`(max-width: ${DEVICE_BREAKPOINTS.PHONE_LANDSCAPE - 1}px)`);
+  const matches = useMediaQuery(`(max-width: ${DEVICE_BREAKPOINTS.PHONE_LANDSCAPE - 1}px)`);
+  return matches && !isElectron();
 };
 
 /**

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -27,7 +27,7 @@ body {
   display: flex;
   place-items: center;
   min-width: 320px;
-  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 #root {

--- a/frontend/src/pages/EditCommunityPage.tsx
+++ b/frontend/src/pages/EditCommunityPage.tsx
@@ -250,7 +250,14 @@ const EditCommunityPage: React.FC = () => {
       {/* Tabs */}
       <Paper>
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-          <Tabs value={tabValue} onChange={handleTabChange} aria-label="community management tabs">
+          <Tabs
+            value={tabValue}
+            onChange={handleTabChange}
+            aria-label="community management tabs"
+            variant="scrollable"
+            scrollButtons="auto"
+            allowScrollButtonsMobile
+          >
             <Tab label="Settings" {...a11yProps(0)} disabled={!canUpdateCommunity} />
             <Tab label="Members" {...a11yProps(1)} disabled={!canManageMembers} />
             <Tab label="Channels" {...a11yProps(2)} disabled={!canManageChannels} />
@@ -345,10 +352,10 @@ const EditCommunityPage: React.FC = () => {
           {canViewModeration ? (
             <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
               <Box sx={{ display: "flex", gap: 3, flexWrap: "wrap" }}>
-                <Box sx={{ flex: "1 1 300px", minWidth: 300 }}>
+                <Box sx={{ flex: "1 1 300px", minWidth: { xs: "100%", sm: 300 } }}>
                   <BanListPanel communityId={communityId!} />
                 </Box>
-                <Box sx={{ flex: "1 1 300px", minWidth: 300 }}>
+                <Box sx={{ flex: "1 1 300px", minWidth: { xs: "100%", sm: 300 } }}>
                   <TimeoutListPanel communityId={communityId!} />
                 </Box>
               </Box>

--- a/frontend/src/pages/JoinInvitePage.tsx
+++ b/frontend/src/pages/JoinInvitePage.tsx
@@ -28,7 +28,7 @@ const FormContainer = styled(Box)({
   alignItems: "center",
   justifyContent: "center",
   padding: "16px",
-  minHeight: "100vh",
+  minHeight: "100dvh",
 });
 
 const FormBox = styled(Box)({

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -21,7 +21,7 @@ const OnboardingPage: React.FC = () => {
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
-          minHeight: '100vh',
+          minHeight: '100dvh',
         }}
       >
         <CircularProgress size={40} />
@@ -36,7 +36,7 @@ const OnboardingPage: React.FC = () => {
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
-          minHeight: '100vh',
+          minHeight: '100dvh',
           p: 2,
         }}
       >
@@ -60,7 +60,7 @@ const OnboardingPage: React.FC = () => {
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
-          minHeight: '100vh',
+          minHeight: '100dvh',
           p: 2,
         }}
       >
@@ -72,7 +72,7 @@ const OnboardingPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
+    <Box sx={{ minHeight: '100dvh', bgcolor: 'background.default' }}>
       <OnboardingWizard
         setupToken={status.setupToken}
         onComplete={handleComplete}


### PR DESCRIPTION
## Summary

PR 5 of 7 in the mobile UX overhaul (stacked on #388, which made these pages reachable on phones in the first place). Form dialogs and management surfaces were desktop-sized: `maxWidth="md"` dialogs clamped with margins on phones, a fixed 7-tab strip on community settings, a permanent admin sidebar, and `100vh` layouts that break under iOS's dynamic URL bar.

## Changes

- **`ResponsiveDialog`** (new, `components/Common/`): below the phone breakpoint it renders fullScreen with a slide-up transition, an app-bar title with close button, and safe-area insets; above it, a plain `Dialog` with `DialogTitle` — desktop pixel-identical. Standard Dialog props pass through; caller `PaperProps.sx` merged safely.
- **Converted to fullscreen-on-phone** (real form work): role members viewer (`RoleManagement`), `RoleAssignmentDialog`, `DeviceSettingsDialog`, `CreateChannelDialog`, `EditChannelDialog`, `CreateDmDialog`, `AddFriendDialog`, `BanDialog`, `TimeoutDialog`, `ShareClipDialog`, InviteManagement's create dialog. **Left as centered modals**: kick/unban/remove-timeout confirms, `ConfirmDialog`, delete confirms — confirms are correct as modals. (`CaptureReplayModal` already adapted; unchanged reference.)
- **`EditCommunityPage`**: scrollable tabs (`allowScrollButtonsMobile`); moderation columns stack full-width on xs instead of overflowing.
- **`AdminLayout`**: permanent sidebar becomes a temporary drawer with a menu button below 768px (auto-closes on navigation); `100dvh`.
- **`100vh` → `100dvh`** on Onboarding, JoinInvite, AuthGate loading, `CommunityToggle`, `CommunityFormLayout`, the App suspense fallback, and `index.css` body — fixes content cut-off behind mobile browser chrome (identical on desktop).
- **`MobileChatPanel`**: the dead "Channel Settings" menu item now navigates to `/community/:id/edit` (relabeled "Community Settings", hidden for DMs).

## Testing

- New `ResponsiveDialog` tests (desktop layout, mobile fullScreen + close, onClose). Existing suites for converted dialogs (Ban/Timeout/AddFriend/MobileChatPanel) pass unchanged — 31 tests in the affected set. `type-check` + `lint` clean. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvVeRD4zf7UofaTfNDJm2Z