### PR TITLE
feat(mobile): swipe navigation, drawer edge-swipe, pull-to-refresh + perf docs

### DIFF
--- a/docs/breakpoint-unification.md
+++ b/docs/breakpoint-unification.md
@@ -1,0 +1,74 @@
+# Breakpoint mismatch: `DEVICE_BREAKPOINTS` vs MUI theme defaults
+
+Status: **documented, NOT changed.** After auditing the actual consumers, the
+mismatch is benign and unifying is *not* clearly safe. Err on the side of not
+changing (see decision below).
+
+## The mismatch
+
+Two breakpoint systems coexist:
+
+- **`frontend/src/utils/breakpoints.ts`** — the app's own device model.
+  `DEVICE_BREAKPOINTS.PHONE_LANDSCAPE = 768` is the mobile/tablet cutoff:
+  `< 768px` is treated as mobile (single-column), `768–1199px` as tablet. This
+  is what `useResponsive()` uses to derive `isMobile`, `isTablet`, and crucially
+  **`shouldUseTouchUI`**, the gate for the whole mobile UX (incl. this phase's
+  gesture layer).
+- **The MUI theme** in `frontend/src/theme/themeConfig.ts` uses `createTheme`
+  **without a `breakpoints` override**, so MUI's defaults apply:
+  `xs=0, sm=600, md=900, lg=1200, xl=1536`. Note `md=900`, not `768`.
+
+So "medium" means 768 in the device model and 900 in the MUI theme.
+
+## Why it's benign today (the audit)
+
+`theme.breakpoints` is consumed in exactly **one** place:
+`frontend/src/hooks/useResponsive.ts`, which computes the back-compat exports
+`isXs / isSm / isMd / isLg / isXl` via `theme.breakpoints.only(...)`.
+
+Grepping the codebase (`src/**`, excluding tests):
+
+- **No component reads `isXs / isSm / isMd / isLg / isXl`** from `useResponsive()`.
+  They are dead back-compat surface. Changing where they flip would affect nobody.
+- The **responsive-critical** decisions (`isMobile`, `isTablet`,
+  `shouldUseTouchUI`, `useMobileBreakpoint`, `useCompactLayout`) are all driven by
+  `DEVICE_BREAKPOINTS` **directly**, not by the MUI theme. They already agree on
+  768. The mobile layout and gesture gating are unaffected by the theme's `md`.
+- The only real consumers of MUI's default breakpoints are **`Grid size={{ xs,
+  sm, md }}`** props in cosmetic/admin layouts:
+  - `frontend/src/components/Profile/ClipLibrary.tsx`
+  - `frontend/src/pages/admin/AdminDashboard.tsx`
+  These grids were laid out around `md=900` (e.g. 3-up at `md`).
+
+## Decision: do not change
+
+Setting `breakpoints: { values: { ..., md: 768, ... } }` in `themeConfig.ts`
+would be *mechanically* trivial, but it is **not visually safe**:
+
+- It would silently change where the `ClipLibrary` and `AdminDashboard` grids
+  reflow (3-up kicks in at 768 instead of 900), plus any future `sx={{ md: ... }}`
+  responsive prop — a class of change that's easy to miss in review and only
+  shows up visually at 768–900px widths.
+- The upside is nil: the only thing that would "unify" is the set of dead
+  `isMd/isSm` exports that nothing consumes.
+
+Since the responsive-critical paths already agree on 768 and the theme's `md`
+only affects unrelated grid cosmetics, the safe and correct move is to **leave
+the theme defaults alone**.
+
+## Migration path (if unification is ever wanted)
+
+1. Add a custom `breakpoints.values` block to `generateTheme()` in
+   `themeConfig.ts` mirroring `BREAKPOINTS` from `breakpoints.ts`
+   (`sm=600, md=768, lg=1024, xl=1200`), so there is one source of truth.
+2. Audit every `Grid size={{ ... }}` and `sx={{ sm/md/lg: ... }}` responsive
+   object (currently `ClipLibrary`, `AdminDashboard`) and re-tune the column
+   counts for the new `md=768` so they don't reflow too early.
+3. Update the `isSm/isMd/...` comments in `useResponsive.ts` (they document the
+   old `600–899 / 900–1199` ranges) or delete the dead exports outright.
+4. Verify visually at the 768–900px band (tablet portrait), which is the only
+   range whose behavior changes.
+
+Until there's a concrete need, keeping the two systems separate — device model
+at 768 for layout/touch, MUI defaults for incidental grid cosmetics — is the
+lower-risk state.

--- a/docs/message-list-virtualization.md
+++ b/docs/message-list-virtualization.md
@@ -1,0 +1,136 @@
+# Message list virtualization — investigation
+
+Status: **investigation only, no code changes.** This documents the current
+message-list architecture and what a virtualization effort would have to
+preserve. File references are to `frontend/src`.
+
+## Current architecture
+
+The message list is **not** virtualized today. Every loaded message renders a
+real DOM node. The moving parts:
+
+- **`components/Message/MessageContainer.tsx`** — renders the scroll container
+  (`overflowY: auto`, `overflowAnchor: none`) as a normal `column` flex box,
+  oldest-first in DOM order (chronological), with a top sentinel and a bottom
+  sentinel `Box`. Messages arrive newest-first (the `useMessages` contract) and
+  are reversed for render. DOM order = chronological order is load-bearing:
+  native cross-message text selection follows DOM order.
+- **`hooks/useBidirectionalScroll.ts`** — the single owner of scroll position.
+  It:
+  - positions the view at the bottom (normal mode) or scroll-to-highlight
+    (anchored mode) on first non-empty render per context (`resetKey`);
+  - runs two `IntersectionObserver`s on the sentinels — top sentinel triggers
+    `onLoadMore` (older), bottom sentinel triggers `onLoadNewer` (anchored) and
+    tracks `atBottom`;
+  - **stabilizes scroll on older-prepend** by measuring `scrollHeight` before/
+    after and shifting `scrollTop` by the delta (native anchoring is explicitly
+    disabled because Chrome suppresses it at `scrollTop === 0`, which is exactly
+    when older pages load);
+  - **sticks to bottom** for new messages / late content growth while pinned,
+    via a `ResizeObserver` on the container and its children;
+  - **compensates above-viewport growth** (image placeholder → image, late link
+    embeds) by tracking each message element's height in a `WeakMap` and shifting
+    `scrollTop` by the growth delta when the grown element sits above the
+    viewport and the user is not pinned;
+  - suppresses pagination until initial positioning / highlight scroll completes.
+- **`hooks/useMessageVisibility.ts`** — an `IntersectionObserver` over the
+  message elements (via `messageRefs`) that marks messages read as they enter the
+  viewport. It needs the real message DOM nodes to observe.
+- **`hooks/useAnchoredModeTransition.ts`** — flips anchored → normal when the user
+  reaches the live bottom.
+
+The three mechanisms that make this feel stable (prepend stabilization,
+bottom-pin, above-viewport growth compensation) all depend on **measuring real
+element heights** in the DOM.
+
+## Why naive `react-window` won't work
+
+`react-window`'s `FixedSizeList` assumes a **known, uniform row height**. Chat
+messages are wildly variable height (one-liners, code blocks, image
+attachments, embeds, grouped vs. ungrouped headers) and grow *after* mount when
+images/embeds load. `VariableSizeList` needs an `itemSize(index)` function known
+*before* render, which we don't have.
+
+Beyond height, a drop-in windowing list breaks the load-bearing behaviors above:
+
+- **Scroll anchoring on prepend.** react-window owns `scrollTop` and resets item
+  offsets when the item array changes; prepending older pages would jump the
+  viewport. Our manual `scrollHeight`-delta compensation assumes a real
+  contiguous DOM, which a windowed list does not provide.
+- **Text selection across messages.** Windowing unmounts off-screen rows, so a
+  selection can't span beyond the rendered window, and selection anchors are lost
+  on scroll.
+- **Read tracking** (`useMessageVisibility`) observes real nodes; windowed rows
+  that aren't mounted are never observed → messages never marked read.
+- **Jump-to-message / highlight** (`highlightMessageId` + `scrollIntoView`)
+  requires the target node to exist; in a windowed list it may not be mounted.
+
+## Recommended library
+
+Use a **dynamic-height, measure-on-render** virtualizer. Two candidates:
+
+- **TanStack Virtual (`@tanstack/react-virtual`)** — headless, framework-idiomatic
+  (we already use TanStack Query), supports dynamic measurement via
+  `measureElement` / `ResizeObserver`, exposes an imperative `scrollToIndex` with
+  alignment, and lets us keep full control of the scroll container. **Preferred**:
+  headless means we can keep our sentinel/pagination and read-tracking model and
+  slot virtualization underneath it, rather than ceding the scroll container.
+- **virtua** — excellent reverse/bidirectional support and a `shift` prop
+  designed for prepending items without a jump (the single hardest problem here).
+  Lighter API, strong "chat" story out of the box. Worth prototyping head-to-head
+  with TanStack Virtual specifically on the older-prepend case.
+
+Both support dynamic heights and late growth via re-measurement, which is the
+non-negotiable requirement. Recommendation: prototype **virtua** first for its
+purpose-built prepend/reverse handling, with **TanStack Virtual** as the fallback
+if we need more manual control.
+
+## Integration risks
+
+1. **Scroll anchor stabilization on prepend.** The single biggest risk. Today
+   `useBidirectionalScroll` does `scrollTop += scrollHeightDelta`. A virtualizer
+   computes offsets from an estimated total size; prepending shifts every index.
+   virtua's `shift` / TanStack's `scrollToIndex` after prepend must reproduce
+   *exactly* the current no-jump behavior, or history reading becomes unusable.
+2. **Dynamic height + image-load reflow.** Estimated sizes are wrong until an
+   element is measured; images/embeds change height post-measure. The virtualizer
+   must re-measure on `ResizeObserver` (both libs can) and the above-viewport
+   growth compensation must be reconciled with the virtualizer's own offset math
+   — running both independently will double-compensate.
+3. **Jump-to-message.** `highlightMessageId` currently relies on the node being in
+   the DOM. With virtualization we must `scrollToIndex(indexOf(id), { align:
+   'center' })` and only flash once the row is mounted/measured — the
+   `highlightSeq` re-trigger logic has to move into that flow.
+4. **Read tracking.** `useMessageVisibility` must switch from observing all nodes
+   to deriving visible range from the virtualizer (it already exposes the visible
+   index range), or keep observing but only the mounted subset — the "mark read"
+   semantics must not regress (don't mark unmounted messages read, don't miss ones
+   scrolled past quickly).
+5. **Text selection.** Cross-message selection across the window boundary will
+   regress. Acceptable trade-off for large lists, but call it out explicitly;
+   consider an overscan large enough that typical selections stay within mounted
+   rows.
+6. **Anchored (jump-to-context) mode.** Two-directional loading with a centered
+   start position must map onto the virtualizer's initial `scrollToIndex`.
+
+## Suggested incremental path
+
+1. **Don't virtualize yet where it isn't needed.** Add a message-count threshold:
+   below ~200 rendered nodes, keep the current non-virtualized path (it's correct
+   and battle-tested). Only switch on the virtualized renderer above the threshold.
+2. **Extract a `MessageList` render-prop/child** out of `MessageContainer` so the
+   scroll container, sentinels, and message mapping can be swapped without
+   touching input, typing indicator, member list, or the FABs.
+3. **Prototype virtua in normal mode only**, wiring its `shift`-on-prepend against
+   the existing `onLoadMore`. Validate the no-jump prepend against a channel with
+   thousands of messages before touching anchored mode.
+4. **Reconcile the scroll-stabilization hooks**: move prepend stabilization,
+   bottom-pin, and above-viewport growth compensation *into* the virtualizer's
+   measurement lifecycle so there is still a single owner of `scrollTop` (the
+   architectural invariant the current hook documents).
+5. **Re-home read tracking** onto the virtualizer's visible range, then verify
+   jump-to-message and highlight flash.
+6. **Only then** port anchored mode.
+
+Ship behind the count threshold so the risky path is opt-in and the current
+correct behavior remains the default for the overwhelming majority of channels.

--- a/frontend/src/__tests__/components/MobileChatPanelSwipe.test.tsx
+++ b/frontend/src/__tests__/components/MobileChatPanelSwipe.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, act } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import { MobileChatPanel } from '../../components/Mobile/Panels/MobileChatPanel';
+import { isSwipeExemptTarget } from '../../utils/swipeExempt';
+import { MOBILE_CONSTANTS } from '../../utils/breakpoints';
+
+// Stable goBack mock so we can assert it was invoked.
+const goBack = vi.hoisted(() => vi.fn());
+
+vi.mock('../../components/Mobile/Navigation/MobileNavigationContext', () => ({
+  useMobileNavigation: () => ({ goBack }),
+}));
+
+// Force touch UI on so the swipe handlers are wired.
+vi.mock('../../hooks/useResponsive', () => ({
+  useResponsive: () => ({ shouldUseTouchUI: true, isMobile: true }),
+}));
+
+// Capture the options passed to useSwipeGesture so we can drive the callbacks
+// directly. The real hook's gesture detection is covered by useSwipeGesture.test.ts.
+type SwipeOpts = Parameters<typeof import('../../hooks/useSwipeGesture').useSwipeGesture>[0];
+const captured: { opts: SwipeOpts | null } = vi.hoisted(() => ({ opts: null }));
+
+vi.mock('../../hooks/useSwipeGesture', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useSwipeGesture')>();
+  return {
+    ...actual,
+    useSwipeGesture: (opts: SwipeOpts) => {
+      captured.opts = opts;
+      return {
+        onTouchStart: vi.fn(),
+        onTouchMove: vi.fn(),
+        onTouchEnd: vi.fn(),
+        getSwipeState: vi.fn(),
+      };
+    },
+  };
+});
+
+vi.mock('../../hooks/useVoiceConnection', () => ({
+  useVoiceConnection: () => ({
+    state: { isConnected: false, currentChannelId: null },
+  }),
+}));
+
+vi.mock('../../api-client/@tanstack/react-query.gen', () => ({
+  channelsControllerFindOneOptions: () => ({ queryKey: ['channel', ''], enabled: false }),
+  directMessagesControllerFindDmGroupOptions: () => ({ queryKey: ['dm', ''], enabled: false }),
+  moderationControllerGetPinnedMessagesOptions: () => ({ queryKey: ['pinned', ''], enabled: false }),
+}));
+
+vi.mock('../../components/Channel/ChannelMessageContainer', () => ({
+  default: () => <div data-testid="channel-message-container" />,
+}));
+
+vi.mock('../../components/DirectMessages/DirectMessageContainer', () => ({
+  default: () => <div data-testid="direct-message-container" />,
+}));
+
+vi.mock('../../components/Mobile/MobileAppBar', () => ({
+  default: () => <div data-testid="mobile-app-bar" />,
+}));
+
+vi.mock('../../components/Message/MemberListContainer', () => ({
+  default: () => <div data-testid="member-list" />,
+}));
+
+vi.mock('../../components/Moderation', () => ({
+  PinnedMessagesPanel: () => <div data-testid="pinned-panel" />,
+}));
+
+/**
+ * The member SwipeableDrawer keeps its content mounted, so "open" is detected by
+ * the absence of the `MuiModal-hidden` class on its modal root (closed drawers
+ * carry that class + aria-hidden).
+ */
+const membersDrawerOpen = () => {
+  const modal = screen.getByText('Members').closest('.MuiModal-root');
+  return !!modal && !modal.className.includes('MuiModal-hidden');
+};
+
+describe('MobileChatPanel swipe navigation wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    captured.opts = null;
+  });
+
+  it('configures the swipe hook with edge/exempt/direction guards', () => {
+    renderWithProviders(<MobileChatPanel communityId="c1" channelId="ch1" />);
+
+    expect(captured.opts).toBeTruthy();
+    expect(captured.opts?.enabled).toBe(true);
+    expect(captured.opts?.ignoreEdgeSwipes).toBe(true);
+    expect(captured.opts?.edgeZone).toBe(MOBILE_CONSTANTS.EDGE_BACK_GESTURE_ZONE);
+    expect(captured.opts?.directionRatio).toBeGreaterThan(1);
+    expect(captured.opts?.isExempt).toBe(isSwipeExemptTarget);
+  });
+
+  it('swipe right invokes goBack', () => {
+    renderWithProviders(<MobileChatPanel communityId="c1" channelId="ch1" />);
+
+    act(() => captured.opts?.onSwipeRight?.(1));
+
+    expect(goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('swipe left opens the members drawer for a channel', () => {
+    const { rerender } = renderWithProviders(
+      <MobileChatPanel communityId="c1" channelId="ch1" />,
+    );
+
+    expect(membersDrawerOpen()).toBe(false);
+
+    act(() => captured.opts?.onSwipeLeft?.(1));
+    // Re-render to flush the state update that opens the drawer.
+    rerender(<MobileChatPanel communityId="c1" channelId="ch1" />);
+
+    expect(membersDrawerOpen()).toBe(true);
+    expect(goBack).not.toHaveBeenCalled();
+  });
+
+  it('swipe left does not open a members drawer in a DM (no channel)', () => {
+    const { rerender } = renderWithProviders(<MobileChatPanel dmGroupId="dm1" />);
+
+    act(() => captured.opts?.onSwipeLeft?.(1));
+    rerender(<MobileChatPanel dmGroupId="dm1" />);
+
+    expect(membersDrawerOpen()).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/components/MobileCommunityDrawer.test.tsx
+++ b/frontend/src/__tests__/components/MobileCommunityDrawer.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders } from '../test-utils';
+import MobileCommunityDrawer from '../../components/Mobile/Navigation/MobileCommunityDrawer';
+
+// Controllable current screen for the nav context mock.
+const navState = vi.hoisted(() => ({ currentScreen: 'channels' as string }));
+const openDrawer = vi.hoisted(() => vi.fn());
+
+vi.mock('../../components/Mobile/Navigation/MobileNavigationContext', () => ({
+  useMobileNavigation: () => ({
+    state: { isDrawerOpen: false, currentScreen: navState.currentScreen, communityId: null },
+    openDrawer,
+    closeDrawer: vi.fn(),
+    navigateToChannels: vi.fn(),
+    navigateToDmList: vi.fn(),
+  }),
+}));
+
+vi.mock('../../hooks/useReadReceipts', () => ({
+  useReadReceipts: () => ({ totalDmUnreadCount: 0 }),
+}));
+
+vi.mock('../../hooks/useAuthenticatedImage', () => ({
+  useAuthenticatedImage: () => ({ blobUrl: null }),
+}));
+
+vi.mock('../../api-client/@tanstack/react-query.gen', () => ({
+  communityControllerFindAllMineOptions: () => ({ queryKey: ['communities'], queryFn: async () => [] }),
+}));
+
+// The SwipeArea (edge hit-zone for swipe-to-open) is only rendered when
+// disableSwipeToOpen is false.
+const hasSwipeArea = () => !!document.querySelector('[class*="SwipeArea-root"]');
+
+describe('MobileCommunityDrawer edge swipe-to-open', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enables swipe-to-open on the channels screen', () => {
+    navState.currentScreen = 'channels';
+    renderWithProviders(<MobileCommunityDrawer />);
+    expect(hasSwipeArea()).toBe(true);
+  });
+
+  it('disables swipe-to-open on the chat screen', () => {
+    navState.currentScreen = 'chat';
+    renderWithProviders(<MobileCommunityDrawer />);
+    expect(hasSwipeArea()).toBe(false);
+  });
+
+  it('disables swipe-to-open on the dm-list screen', () => {
+    navState.currentScreen = 'dm-list';
+    renderWithProviders(<MobileCommunityDrawer />);
+    expect(hasSwipeArea()).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/components/MobileMessagesPanel.test.tsx
+++ b/frontend/src/__tests__/components/MobileMessagesPanel.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import { MobileMessagesPanel } from '../../components/Mobile/Panels/MobileMessagesPanel';
+
+vi.mock('../../components/Mobile/Navigation/MobileNavigationContext', () => ({
+  useMobileNavigation: () => ({ navigateToDmChat: vi.fn() }),
+}));
+
+// Force touch UI on so pull-to-refresh handlers are attached.
+vi.mock('../../hooks/useResponsive', () => ({
+  useResponsive: () => ({ shouldUseTouchUI: true, isMobile: true }),
+}));
+
+vi.mock('../../hooks/useVoiceConnection', () => ({
+  useVoiceConnection: () => ({ state: { isConnected: false } }),
+}));
+
+vi.mock('../../hooks/useReadReceipts', () => ({
+  useReadReceipts: () => ({ unreadCount: () => 0, mentionCount: () => 0 }),
+}));
+
+vi.mock('../../api-client/@tanstack/react-query.gen', () => ({
+  directMessagesControllerFindUserDmGroupsOptions: () => ({
+    queryKey: ['dm-groups'],
+    queryFn: async () => [],
+  }),
+  userControllerGetProfileOptions: () => ({
+    queryKey: ['profile'],
+    queryFn: async () => ({ id: 'u1' }),
+  }),
+}));
+
+vi.mock('../../components/DirectMessages/DmListItem', () => ({
+  default: () => <li data-testid="dm-list-item" />,
+}));
+
+vi.mock('../../components/DirectMessages/CreateDmDialog', () => ({
+  default: () => <div data-testid="create-dm-dialog" />,
+}));
+
+vi.mock('../../components/Mobile/MobileAppBar', () => ({
+  default: () => <div data-testid="mobile-app-bar" />,
+}));
+
+describe('MobileMessagesPanel pull-to-refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refetches DM groups when pulled past the threshold', async () => {
+    const { queryClient } = renderWithProviders(<MobileMessagesPanel />);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    // Wait for the list (not the loading spinner) to render.
+    const list = await screen.findByRole('list');
+    const scrollBox = list.parentElement as HTMLElement;
+
+    fireEvent.touchStart(scrollBox, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(scrollBox, { touches: [{ clientY: 140 }] }); // past 80px threshold
+    fireEvent.touchEnd(scrollBox);
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['dm-groups'] }),
+      );
+    });
+  });
+
+  it('does not refetch for a short pull under the threshold', async () => {
+    const { queryClient } = renderWithProviders(<MobileMessagesPanel />);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const list = await screen.findByRole('list');
+    const scrollBox = list.parentElement as HTMLElement;
+
+    fireEvent.touchStart(scrollBox, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(scrollBox, { touches: [{ clientY: 30 }] }); // under 80px
+    fireEvent.touchEnd(scrollBox);
+
+    // Give any async handler a tick; invalidate must not have fired.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(invalidateSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['dm-groups'] }),
+    );
+  });
+});

--- a/frontend/src/__tests__/hooks/usePullToRefresh.test.ts
+++ b/frontend/src/__tests__/hooks/usePullToRefresh.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { usePullToRefresh } from '../../hooks/useSwipeGesture';
+
+function touchY(y: number) {
+  return { touches: [{ clientY: y }] } as unknown as React.TouchEvent;
+}
+
+/** A ref to a fake scroll element with a controllable scrollTop. */
+function scrollRef(scrollTop = 0) {
+  return { current: { scrollTop } as unknown as HTMLElement };
+}
+
+describe('usePullToRefresh', () => {
+  it('triggers onRefresh when pulled past the threshold from the top', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const ref = scrollRef(0);
+    const { result } = renderHook(() =>
+      usePullToRefresh(onRefresh, { threshold: 80, scrollElementRef: ref }),
+    );
+
+    act(() => result.current.onTouchStart(touchY(0)));
+    act(() => result.current.onTouchMove(touchY(120))); // 120 > 80
+    await act(async () => {
+      await result.current.onTouchEnd();
+    });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger when the pull is short of the threshold', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const ref = scrollRef(0);
+    const { result } = renderHook(() =>
+      usePullToRefresh(onRefresh, { threshold: 80, scrollElementRef: ref }),
+    );
+
+    act(() => result.current.onTouchStart(touchY(0)));
+    act(() => result.current.onTouchMove(touchY(40))); // 40 < 80
+    await act(async () => {
+      await result.current.onTouchEnd();
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger when the scroll region is not at the top', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const ref = scrollRef(50); // scrolled down
+    const { result } = renderHook(() =>
+      usePullToRefresh(onRefresh, { threshold: 80, scrollElementRef: ref }),
+    );
+
+    act(() => result.current.onTouchStart(touchY(0)));
+    act(() => result.current.onTouchMove(touchY(120)));
+    await act(async () => {
+      await result.current.onTouchEnd();
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when disabled', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const ref = scrollRef(0);
+    const { result } = renderHook(() =>
+      usePullToRefresh(onRefresh, { threshold: 80, enabled: false, scrollElementRef: ref }),
+    );
+
+    act(() => result.current.onTouchStart(touchY(0)));
+    act(() => result.current.onTouchMove(touchY(120)));
+    await act(async () => {
+      await result.current.onTouchEnd();
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('exposes reactive isRefreshing state during the refresh', async () => {
+    let resolveRefresh: () => void = () => {};
+    const onRefresh = vi.fn(
+      () => new Promise<void>((resolve) => { resolveRefresh = resolve; }),
+    );
+    const ref = scrollRef(0);
+    const { result } = renderHook(() =>
+      usePullToRefresh(onRefresh, { threshold: 80, scrollElementRef: ref }),
+    );
+
+    act(() => result.current.onTouchStart(touchY(0)));
+    act(() => result.current.onTouchMove(touchY(120)));
+
+    let endPromise: Promise<void>;
+    act(() => {
+      endPromise = result.current.onTouchEnd();
+    });
+
+    await waitFor(() => expect(result.current.isRefreshing).toBe(true));
+
+    await act(async () => {
+      resolveRefresh();
+      await endPromise;
+    });
+
+    expect(result.current.isRefreshing).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/hooks/useSwipeGesture.test.ts
+++ b/frontend/src/__tests__/hooks/useSwipeGesture.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSwipeGesture } from '../../hooks/useSwipeGesture';
+
+/** Build a touch-like event accepted by the swipe handlers. */
+function touch(x: number, y: number, target: EventTarget = document.createElement('div')) {
+  const point = { clientX: x, clientY: y };
+  return {
+    target,
+    targetTouches: [point],
+    touches: [point],
+    changedTouches: [point],
+  } as unknown as React.TouchEvent;
+}
+
+function swipe(
+  result: { current: ReturnType<typeof useSwipeGesture> },
+  from: [number, number],
+  to: [number, number],
+  target?: EventTarget,
+) {
+  act(() => result.current.onTouchStart(touch(from[0], from[1], target)));
+  act(() => result.current.onTouchMove(touch(to[0], to[1], target)));
+  act(() => result.current.onTouchEnd());
+}
+
+describe('useSwipeGesture', () => {
+  // jsdom default innerWidth is 1024; edges are near 0 and near 1024.
+
+  it('fires onSwipeRight for a clear rightward drag', () => {
+    const onSwipeRight = vi.fn();
+    const onSwipeLeft = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeGesture({ onSwipeRight, onSwipeLeft, directionRatio: 1.5 }),
+    );
+
+    swipe(result, [200, 100], [360, 100]);
+
+    expect(onSwipeRight).toHaveBeenCalledTimes(1);
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+
+  it('fires onSwipeLeft for a clear leftward drag', () => {
+    const onSwipeRight = vi.fn();
+    const onSwipeLeft = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeGesture({ onSwipeRight, onSwipeLeft, directionRatio: 1.5 }),
+    );
+
+    swipe(result, [360, 100], [200, 100]);
+
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it('does not fire horizontal callbacks for a mostly-vertical drag (scroll)', () => {
+    const onSwipeRight = vi.fn();
+    const onSwipeLeft = vi.fn();
+    const onSwipeDown = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeGesture({ onSwipeRight, onSwipeLeft, onSwipeDown, directionRatio: 1.5 }),
+    );
+
+    // Large vertical, small horizontal — must not register as left/right.
+    swipe(result, [200, 100], [215, 320]);
+
+    expect(onSwipeRight).not.toHaveBeenCalled();
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeDown).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a swipe that starts within the edge zone when ignoreEdgeSwipes is set', () => {
+    const onSwipeRight = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeGesture({ onSwipeRight, ignoreEdgeSwipes: true, edgeZone: 24, directionRatio: 1.5 }),
+    );
+
+    // Starts at x=10 (< 24px from left edge) → ignored.
+    swipe(result, [10, 100], [250, 100]);
+
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it('still fires when ignoreEdgeSwipes is off even if started near the edge', () => {
+    const onSwipeRight = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeGesture({ onSwipeRight, ignoreEdgeSwipes: false, edgeZone: 24, directionRatio: 1.5 }),
+    );
+
+    swipe(result, [10, 100], [250, 100]);
+
+    expect(onSwipeRight).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a swipe that starts on an exempt element', () => {
+    const onSwipeRight = vi.fn();
+    const exemptEl = document.createElement('pre');
+    const { result } = renderHook(() =>
+      useSwipeGesture({
+        onSwipeRight,
+        directionRatio: 1.5,
+        isExempt: (t) => t instanceof Element && !!t.closest('pre'),
+      }),
+    );
+
+    swipe(result, [200, 100], [360, 100], exemptEl);
+
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when disabled', () => {
+    const onSwipeRight = vi.fn();
+    const { result } = renderHook(() =>
+      useSwipeGesture({ onSwipeRight, enabled: false }),
+    );
+
+    swipe(result, [200, 100], [360, 100]);
+
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/utils/swipeExempt.test.ts
+++ b/frontend/src/__tests__/utils/swipeExempt.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { isSwipeExemptTarget } from '../../utils/swipeExempt';
+
+describe('isSwipeExemptTarget', () => {
+  it('returns false for a plain div', () => {
+    expect(isSwipeExemptTarget(document.createElement('div'))).toBe(false);
+  });
+
+  it('returns false for non-Element targets', () => {
+    expect(isSwipeExemptTarget(null)).toBe(false);
+    expect(isSwipeExemptTarget(document)).toBe(false);
+  });
+
+  it('exempts inputs and textareas (text selection surfaces)', () => {
+    expect(isSwipeExemptTarget(document.createElement('input'))).toBe(true);
+    expect(isSwipeExemptTarget(document.createElement('textarea'))).toBe(true);
+  });
+
+  it('exempts code blocks (pre) which scroll horizontally', () => {
+    const pre = document.createElement('pre');
+    const code = document.createElement('code');
+    pre.appendChild(code);
+    expect(isSwipeExemptTarget(code)).toBe(true);
+  });
+
+  it('exempts elements marked with data-swipe-exempt (and their descendants)', () => {
+    const gallery = document.createElement('div');
+    gallery.setAttribute('data-swipe-exempt', '');
+    const img = document.createElement('img');
+    gallery.appendChild(img);
+    expect(isSwipeExemptTarget(gallery)).toBe(true);
+    expect(isSwipeExemptTarget(img)).toBe(true);
+  });
+
+  it('exempts contenteditable regions', () => {
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', 'true');
+    expect(isSwipeExemptTarget(editable)).toBe(true);
+  });
+
+  it('exempts an ancestor with inline overflow-x: auto', () => {
+    const scroller = document.createElement('div');
+    scroller.setAttribute('style', 'overflow-x: auto');
+    const child = document.createElement('span');
+    scroller.appendChild(child);
+    expect(isSwipeExemptTarget(child)).toBe(true);
+  });
+});

--- a/frontend/src/__tests__/utils/swipeExempt.test.ts
+++ b/frontend/src/__tests__/utils/swipeExempt.test.ts
@@ -38,11 +38,24 @@ describe('isSwipeExemptTarget', () => {
     expect(isSwipeExemptTarget(editable)).toBe(true);
   });
 
-  it('exempts an ancestor with inline overflow-x: auto', () => {
+  it('exempts an ancestor with inline overflow-x: auto that actually scrolls', () => {
     const scroller = document.createElement('div');
     scroller.setAttribute('style', 'overflow-x: auto');
+    // jsdom does no layout — model a genuinely scrollable container explicitly.
+    Object.defineProperty(scroller, 'scrollWidth', { value: 600 });
+    Object.defineProperty(scroller, 'clientWidth', { value: 300 });
     const child = document.createElement('span');
     scroller.appendChild(child);
     expect(isSwipeExemptTarget(child)).toBe(true);
+  });
+
+  it('does not exempt an overflow-x container whose content fits (not scrollable)', () => {
+    const scroller = document.createElement('div');
+    scroller.setAttribute('style', 'overflow-x: auto');
+    Object.defineProperty(scroller, 'scrollWidth', { value: 300 });
+    Object.defineProperty(scroller, 'clientWidth', { value: 300 });
+    const child = document.createElement('span');
+    scroller.appendChild(child);
+    expect(isSwipeExemptTarget(child)).toBe(false);
   });
 });

--- a/frontend/src/components/Mobile/Navigation/MobileCommunityDrawer.tsx
+++ b/frontend/src/components/Mobile/Navigation/MobileCommunityDrawer.tsx
@@ -111,7 +111,13 @@ const CommunityListSkeleton: React.FC = () => (
 
 const MobileCommunityDrawer: React.FC = () => {
   const navigate = useNavigate();
-  const { state, closeDrawer, navigateToChannels, navigateToDmList } = useMobileNavigation();
+  const { state, openDrawer, closeDrawer, navigateToChannels, navigateToDmList } = useMobileNavigation();
+
+  // Swipe-to-open (left edge) is normally disabled because it collides with
+  // Chrome's back-gesture. It's only safe on the channel list ('channels'
+  // screen), where there is no in-app back destination for the edge swipe to
+  // fight over. Enabled there, disabled everywhere else.
+  const allowSwipeToOpen = state.currentScreen === 'channels';
   const { data: communities, isLoading } = useQuery(communityControllerFindAllMineOptions());
   const { totalDmUnreadCount: totalDmUnread } = useReadReceipts();
 
@@ -140,8 +146,8 @@ const MobileCommunityDrawer: React.FC = () => {
       anchor="left"
       open={state.isDrawerOpen}
       onClose={closeDrawer}
-      onOpen={() => {}} // No-op since we use button to open
-      disableSwipeToOpen // Disable edge swipe to avoid Chrome back gesture conflict
+      onOpen={openDrawer}
+      disableSwipeToOpen={!allowSwipeToOpen} // Only allow edge swipe on the channel list (no back-gesture conflict there)
       sx={{
         '& .MuiDrawer-paper': {
           width: MOBILE_CONSTANTS.DRAWER_WIDTH,

--- a/frontend/src/components/Mobile/Panels/MobileChatPanel.tsx
+++ b/frontend/src/components/Mobile/Panels/MobileChatPanel.tsx
@@ -31,6 +31,10 @@ import {
   moderationControllerGetPinnedMessagesOptions,
 } from '../../../api-client/@tanstack/react-query.gen';
 import { useMobileNavigation } from '../Navigation/MobileNavigationContext';
+import { useResponsive } from '../../../hooks/useResponsive';
+import { useSwipeGesture } from '../../../hooks/useSwipeGesture';
+import { isSwipeExemptTarget } from '../../../utils/swipeExempt';
+import { MOBILE_CONSTANTS } from '../../../utils/breakpoints';
 import { ChannelType } from '../../../types/channel.type';
 import ChannelMessageContainer from '../../Channel/ChannelMessageContainer';
 import DirectMessageContainer from '../../DirectMessages/DirectMessageContainer';
@@ -60,6 +64,7 @@ export const MobileChatPanel: React.FC<MobileChatPanelProps> = ({
 }) => {
   const { goBack } = useMobileNavigation();
   const navigate = useNavigate();
+  const { shouldUseTouchUI } = useResponsive();
   const { state: voiceState } = useVoiceConnection();
 
   // Fetch channel or DM data
@@ -109,6 +114,29 @@ export const MobileChatPanel: React.FC<MobileChatPanelProps> = ({
       navigate(`/community/${effectiveCommunityId}/edit`);
     }
   };
+
+  // Swipe navigation on the chat surface (touch UI only):
+  //  - Swipe RIGHT anywhere → go back (channel chat → channel list,
+  //    dm-chat → dm list; both handled by the nav context's goBack()).
+  //  - Swipe LEFT → open the members drawer (channel chat only).
+  // Gestures starting within the edge back-gesture zone, on exempt content
+  // (inputs, code blocks, horizontally scrollable widgets), or that are mostly
+  // vertical (scrolling) are ignored. The SwipeableDrawers render in portals, so
+  // touches on them never reach this surface.
+  const { onTouchStart, onTouchMove, onTouchEnd } = useSwipeGesture({
+    enabled: shouldUseTouchUI,
+    onSwipeRight: () => goBack(),
+    onSwipeLeft: () => {
+      if (channelId) setShowMemberDrawer(true);
+    },
+    isExempt: isSwipeExemptTarget,
+    ignoreEdgeSwipes: true,
+    edgeZone: MOBILE_CONSTANTS.EDGE_BACK_GESTURE_ZONE,
+    // Require horizontal displacement to clearly dominate vertical so ordinary
+    // vertical scrolling never navigates.
+    directionRatio: 1.5,
+  });
+  const swipeHandlers = { onTouchStart, onTouchMove, onTouchEnd };
 
   // Determine title
   let title = '';
@@ -217,7 +245,10 @@ export const MobileChatPanel: React.FC<MobileChatPanelProps> = ({
       />
 
       {/* Content */}
-      <Box sx={{ flex: 1, overflow: 'hidden' }}>
+      <Box
+        sx={{ flex: 1, overflow: 'hidden' }}
+        {...(shouldUseTouchUI ? swipeHandlers : {})}
+      >
         {renderContent()}
       </Box>
 

--- a/frontend/src/components/Mobile/Panels/MobileMessagesPanel.tsx
+++ b/frontend/src/components/Mobile/Panels/MobileMessagesPanel.tsx
@@ -5,7 +5,7 @@
  * Uses the new screen-based navigation with MobileAppBar.
  */
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import {
   Box,
   Typography,
@@ -16,7 +16,7 @@ import {
 import {
   Add as AddIcon,
 } from '@mui/icons-material';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   directMessagesControllerFindUserDmGroupsOptions,
   userControllerGetProfileOptions,
@@ -27,6 +27,8 @@ import CreateDmDialog from '../../DirectMessages/CreateDmDialog';
 import { useMobileNavigation } from '../Navigation/MobileNavigationContext';
 import { useVoiceConnection } from '../../../hooks/useVoiceConnection';
 import { useReadReceipts } from '../../../hooks/useReadReceipts';
+import { useResponsive } from '../../../hooks/useResponsive';
+import { usePullToRefresh } from '../../../hooks/useSwipeGesture';
 import { LAYOUT_CONSTANTS } from '../../../utils/breakpoints';
 import MobileAppBar from '../MobileAppBar';
 import { VoiceSessionType } from '../../../contexts/VoiceContext';
@@ -37,12 +39,28 @@ import { VoiceSessionType } from '../../../contexts/VoiceContext';
  */
 export const MobileMessagesPanel: React.FC = () => {
   const { navigateToDmChat } = useMobileNavigation();
+  const { shouldUseTouchUI } = useResponsive();
+  const queryClient = useQueryClient();
   const { data: dmGroups = [], isLoading } = useQuery(directMessagesControllerFindUserDmGroupsOptions());
   const { data: currentUser } = useQuery(userControllerGetProfileOptions());
   const { state: voiceState } = useVoiceConnection();
   const { unreadCount, mentionCount } = useReadReceipts();
 
   const [showCreateDialog, setShowCreateDialog] = useState(false);
+
+  // Pull-to-refresh: drag down from the top of the DM list to refetch it.
+  const listScrollRef = useRef<HTMLDivElement>(null);
+  const { onTouchStart, onTouchMove, onTouchEnd, isRefreshing } = usePullToRefresh(
+    async () => {
+      await queryClient.invalidateQueries({
+        queryKey: directMessagesControllerFindUserDmGroupsOptions().queryKey,
+      });
+    },
+    { enabled: shouldUseTouchUI, scrollElementRef: listScrollRef },
+  );
+  const pullHandlers = shouldUseTouchUI
+    ? { onTouchStart, onTouchMove, onTouchEnd }
+    : {};
 
   const handleDmClick = (dmGroupId: string) => {
     navigateToDmChat(dmGroupId);
@@ -67,12 +85,27 @@ export const MobileMessagesPanel: React.FC = () => {
         </Box>
       ) : (
         <Box
+          ref={listScrollRef}
           sx={{
             flex: 1,
             overflowY: 'auto',
             px: 1,
+            position: 'relative',
           }}
+          {...pullHandlers}
         >
+          {/* Pull-to-refresh indicator */}
+          {isRefreshing && (
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                py: 1.5,
+              }}
+            >
+              <CircularProgress size={24} />
+            </Box>
+          )}
           <List>
             {dmGroups.map((dmGroup) => (
               <DmListItem

--- a/frontend/src/components/Mobile/Panels/MobileMessagesPanel.tsx
+++ b/frontend/src/components/Mobile/Panels/MobileMessagesPanel.tsx
@@ -56,7 +56,9 @@ export const MobileMessagesPanel: React.FC = () => {
         queryKey: directMessagesControllerFindUserDmGroupsOptions().queryKey,
       });
     },
-    { enabled: shouldUseTouchUI, scrollElementRef: listScrollRef },
+    // trackPullDistance off: only isRefreshing is consumed here, and distance
+    // updates would re-render the whole DM list on every touchmove.
+    { enabled: shouldUseTouchUI, scrollElementRef: listScrollRef, trackPullDistance: false },
   );
   const pullHandlers = shouldUseTouchUI
     ? { onTouchStart, onTouchMove, onTouchEnd }

--- a/frontend/src/hooks/useSwipeGesture.ts
+++ b/frontend/src/hooks/useSwipeGesture.ts
@@ -412,7 +412,15 @@ export const usePullToRefresh = (
   }, [scrollElementRef]);
 
   const handleTouchStart = useCallback((e: TouchEvent) => {
-    if (!enabled || isRefreshingRef.current) return;
+    // Always start clean — a previous gesture may have left pull distance
+    // behind (e.g. it ended outside the element and touchend never fired).
+    pullDistanceRef.current = 0;
+    setPullDistance(0);
+
+    if (!enabled || isRefreshingRef.current) {
+      touchStart.current = null;
+      return;
+    }
 
     // Only begin a pull when scrolled to the very top of the scroll region.
     if (getScrollTop() > 0) {
@@ -433,14 +441,17 @@ export const usePullToRefresh = (
   }, [enabled]);
 
   const handleTouchEnd = useCallback(async () => {
-    if (!enabled || isRefreshingRef.current) {
-      touchStart.current = null;
-      return;
-    }
-
-    const shouldRefresh = pullDistanceRef.current >= threshold;
-
+    // No active pull (rejected at touchstart or already consumed) — nothing
+    // to evaluate, but make sure no stale distance lingers.
+    const hadActivePull = touchStart.current !== null;
     touchStart.current = null;
+
+    const shouldRefresh =
+      hadActivePull &&
+      enabled &&
+      !isRefreshingRef.current &&
+      pullDistanceRef.current >= threshold;
+
     pullDistanceRef.current = 0;
     setPullDistance(0);
 

--- a/frontend/src/hooks/useSwipeGesture.ts
+++ b/frontend/src/hooks/useSwipeGesture.ts
@@ -394,9 +394,20 @@ export const usePullToRefresh = (
     threshold?: number;
     enabled?: boolean;
     scrollElementRef?: React.RefObject<HTMLElement | null>;
+    /**
+     * Whether to publish `pullDistance`/`pullProgress` as React state.
+     * Defaults to true; pass false when the consumer only reads
+     * `isRefreshing` — otherwise every touchmove re-renders it.
+     */
+    trackPullDistance?: boolean;
   } = {}
 ) => {
-  const { threshold = 80, enabled = true, scrollElementRef } = options;
+  const {
+    threshold = 80,
+    enabled = true,
+    scrollElementRef,
+    trackPullDistance = true,
+  } = options;
 
   // null = no active pull. (Storing 0 would be ambiguous with a pull that
   // starts at clientY === 0.)
@@ -415,7 +426,7 @@ export const usePullToRefresh = (
     // Always start clean — a previous gesture may have left pull distance
     // behind (e.g. it ended outside the element and touchend never fired).
     pullDistanceRef.current = 0;
-    setPullDistance(0);
+    if (trackPullDistance) setPullDistance(0);
 
     if (!enabled || isRefreshingRef.current) {
       touchStart.current = null;
@@ -429,7 +440,7 @@ export const usePullToRefresh = (
     }
 
     touchStart.current = e.touches[0].clientY;
-  }, [enabled, getScrollTop]);
+  }, [enabled, getScrollTop, trackPullDistance]);
 
   const handleTouchMove = useCallback((e: TouchEvent) => {
     if (!enabled || isRefreshingRef.current || touchStart.current === null) return;
@@ -437,8 +448,8 @@ export const usePullToRefresh = (
     const touchY = e.touches[0].clientY;
     const distance = Math.max(0, touchY - touchStart.current);
     pullDistanceRef.current = distance;
-    setPullDistance(distance);
-  }, [enabled]);
+    if (trackPullDistance) setPullDistance(distance);
+  }, [enabled, trackPullDistance]);
 
   const handleTouchEnd = useCallback(async () => {
     // No active pull (rejected at touchstart or already consumed) — nothing
@@ -453,7 +464,7 @@ export const usePullToRefresh = (
       pullDistanceRef.current >= threshold;
 
     pullDistanceRef.current = 0;
-    setPullDistance(0);
+    if (trackPullDistance) setPullDistance(0);
 
     if (shouldRefresh) {
       isRefreshingRef.current = true;
@@ -465,7 +476,7 @@ export const usePullToRefresh = (
         setIsRefreshing(false);
       }
     }
-  }, [enabled, threshold, onRefresh]);
+  }, [enabled, threshold, onRefresh, trackPullDistance]);
 
   return {
     onTouchStart: handleTouchStart,

--- a/frontend/src/hooks/useSwipeGesture.ts
+++ b/frontend/src/hooks/useSwipeGesture.ts
@@ -5,7 +5,7 @@
  * progress callbacks, and velocity tracking.
  */
 
-import { useRef, useEffect, TouchEvent, useCallback } from 'react';
+import { useRef, useEffect, useState, TouchEvent, useCallback } from 'react';
 import { MOBILE_CONSTANTS } from '../utils/breakpoints';
 import { useHapticFeedback } from './useHapticFeedback';
 
@@ -31,16 +31,31 @@ interface SwipeGestureOptions {
   // Edge swipe detection
   onEdgeSwipeStart?: (edge: 'left' | 'right') => void;
   edgeZone?: number; // Pixels from edge to detect edge swipe
+  // When true, a swipe that STARTS within `edgeZone` of the left/right edge is
+  // ignored entirely (no directional callbacks fire). Used to avoid fighting the
+  // browser's native edge back-gesture.
+  ignoreEdgeSwipes?: boolean;
+
+  // Return true to skip a gesture entirely based on where it started (e.g. it
+  // began inside horizontally scrollable content or a text input). Evaluated
+  // once on touch start against the event target.
+  isExempt?: (target: EventTarget | null) => boolean;
 
   // Configuration
   threshold?: number; // Minimum distance for swipe
   velocityThreshold?: number; // Minimum velocity (px/ms)
+  // How strongly one axis must dominate the other for the gesture to count as
+  // that axis. e.g. 1.5 means horizontal displacement must exceed 1.5x the
+  // vertical displacement before a left/right swipe registers — this keeps
+  // ordinary vertical scrolling from triggering navigation.
+  directionRatio?: number;
   enabled?: boolean;
 }
 
 interface SwipeState {
   startedFromEdge: 'left' | 'right' | null;
   isSwiping: boolean;
+  isExempt: boolean;
 }
 
 /**
@@ -56,8 +71,11 @@ export const useSwipeGesture = (options: SwipeGestureOptions = {}) => {
     onProgress,
     onEdgeSwipeStart,
     edgeZone = MOBILE_CONSTANTS.EDGE_SWIPE_ZONE,
+    ignoreEdgeSwipes = false,
+    isExempt,
     threshold = MOBILE_CONSTANTS.SWIPE_THRESHOLD,
     velocityThreshold = 0.3, // px/ms
+    directionRatio = 1,
     enabled = true,
   } = options;
 
@@ -66,6 +84,7 @@ export const useSwipeGesture = (options: SwipeGestureOptions = {}) => {
   const swipeState = useRef<SwipeState>({
     startedFromEdge: null,
     isSwiping: false,
+    isExempt: false,
   });
 
   const handleTouchStart = useCallback((e: TouchEvent) => {
@@ -92,12 +111,14 @@ export const useSwipeGesture = (options: SwipeGestureOptions = {}) => {
     swipeState.current = {
       startedFromEdge: edge,
       isSwiping: false,
+      // Evaluate exemption once, against the element the gesture started on.
+      isExempt: isExempt ? isExempt(e.target) : false,
     };
 
     if (edge && onEdgeSwipeStart) {
       onEdgeSwipeStart(edge);
     }
-  }, [enabled, edgeZone, onEdgeSwipeStart]);
+  }, [enabled, edgeZone, isExempt, onEdgeSwipeStart]);
 
   const handleTouchMove = useCallback((e: TouchEvent) => {
     if (!enabled || !touchStart.current) return;
@@ -128,10 +149,21 @@ export const useSwipeGesture = (options: SwipeGestureOptions = {}) => {
   }, [enabled, threshold, onProgress]);
 
   const handleTouchEnd = useCallback(() => {
+    const { startedFromEdge, isExempt: gestureExempt } = swipeState.current;
+
     if (!enabled || !touchStart.current || !touchEnd.current) {
       touchStart.current = null;
       touchEnd.current = null;
-      swipeState.current = { startedFromEdge: null, isSwiping: false };
+      swipeState.current = { startedFromEdge: null, isSwiping: false, isExempt: false };
+      return;
+    }
+
+    // Bail if the gesture started on exempt content, or (when configured) within
+    // the edge back-gesture zone — no directional callbacks fire.
+    if (gestureExempt || (ignoreEdgeSwipes && startedFromEdge)) {
+      touchStart.current = null;
+      touchEnd.current = null;
+      swipeState.current = { startedFromEdge: null, isSwiping: false, isExempt: false };
       return;
     }
 
@@ -142,28 +174,28 @@ export const useSwipeGesture = (options: SwipeGestureOptions = {}) => {
     const absX = Math.abs(deltaX);
     const absY = Math.abs(deltaY);
 
-    // Calculate velocity (px/ms)
-    const velocity = absX / (deltaTime || 1);
-
-    // Determine swipe direction
+    // Determine swipe direction. One axis must clearly dominate the other
+    // (`directionRatio`) so vertical scrolling never registers as horizontal.
     let direction: SwipeDirection | null = null;
 
-    // Only register swipe if:
-    // 1. Distance exceeds threshold, OR
-    // 2. Velocity exceeds threshold (fast swipe even if short)
-    const meetsDistanceThreshold = (absX > absY && absX > threshold) ||
-                                   (absY > absX && absY > threshold);
-    const meetsVelocityThreshold = velocity > velocityThreshold;
+    const isHorizontalIntent = absX > absY * directionRatio;
+    const isVerticalIntent = absY > absX * directionRatio;
 
-    if (meetsDistanceThreshold || meetsVelocityThreshold) {
-      if (absX > absY) {
-        // Horizontal swipe
+    // Register a swipe when the dominant-axis distance exceeds the threshold, OR
+    // the dominant-axis velocity exceeds its threshold (fast flick, even if short).
+    if (isHorizontalIntent) {
+      const axisVelocity = absX / (deltaTime || 1);
+      if (absX > threshold || axisVelocity > velocityThreshold) {
         direction = deltaX > 0 ? 'right' : 'left';
-      } else {
-        // Vertical swipe
+      }
+    } else if (isVerticalIntent) {
+      const axisVelocity = absY / (deltaTime || 1);
+      if (absY > threshold || axisVelocity > velocityThreshold) {
         direction = deltaY > 0 ? 'down' : 'up';
       }
     }
+
+    const velocity = (absX > absY ? absX : absY) / (deltaTime || 1);
 
     if (direction) {
       onSwipe?.(direction, velocity);
@@ -187,8 +219,8 @@ export const useSwipeGesture = (options: SwipeGestureOptions = {}) => {
     // Reset state
     touchStart.current = null;
     touchEnd.current = null;
-    swipeState.current = { startedFromEdge: null, isSwiping: false };
-  }, [enabled, threshold, velocityThreshold, onSwipe, onSwipeLeft, onSwipeRight, onSwipeUp, onSwipeDown]);
+    swipeState.current = { startedFromEdge: null, isSwiping: false, isExempt: false };
+  }, [enabled, threshold, velocityThreshold, directionRatio, ignoreEdgeSwipes, onSwipe, onSwipeLeft, onSwipeRight, onSwipeUp, onSwipeDown]);
 
   // Getter for current swipe state
   const getSwipeState = useCallback(() => ({
@@ -348,56 +380,88 @@ export const useLongPress = (
 };
 
 /**
- * Hook for pull-to-refresh gesture
+ * Hook for pull-to-refresh gesture.
+ *
+ * Triggers `onRefresh` when the user drags down past `threshold` while scrolled
+ * to the top. Exposes reactive `isRefreshing` / `pullDistance` state so a small
+ * indicator can be rendered. Pass `scrollElementRef` when the scrollable region
+ * is an inner element rather than the document (the common case for app panels)
+ * — otherwise the top check reads the document scroll position.
  */
 export const usePullToRefresh = (
   onRefresh: () => Promise<void>,
-  options: { threshold?: number; enabled?: boolean } = {}
+  options: {
+    threshold?: number;
+    enabled?: boolean;
+    scrollElementRef?: React.RefObject<HTMLElement | null>;
+  } = {}
 ) => {
-  const { threshold = 80, enabled = true } = options;
+  const { threshold = 80, enabled = true, scrollElementRef } = options;
 
-  const touchStart = useRef<number>(0);
-  const pullDistance = useRef<number>(0);
-  const isRefreshing = useRef<boolean>(false);
+  // null = no active pull. (Storing 0 would be ambiguous with a pull that
+  // starts at clientY === 0.)
+  const touchStart = useRef<number | null>(null);
+  const pullDistanceRef = useRef<number>(0);
+  const isRefreshingRef = useRef<boolean>(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [pullDistance, setPullDistance] = useState(0);
+
+  const getScrollTop = useCallback((): number => {
+    if (scrollElementRef?.current) return scrollElementRef.current.scrollTop;
+    return document.documentElement.scrollTop || document.body.scrollTop;
+  }, [scrollElementRef]);
 
   const handleTouchStart = useCallback((e: TouchEvent) => {
-    if (!enabled || isRefreshing.current) return;
+    if (!enabled || isRefreshingRef.current) return;
 
-    // Only enable pull-to-refresh when scrolled to top
-    const scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
-    if (scrollTop > 0) return;
+    // Only begin a pull when scrolled to the very top of the scroll region.
+    if (getScrollTop() > 0) {
+      touchStart.current = null;
+      return;
+    }
 
     touchStart.current = e.touches[0].clientY;
-  }, [enabled]);
+  }, [enabled, getScrollTop]);
 
   const handleTouchMove = useCallback((e: TouchEvent) => {
-    if (!enabled || isRefreshing.current || touchStart.current === 0) return;
+    if (!enabled || isRefreshingRef.current || touchStart.current === null) return;
 
     const touchY = e.touches[0].clientY;
-    pullDistance.current = Math.max(0, touchY - touchStart.current);
+    const distance = Math.max(0, touchY - touchStart.current);
+    pullDistanceRef.current = distance;
+    setPullDistance(distance);
   }, [enabled]);
 
   const handleTouchEnd = useCallback(async () => {
-    if (!enabled || isRefreshing.current) return;
+    if (!enabled || isRefreshingRef.current) {
+      touchStart.current = null;
+      return;
+    }
 
-    if (pullDistance.current >= threshold) {
-      isRefreshing.current = true;
+    const shouldRefresh = pullDistanceRef.current >= threshold;
+
+    touchStart.current = null;
+    pullDistanceRef.current = 0;
+    setPullDistance(0);
+
+    if (shouldRefresh) {
+      isRefreshingRef.current = true;
+      setIsRefreshing(true);
       try {
         await onRefresh();
       } finally {
-        isRefreshing.current = false;
+        isRefreshingRef.current = false;
+        setIsRefreshing(false);
       }
     }
-
-    touchStart.current = 0;
-    pullDistance.current = 0;
   }, [enabled, threshold, onRefresh]);
 
   return {
     onTouchStart: handleTouchStart,
     onTouchMove: handleTouchMove,
     onTouchEnd: handleTouchEnd,
-    getPullDistance: () => pullDistance.current,
-    isRefreshing: () => isRefreshing.current,
+    isRefreshing,
+    pullDistance,
+    pullProgress: Math.min(pullDistance / threshold, 1),
   };
 };

--- a/frontend/src/utils/breakpoints.ts
+++ b/frontend/src/utils/breakpoints.ts
@@ -53,6 +53,9 @@ export const MOBILE_CONSTANTS = {
   MESSAGE_AVATAR_SIZE: 32,
   SWIPE_THRESHOLD: 50, // pixels
   EDGE_SWIPE_ZONE: 20, // pixels from edge to trigger drawer
+  // Gestures that START within this many pixels of the left/right screen edge
+  // are ignored, so they don't fight the browser's native edge back-gesture.
+  EDGE_BACK_GESTURE_ZONE: 24, // pixels from edge to ignore navigation swipes
   LONG_PRESS_DURATION: 500, // milliseconds
   LONG_PRESS_SLOP: 10, // pixels of movement that cancels a pending long-press
 } as const;

--- a/frontend/src/utils/swipeExempt.ts
+++ b/frontend/src/utils/swipeExempt.ts
@@ -34,7 +34,13 @@ const EXEMPT_SELECTOR = [
 const MAX_ANCESTOR_DEPTH = 8;
 
 const hasHorizontalOverflowStyle = (el: Element): boolean => {
-  // Cheap inline-style check first (works in jsdom and avoids layout).
+  // Only exempt when the element can actually scroll horizontally — an
+  // overflow-x style on a container that fits its content shouldn't block
+  // navigation swipes.
+  const htmlEl = el as HTMLElement;
+  if (htmlEl.scrollWidth <= htmlEl.clientWidth) return false;
+
+  // Cheap inline-style check first (avoids computed-style layout work).
   const inline = el.getAttribute('style');
   if (inline && /overflow-x\s*:\s*(auto|scroll)/i.test(inline)) {
     return true;
@@ -42,17 +48,12 @@ const hasHorizontalOverflowStyle = (el: Element): boolean => {
 
   // Computed-style check, guarded for environments without getComputedStyle.
   if (typeof window === 'undefined' || !window.getComputedStyle) return false;
-  let overflowX = '';
   try {
-    overflowX = window.getComputedStyle(el).overflowX;
+    const overflowX = window.getComputedStyle(el).overflowX;
+    return overflowX === 'auto' || overflowX === 'scroll';
   } catch {
     return false;
   }
-  if (overflowX !== 'auto' && overflowX !== 'scroll') return false;
-
-  // Only exempt when the element can actually scroll horizontally.
-  const htmlEl = el as HTMLElement;
-  return htmlEl.scrollWidth > htmlEl.clientWidth;
 };
 
 /**

--- a/frontend/src/utils/swipeExempt.ts
+++ b/frontend/src/utils/swipeExempt.ts
@@ -1,0 +1,73 @@
+/**
+ * Swipe-exemption heuristic.
+ *
+ * Navigation swipes on the mobile chat surface must NOT trigger when the gesture
+ * begins inside content that has its own horizontal handling or where a swipe
+ * would fight the user's intent. A gesture is exempt when it starts on (or
+ * inside) any of:
+ *
+ *  - Text-entry / selection surfaces: `input`, `textarea`, `[contenteditable]`
+ *    (the message composer, edit fields) — swiping there is text selection.
+ *  - `pre` (code blocks) and `.hljs` (syntax-highlighted code) — these scroll
+ *    horizontally.
+ *  - An explicit opt-out marker: `[data-swipe-exempt]` — attach this to any
+ *    horizontally scrollable widget (image galleries, carousels, wide tables).
+ *  - An ancestor (up to a few levels) whose inline style or computed style sets
+ *    `overflow-x: auto | scroll` AND is actually scrollable (`scrollWidth >
+ *    clientWidth`). This is a best-effort catch for horizontally scrollable
+ *    regions that didn't opt out explicitly.
+ *
+ * The heuristic is deliberately conservative and cheap — it walks at most a
+ * handful of ancestors. When in doubt, add `data-swipe-exempt` to the element.
+ */
+
+const EXEMPT_SELECTOR = [
+  'input',
+  'textarea',
+  '[contenteditable="true"]',
+  'pre',
+  '.hljs',
+  '[data-swipe-exempt]',
+].join(',');
+
+/** Max ancestors to inspect for horizontal scrollability. */
+const MAX_ANCESTOR_DEPTH = 8;
+
+const hasHorizontalOverflowStyle = (el: Element): boolean => {
+  // Cheap inline-style check first (works in jsdom and avoids layout).
+  const inline = el.getAttribute('style');
+  if (inline && /overflow-x\s*:\s*(auto|scroll)/i.test(inline)) {
+    return true;
+  }
+
+  // Computed-style check, guarded for environments without getComputedStyle.
+  if (typeof window === 'undefined' || !window.getComputedStyle) return false;
+  let overflowX = '';
+  try {
+    overflowX = window.getComputedStyle(el).overflowX;
+  } catch {
+    return false;
+  }
+  if (overflowX !== 'auto' && overflowX !== 'scroll') return false;
+
+  // Only exempt when the element can actually scroll horizontally.
+  const htmlEl = el as HTMLElement;
+  return htmlEl.scrollWidth > htmlEl.clientWidth;
+};
+
+/**
+ * Whether a swipe starting on `target` should be exempt from navigation.
+ */
+export const isSwipeExemptTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof Element)) return false;
+
+  if (target.closest(EXEMPT_SELECTOR)) return true;
+
+  let el: Element | null = target;
+  for (let depth = 0; el && depth < MAX_ANCESTOR_DEPTH; depth += 1) {
+    if (hasHorizontalOverflowStyle(el)) return true;
+    el = el.parentElement;
+  }
+
+  return false;
+};


### PR DESCRIPTION
## Summary

PR 7 of 7 — the final polish layer of the mobile UX overhaul (stacked on #389 for the hardened gesture hooks). Adds the Discord-style swipe layer and wires the last of the previously dead touch toolkit.

## Changes

- **Swipe navigation in chat** (`MobileChatPanel`): swipe right → back (channel list / DM list), swipe left → members drawer. Guarded by horizontal-intent detection (one axis must dominate 1.5:1), a 24px edge-zone bailout so the browser's back-gesture wins at screen edges, and an exemption heuristic — gestures starting in inputs, code blocks, genuinely-scrollable `overflow-x` containers, or `[data-swipe-exempt]` never navigate.
- **Community drawer edge-swipe**: enabled only on the channels screen (where there's no back-destination to conflict with); disabled elsewhere, as before.
- **Pull-to-refresh** on the DM list via the previously dead `usePullToRefresh` (rewritten with reactive progress state + inner-scroll-container support; fixes a latent `clientY === 0` sentinel bug), invalidating the DM groups query.
- **Virtualization**: written investigation only (`docs/message-list-virtualization.md`) — the custom bidirectional IntersectionObserver scroll + anchor stabilization makes this the highest-regression-risk change in the app; doc recommends prototyping virtua in a dedicated PR.
- **Breakpoint unification**: audited and deliberately not changed (`docs/breakpoint-unification.md`) — the only MUI `md=900` consumers are cosmetic grids; the responsive-critical paths already agree on 768.

## Testing

- 29 new tests (swipe hook with synthetic touches: direction ratio, edge bailout, exemptions; pull-to-refresh; exemption heuristic; panel wiring; drawer swipe gating). All 40 tests in the affected set pass; `type-check` + `lint` clean; no new dependencies; desktop/Electron untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvVeRD4zf7UofaTfNDJm2Z