### PR TITLE
fix(mobile): polish backlog — dvh fallback, desktop titleActions, tablet swipe, iOS callout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,7 +92,7 @@ function App() {
       <UpdateToast />
       <OfflineBanner />
       <Suspense fallback={
-        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100dvh' }}>
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 'var(--full-dvh)' }}>
           <CircularProgress />
         </Box>
       }>

--- a/frontend/src/__tests__/components/MobileChatPanelSwipe.test.tsx
+++ b/frontend/src/__tests__/components/MobileChatPanelSwipe.test.tsx
@@ -12,9 +12,16 @@ vi.mock('../../components/Mobile/Navigation/MobileNavigationContext', () => ({
   useMobileNavigation: () => ({ goBack }),
 }));
 
-// Force touch UI on so the swipe handlers are wired.
+// Force touch UI on so the swipe handlers are wired. Mocked as a vi.fn so
+// individual tests can override the returned device type (phone vs tablet).
+// Note: vi.clearAllMocks() does NOT reset a mockReturnValue, so the phone
+// default is re-asserted explicitly in beforeEach.
+const { mockUseResponsive } = vi.hoisted(() => ({
+  mockUseResponsive: vi.fn(() => ({ shouldUseTouchUI: true, isMobile: true })),
+}));
+
 vi.mock('../../hooks/useResponsive', () => ({
-  useResponsive: () => ({ shouldUseTouchUI: true, isMobile: true }),
+  useResponsive: mockUseResponsive,
 }));
 
 // Capture the options passed to useSwipeGesture so we can drive the callbacks
@@ -84,6 +91,7 @@ describe('MobileChatPanel swipe navigation wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     captured.opts = null;
+    mockUseResponsive.mockReturnValue({ shouldUseTouchUI: true, isMobile: true });
   });
 
   it('configures the swipe hook with edge/exempt/direction guards', () => {
@@ -97,12 +105,22 @@ describe('MobileChatPanel swipe navigation wiring', () => {
     expect(captured.opts?.isExempt).toBe(isSwipeExemptTarget);
   });
 
-  it('swipe right invokes goBack', () => {
+  it('swipe right invokes goBack on phone', () => {
+    mockUseResponsive.mockReturnValue({ shouldUseTouchUI: true, isMobile: true });
     renderWithProviders(<MobileChatPanel communityId="c1" channelId="ch1" />);
 
     act(() => captured.opts?.onSwipeRight?.(1));
 
     expect(goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('swipe right does not invoke goBack on tablet (split-view already shows the list)', () => {
+    mockUseResponsive.mockReturnValue({ shouldUseTouchUI: true, isMobile: false });
+    renderWithProviders(<MobileChatPanel communityId="c1" channelId="ch1" />);
+
+    act(() => captured.opts?.onSwipeRight?.(1));
+
+    expect(goBack).not.toHaveBeenCalled();
   });
 
   it('swipe left opens the members drawer for a channel', () => {
@@ -118,6 +136,20 @@ describe('MobileChatPanel swipe navigation wiring', () => {
 
     expect(membersDrawerOpen()).toBe(true);
     expect(goBack).not.toHaveBeenCalled();
+  });
+
+  it('swipe left still opens the members drawer on tablet', () => {
+    mockUseResponsive.mockReturnValue({ shouldUseTouchUI: true, isMobile: false });
+    const { rerender } = renderWithProviders(
+      <MobileChatPanel communityId="c1" channelId="ch1" />,
+    );
+
+    expect(membersDrawerOpen()).toBe(false);
+
+    act(() => captured.opts?.onSwipeLeft?.(1));
+    rerender(<MobileChatPanel communityId="c1" channelId="ch1" />);
+
+    expect(membersDrawerOpen()).toBe(true);
   });
 
   it('swipe left does not open a members drawer in a DM (no channel)', () => {

--- a/frontend/src/__tests__/components/ResponsiveDialog.test.tsx
+++ b/frontend/src/__tests__/components/ResponsiveDialog.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { DialogContent, DialogActions, Button } from '@mui/material';
@@ -13,9 +14,16 @@ vi.mock('../../hooks/useResponsive', () => ({
   useMobileBreakpoint: mockUseMobileBreakpoint,
 }));
 
-const renderDialog = (onClose = vi.fn()) =>
+const renderDialog = (onClose = vi.fn(), titleActions?: ReactNode) =>
   renderWithProviders(
-    <ResponsiveDialog open onClose={onClose} title="My Dialog Title" maxWidth="md" fullWidth>
+    <ResponsiveDialog
+      open
+      onClose={onClose}
+      title="My Dialog Title"
+      titleActions={titleActions}
+      maxWidth="md"
+      fullWidth
+    >
       <DialogContent>
         <div>Dialog body content</div>
       </DialogContent>
@@ -54,6 +62,14 @@ describe('ResponsiveDialog', () => {
     // MUI applies the fullScreen paper class to the dialog paper when active
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveClass('MuiDialog-paperFullScreen');
+  });
+
+  it('renders titleActions content in the DialogTitle on desktop', () => {
+    mockUseMobileBreakpoint.mockReturnValue(false);
+    renderDialog(vi.fn(), <button aria-label="pin">Pin</button>);
+
+    expect(screen.getByText('My Dialog Title')).toBeInTheDocument();
+    expect(screen.getByLabelText('pin')).toBeInTheDocument();
   });
 
   it('fires onClose when the mobile close button is clicked', async () => {

--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -130,7 +130,7 @@ export function AuthGate() {
           flexDirection: "column",
           justifyContent: "center",
           alignItems: "center",
-          minHeight: "100dvh",
+          minHeight: "var(--full-dvh)",
           gap: 2,
         }}
       >

--- a/frontend/src/components/Channel/ChannelMessageContainer.tsx
+++ b/frontend/src/components/Channel/ChannelMessageContainer.tsx
@@ -258,7 +258,7 @@ const ChannelMessageContainer: React.FC<ChannelMessageContainerProps> = ({
         PaperProps={{
           sx: {
             width: 'min(400px, 100vw)',
-            height: '100dvh',
+            height: 'var(--full-dvh)',
             overflow: 'hidden',
             paddingBottom: voiceConnected ? `${VOICE_BAR_HEIGHT}px` : 0,
           },

--- a/frontend/src/components/Common/ResponsiveDialog.tsx
+++ b/frontend/src/components/Common/ResponsiveDialog.tsx
@@ -7,6 +7,7 @@ import {
   Typography,
   IconButton,
   Slide,
+  Box,
 } from '@mui/material';
 import type { DialogProps } from '@mui/material';
 import type { TransitionProps } from '@mui/material/transitions';
@@ -27,8 +28,9 @@ export interface ResponsiveDialogProps extends Omit<DialogProps, 'title'> {
   /** Dialog heading. Rendered in a DialogTitle on desktop and in an app-bar on mobile. */
   title?: React.ReactNode;
   /**
-   * Optional element rendered on the right side of the mobile title bar,
-   * before the close button (e.g. an extra action icon).
+   * Optional element rendered alongside the title (e.g. an extra action
+   * icon): on the right side of the `DialogTitle` on desktop, and before the
+   * close button in the mobile app-bar title bar.
    */
   titleActions?: React.ReactNode;
   /**
@@ -117,7 +119,12 @@ export const ResponsiveDialog: React.FC<ResponsiveDialogProps> = ({
           </Toolbar>
         </AppBar>
       ) : (
-        title != null && <DialogTitle>{title}</DialogTitle>
+        (title != null || titleActions != null) && (
+          <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Box sx={{ flex: 1, minWidth: 0 }}>{title}</Box>
+            {titleActions}
+          </DialogTitle>
+        )
       )}
       {children}
     </Dialog>

--- a/frontend/src/components/Common/ResponsiveDialog.tsx
+++ b/frontend/src/components/Common/ResponsiveDialog.tsx
@@ -121,7 +121,11 @@ export const ResponsiveDialog: React.FC<ResponsiveDialogProps> = ({
       ) : (
         (title != null || titleActions != null) && (
           <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Box sx={{ flex: 1, minWidth: 0 }}>{title}</Box>
+            {/* span, not div: DialogTitle renders as an h2 and only allows
+                phrasing content. */}
+            <Box component="span" sx={{ flex: 1, minWidth: 0 }}>
+              {title}
+            </Box>
             {titleActions}
           </DialogTitle>
         )

--- a/frontend/src/components/Community/CommunityFormLayout.tsx
+++ b/frontend/src/components/Community/CommunityFormLayout.tsx
@@ -15,7 +15,7 @@ const Root = styled(Box)(({ theme }) => ({
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
-  minHeight: "100dvh",
+  minHeight: "var(--full-dvh)",
   padding: theme.spacing(2),
   background: theme.palette.background.default,
 }));

--- a/frontend/src/components/CommunityList/CommunityToggle.tsx
+++ b/frontend/src/components/CommunityList/CommunityToggle.tsx
@@ -43,13 +43,13 @@ const Sidebar = styled(Drawer, {
     paddingTop: 16,
     paddingBottom: 16,
     top: appBarHeight,
-    height: `calc(100dvh - ${appBarHeight}px)`,
+    height: `calc(var(--full-dvh) - ${appBarHeight}px)`,
     transition: "width 0.3s cubic-bezier(0.4,0,0.2,1)",
     overflowX: "hidden",
   },
   "&.MuiDrawer-root": {
     top: appBarHeight,
-    height: `calc(100dvh - ${appBarHeight}px)`,
+    height: `calc(var(--full-dvh) - ${appBarHeight}px)`,
   },
 }));
 

--- a/frontend/src/components/Message/MemberList.tsx
+++ b/frontend/src/components/Message/MemberList.tsx
@@ -127,8 +127,10 @@ const MemberRow: React.FC<{
       sx={{
         px: 2,
         py: 0.5,
-        WebkitTouchCallout: "none",
-        userSelect: "none",
+       ...(shouldUseTouchUI && {
+         WebkitTouchCallout: "none",
+         userSelect: "none",
+       }),
         "&:hover": {
           backgroundColor: theme.palette.semantic.overlay.light,
         },

--- a/frontend/src/components/Message/MemberList.tsx
+++ b/frontend/src/components/Message/MemberList.tsx
@@ -127,6 +127,8 @@ const MemberRow: React.FC<{
       sx={{
         px: 2,
         py: 0.5,
+        WebkitTouchCallout: "none",
+        userSelect: "none",
         "&:hover": {
           backgroundColor: theme.palette.semantic.overlay.light,
         },

--- a/frontend/src/components/Mobile/MobileLayout.tsx
+++ b/frontend/src/components/Mobile/MobileLayout.tsx
@@ -46,7 +46,7 @@ export const MobileLayout: React.FC = () => {
         sx={{
           display: 'flex',
           flexDirection: 'column',
-          height: '100dvh', // Use dynamic viewport height for mobile
+          height: 'var(--full-dvh)', // Use dynamic viewport height for mobile
           width: '100vw',
           overflow: 'hidden',
           position: 'fixed',

--- a/frontend/src/components/Mobile/Panels/MobileChatPanel.tsx
+++ b/frontend/src/components/Mobile/Panels/MobileChatPanel.tsx
@@ -64,7 +64,7 @@ export const MobileChatPanel: React.FC<MobileChatPanelProps> = ({
 }) => {
   const { goBack } = useMobileNavigation();
   const navigate = useNavigate();
-  const { shouldUseTouchUI } = useResponsive();
+  const { shouldUseTouchUI, isMobile } = useResponsive();
   const { state: voiceState } = useVoiceConnection();
 
   // Fetch channel or DM data
@@ -116,16 +116,19 @@ export const MobileChatPanel: React.FC<MobileChatPanelProps> = ({
   };
 
   // Swipe navigation on the chat surface (touch UI only):
-  //  - Swipe RIGHT anywhere → go back (channel chat → channel list,
-  //    dm-chat → dm list; both handled by the nav context's goBack()).
-  //  - Swipe LEFT → open the members drawer (channel chat only).
+  //  - Swipe RIGHT on phone → go back (channel chat → channel list,
+  //    dm-chat → dm list; both handled by the nav context's goBack()). On
+  //    tablet the channel list is already visible in the split-view sidebar
+  //    (TabletContentArea), so swipe-right must NOT navigate there.
+  //  - Swipe LEFT → open the members drawer (channel chat only). Keeps
+  //    working on tablet as well as phone.
   // Gestures starting within the edge back-gesture zone, on exempt content
   // (inputs, code blocks, horizontally scrollable widgets), or that are mostly
   // vertical (scrolling) are ignored. The SwipeableDrawers render in portals, so
   // touches on them never reach this surface.
   const { onTouchStart, onTouchMove, onTouchEnd } = useSwipeGesture({
     enabled: shouldUseTouchUI,
-    onSwipeRight: () => goBack(),
+    onSwipeRight: isMobile ? () => goBack() : undefined,
     onSwipeLeft: () => {
       if (channelId) setShowMemberDrawer(true);
     },

--- a/frontend/src/components/Mobile/Tablet/TabletLayout.tsx
+++ b/frontend/src/components/Mobile/Tablet/TabletLayout.tsx
@@ -43,7 +43,7 @@ const TabletLayoutInner: React.FC = () => {
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        height: '100dvh',
+        height: 'var(--full-dvh)',
         width: '100vw',
         overflow: 'hidden',
         position: 'fixed',

--- a/frontend/src/components/Voice/components/CompactUserItem.tsx
+++ b/frontend/src/components/Voice/components/CompactUserItem.tsx
@@ -99,6 +99,8 @@ const CompactUserItem: React.FC<CompactUserItemProps> = React.memo(({
         pl: 4,
         minHeight: 40,
         cursor: "pointer",
+        WebkitTouchCallout: "none",
+        userSelect: "none",
         "&:hover": {
           backgroundColor: theme.palette.semantic.overlay.light,
         },

--- a/frontend/src/components/Voice/components/CompactUserItem.tsx
+++ b/frontend/src/components/Voice/components/CompactUserItem.tsx
@@ -99,8 +99,10 @@ const CompactUserItem: React.FC<CompactUserItemProps> = React.memo(({
         pl: 4,
         minHeight: 40,
         cursor: "pointer",
-        WebkitTouchCallout: "none",
-        userSelect: "none",
+       ...(shouldUseTouchUI && {
+         WebkitTouchCallout: "none",
+         userSelect: "none",
+       }),
         "&:hover": {
           backgroundColor: theme.palette.semantic.overlay.light,
         },

--- a/frontend/src/components/Voice/components/UserItem.tsx
+++ b/frontend/src/components/Voice/components/UserItem.tsx
@@ -88,8 +88,10 @@ const UserItem: React.FC<UserItemProps> = React.memo(({
           px: showInline ? 1 : 2,
           py: 1,
           cursor: "pointer",
-          WebkitTouchCallout: "none",
-          userSelect: "none",
+         ...(shouldUseTouchUI && {
+           WebkitTouchCallout: "none",
+           userSelect: "none",
+         }),
           "&:hover": {
             backgroundColor: "action.hover",
           },

--- a/frontend/src/components/Voice/components/UserItem.tsx
+++ b/frontend/src/components/Voice/components/UserItem.tsx
@@ -88,6 +88,8 @@ const UserItem: React.FC<UserItemProps> = React.memo(({
           px: showInline ? 1 : 2,
           py: 1,
           cursor: "pointer",
+          WebkitTouchCallout: "none",
+          userSelect: "none",
           "&:hover": {
             backgroundColor: "action.hover",
           },

--- a/frontend/src/components/admin/AdminLayout.tsx
+++ b/frontend/src/components/admin/AdminLayout.tsx
@@ -107,7 +107,7 @@ const AdminLayout: React.FC = () => {
   );
 
   return (
-    <Box sx={{ display: "flex", minHeight: `calc(100dvh - ${APPBAR_HEIGHT}px)` }}>
+    <Box sx={{ display: "flex", minHeight: `calc(var(--full-dvh) - ${APPBAR_HEIGHT}px)` }}>
       {/* Sidebar */}
       {isMobile ? (
         <Drawer
@@ -135,7 +135,7 @@ const AdminLayout: React.FC = () => {
               width: DRAWER_WIDTH,
               boxSizing: "border-box",
               position: "relative",
-              minHeight: `calc(100dvh - ${APPBAR_HEIGHT}px)`,
+              minHeight: `calc(var(--full-dvh) - ${APPBAR_HEIGHT}px)`,
               backgroundColor: theme.palette.background.paper,
             },
           }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,7 @@
 :root {
+  /* Full-viewport height: dvh where supported, vh fallback for older browsers. */
+  --full-dvh: 100vh;
+
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
@@ -27,7 +30,13 @@ body {
   display: flex;
   place-items: center;
   min-width: 320px;
-  min-height: 100dvh;
+  min-height: var(--full-dvh);
+}
+
+@supports (min-height: 100dvh) {
+  :root {
+    --full-dvh: 100dvh;
+  }
 }
 
 #root {

--- a/frontend/src/pages/JoinInvitePage.tsx
+++ b/frontend/src/pages/JoinInvitePage.tsx
@@ -28,7 +28,7 @@ const FormContainer = styled(Box)({
   alignItems: "center",
   justifyContent: "center",
   padding: "16px",
-  minHeight: "100dvh",
+  minHeight: "var(--full-dvh)",
 });
 
 const FormBox = styled(Box)({

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -21,7 +21,7 @@ const OnboardingPage: React.FC = () => {
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
-          minHeight: '100dvh',
+          minHeight: 'var(--full-dvh)',
         }}
       >
         <CircularProgress size={40} />
@@ -36,7 +36,7 @@ const OnboardingPage: React.FC = () => {
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
-          minHeight: '100dvh',
+          minHeight: 'var(--full-dvh)',
           p: 2,
         }}
       >
@@ -60,7 +60,7 @@ const OnboardingPage: React.FC = () => {
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
-          minHeight: '100dvh',
+          minHeight: 'var(--full-dvh)',
           p: 2,
         }}
       >
@@ -72,7 +72,7 @@ const OnboardingPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ minHeight: '100dvh', bgcolor: 'background.default' }}>
+    <Box sx={{ minHeight: 'var(--full-dvh)', bgcolor: 'background.default' }}>
       <OnboardingWizard
         setupToken={status.setupToken}
         onComplete={handleComplete}


### PR DESCRIPTION
Closes #399 (items 2, 3, 4, 5).

## Changes
- **`100dvh` fallback (item 2)**: all viewport-height sites now use a shared `--full-dvh` CSS custom property, defined as `100vh` with an `@supports` upgrade to `100dvh` (`index.css`). Covers the body rule plus 15 `sx` sites including the `calc()` ones in `CommunityToggle` and `AdminLayout`.
- **`titleActions` on desktop (item 3)**: `ResponsiveDialog` now renders `titleActions` on the right of the desktop `DialogTitle` instead of dropping it (was mobile-only). No current callers change appearance.
- **Tablet swipe-right no-op (item 4)**: in `MobileChatPanel`, swipe-right→`goBack()` is now gated on `isMobile` — on tablets the channel list is already visible in the split-view sidebar, so back-navigation made no sense there. Swipe-left (members drawer) keeps working on tablet.
- **iOS long-press callout (item 5)**: `WebkitTouchCallout/userSelect: none` added to the three long-press rows (`MemberList`, `UserItem`, `CompactUserItem`), matching the existing `MessageComponent` pattern.

Not included, per the issue's own framing: item 1 (ResponsiveDialog remount when crossing the breakpoint mid-open — revisit only if users hit it) and item 6 (breakpoint unification — documented no-op in `docs/breakpoint-unification.md`).

## Tests
- `ResponsiveDialog.test.tsx`: `titleActions` visible in the desktop presentation.
- `MobileChatPanelSwipe.test.tsx`: swipe-right does not fire `goBack` on tablet, still does on phone; swipe-left still opens the members drawer on tablet.
- Full frontend suite: 1536/1537 passed; the one failure (`UserSearchAutocomplete` 5s timeout) is the known WSL2 flake and passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvVeRD4zf7UofaTfNDJm2Z