### PR TITLE
feat(voice): community audio soundboard (#292)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7053,9 +7053,9 @@
         ]
       }
     },
-    "/api/custom-emoji/community/{communityId}": {
+    "/api/soundboard/community/{communityId}": {
       "get": {
-        "operationId": "CustomEmojiController_listCommunityEmojis",
+        "operationId": "SoundboardController_listCommunitySounds",
         "parameters": [
           {
             "name": "communityId",
@@ -7074,20 +7074,20 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/CustomEmojiDto"
+                    "$ref": "#/components/schemas/SoundboardSoundDto"
                   }
                 }
               }
             }
           }
         },
-        "summary": "List all custom emojis for a community. Available to any community member.",
+        "summary": "List all soundboard sounds for a community.",
         "tags": [
-          "CustomEmoji"
+          "Soundboard"
         ]
       },
       "post": {
-        "operationId": "CustomEmojiController_createEmoji",
+        "operationId": "SoundboardController_createSound",
         "parameters": [
           {
             "name": "communityId",
@@ -7103,7 +7103,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateCustomEmojiDto"
+                "$ref": "#/components/schemas/CreateSoundboardSoundDto"
               }
             }
           }
@@ -7114,21 +7114,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CustomEmojiDto"
+                  "$ref": "#/components/schemas/SoundboardSoundDto"
                 }
               }
             }
           }
         },
-        "summary": "Register a new custom emoji from an uploaded CUSTOM_EMOJI file.",
+        "summary": "Create a new soundboard sound from a previously uploaded audio file.",
         "tags": [
-          "CustomEmoji"
+          "Soundboard"
         ]
       }
     },
-    "/api/custom-emoji/community/{communityId}/{emojiId}": {
+    "/api/soundboard/community/{communityId}/{soundId}": {
       "delete": {
-        "operationId": "CustomEmojiController_deleteEmoji",
+        "operationId": "SoundboardController_deleteSound",
         "parameters": [
           {
             "name": "communityId",
@@ -7139,7 +7139,7 @@
             }
           },
           {
-            "name": "emojiId",
+            "name": "soundId",
             "required": true,
             "in": "path",
             "schema": {
@@ -7152,9 +7152,9 @@
             "description": ""
           }
         },
-        "summary": "Delete a custom emoji from a community.",
+        "summary": "Delete a soundboard sound.",
         "tags": [
-          "CustomEmoji"
+          "Soundboard"
         ]
       }
     }
@@ -7805,7 +7805,9 @@
                 "VIEW_BAN_LIST",
                 "VIEW_MODERATION_LOGS",
                 "MUTE_PARTICIPANT",
-                "MANAGE_EMOJIS"
+                "CREATE_SOUNDBOARD_SOUND",
+                "DELETE_SOUNDBOARD_SOUND",
+                "READ_SOUNDBOARD_SOUND"
               ]
             }
           },
@@ -7965,7 +7967,9 @@
                 "VIEW_BAN_LIST",
                 "VIEW_MODERATION_LOGS",
                 "MUTE_PARTICIPANT",
-                "MANAGE_EMOJIS"
+                "CREATE_SOUNDBOARD_SOUND",
+                "DELETE_SOUNDBOARD_SOUND",
+                "READ_SOUNDBOARD_SOUND"
               ]
             }
           },
@@ -8047,7 +8051,9 @@
                 "VIEW_BAN_LIST",
                 "VIEW_MODERATION_LOGS",
                 "MUTE_PARTICIPANT",
-                "MANAGE_EMOJIS"
+                "CREATE_SOUNDBOARD_SOUND",
+                "DELETE_SOUNDBOARD_SOUND",
+                "READ_SOUNDBOARD_SOUND"
               ]
             }
           },
@@ -8424,8 +8430,7 @@
               "SPECIAL_MENTION",
               "COMMUNITY_MENTION",
               "ALIAS_MENTION",
-              "CODE_BLOCK",
-              "EMOJI"
+              "CODE_BLOCK"
             ]
           },
           "text": {
@@ -8445,10 +8450,6 @@
             "nullable": true
           },
           "aliasId": {
-            "type": "string",
-            "nullable": true
-          },
-          "emojiId": {
             "type": "string",
             "nullable": true
           },
@@ -8475,8 +8476,7 @@
           "userId",
           "specialKind",
           "communityId",
-          "aliasId",
-          "emojiId"
+          "aliasId"
         ]
       },
       "CreateMessageDto": {
@@ -8633,13 +8633,8 @@
               "SPECIAL_MENTION",
               "COMMUNITY_MENTION",
               "ALIAS_MENTION",
-              "CODE_BLOCK",
-              "EMOJI"
+              "CODE_BLOCK"
             ]
-          },
-          "emojiId": {
-            "type": "string",
-            "nullable": true
           },
           "bold": {
             "type": "boolean",
@@ -11479,7 +11474,8 @@
               "COMMUNITY_AVATAR",
               "MESSAGE_ATTACHMENT",
               "CUSTOM_EMOJI",
-              "REPLAY_CLIP"
+              "REPLAY_CLIP",
+              "SOUNDBOARD_SOUND"
             ]
           },
           "resourceId": {
@@ -11513,7 +11509,8 @@
               "COMMUNITY_AVATAR",
               "MESSAGE_ATTACHMENT",
               "CUSTOM_EMOJI",
-              "REPLAY_CLIP"
+              "REPLAY_CLIP",
+              "SOUNDBOARD_SOUND"
             ]
           },
           "storageType": {
@@ -12680,7 +12677,7 @@
           "memberIds"
         ]
       },
-      "CustomEmojiDto": {
+      "SoundboardSoundDto": {
         "type": "object",
         "properties": {
           "id": {
@@ -12691,6 +12688,10 @@
           },
           "name": {
             "type": "string"
+          },
+          "emoji": {
+            "type": "string",
+            "nullable": true
           },
           "fileId": {
             "type": "string"
@@ -12708,17 +12709,24 @@
           "id",
           "communityId",
           "name",
+          "emoji",
           "fileId",
           "createdBy",
           "createdAt"
         ]
       },
-      "CreateCustomEmojiDto": {
+      "CreateSoundboardSoundDto": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string",
-            "pattern": "CUSTOM_EMOJI_NAME_REGEX"
+            "minLength": 1,
+            "maxLength": 50,
+            "pattern": "/^[a-zA-Z0-9 _-]+$/"
+          },
+          "emoji": {
+            "type": "string",
+            "maxLength": 16
           },
           "fileId": {
             "type": "string",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7053,6 +7053,111 @@
         ]
       }
     },
+    "/api/custom-emoji/community/{communityId}": {
+      "get": {
+        "operationId": "CustomEmojiController_listCommunityEmojis",
+        "parameters": [
+          {
+            "name": "communityId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomEmojiDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List all custom emojis for a community. Available to any community member.",
+        "tags": [
+          "CustomEmoji"
+        ]
+      },
+      "post": {
+        "operationId": "CustomEmojiController_createEmoji",
+        "parameters": [
+          {
+            "name": "communityId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCustomEmojiDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomEmojiDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Register a new custom emoji from an uploaded CUSTOM_EMOJI file.",
+        "tags": [
+          "CustomEmoji"
+        ]
+      }
+    },
+    "/api/custom-emoji/community/{communityId}/{emojiId}": {
+      "delete": {
+        "operationId": "CustomEmojiController_deleteEmoji",
+        "parameters": [
+          {
+            "name": "communityId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "emojiId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Delete a custom emoji from a community.",
+        "tags": [
+          "CustomEmoji"
+        ]
+      }
+    },
     "/api/soundboard/community/{communityId}": {
       "get": {
         "operationId": "SoundboardController_listCommunitySounds",
@@ -7805,6 +7910,7 @@
                 "VIEW_BAN_LIST",
                 "VIEW_MODERATION_LOGS",
                 "MUTE_PARTICIPANT",
+                "MANAGE_EMOJIS",
                 "CREATE_SOUNDBOARD_SOUND",
                 "DELETE_SOUNDBOARD_SOUND",
                 "READ_SOUNDBOARD_SOUND"
@@ -7967,6 +8073,7 @@
                 "VIEW_BAN_LIST",
                 "VIEW_MODERATION_LOGS",
                 "MUTE_PARTICIPANT",
+                "MANAGE_EMOJIS",
                 "CREATE_SOUNDBOARD_SOUND",
                 "DELETE_SOUNDBOARD_SOUND",
                 "READ_SOUNDBOARD_SOUND"
@@ -8051,6 +8158,7 @@
                 "VIEW_BAN_LIST",
                 "VIEW_MODERATION_LOGS",
                 "MUTE_PARTICIPANT",
+                "MANAGE_EMOJIS",
                 "CREATE_SOUNDBOARD_SOUND",
                 "DELETE_SOUNDBOARD_SOUND",
                 "READ_SOUNDBOARD_SOUND"
@@ -8430,7 +8538,8 @@
               "SPECIAL_MENTION",
               "COMMUNITY_MENTION",
               "ALIAS_MENTION",
-              "CODE_BLOCK"
+              "CODE_BLOCK",
+              "EMOJI"
             ]
           },
           "text": {
@@ -8450,6 +8559,10 @@
             "nullable": true
           },
           "aliasId": {
+            "type": "string",
+            "nullable": true
+          },
+          "emojiId": {
             "type": "string",
             "nullable": true
           },
@@ -8476,7 +8589,8 @@
           "userId",
           "specialKind",
           "communityId",
-          "aliasId"
+          "aliasId",
+          "emojiId"
         ]
       },
       "CreateMessageDto": {
@@ -8633,8 +8747,13 @@
               "SPECIAL_MENTION",
               "COMMUNITY_MENTION",
               "ALIAS_MENTION",
-              "CODE_BLOCK"
+              "CODE_BLOCK",
+              "EMOJI"
             ]
+          },
+          "emojiId": {
+            "type": "string",
+            "nullable": true
           },
           "bold": {
             "type": "boolean",
@@ -12675,6 +12794,56 @@
         },
         "required": [
           "memberIds"
+        ]
+      },
+      "CustomEmojiDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "communityId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "fileId": {
+            "type": "string"
+          },
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "communityId",
+          "name",
+          "fileId",
+          "createdBy",
+          "createdAt"
+        ]
+      },
+      "CreateCustomEmojiDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "CUSTOM_EMOJI_NAME_REGEX"
+          },
+          "fileId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "name",
+          "fileId"
         ]
       },
       "SoundboardSoundDto": {

--- a/backend/prisma/migrations/20260705024702_soundboard/migration.sql
+++ b/backend/prisma/migrations/20260705024702_soundboard/migration.sql
@@ -1,0 +1,47 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "RbacActions" ADD VALUE 'CREATE_SOUNDBOARD_SOUND';
+ALTER TYPE "RbacActions" ADD VALUE 'DELETE_SOUNDBOARD_SOUND';
+ALTER TYPE "RbacActions" ADD VALUE 'READ_SOUNDBOARD_SOUND';
+
+-- AlterEnum
+ALTER TYPE "ResourceType" ADD VALUE 'SOUNDBOARD_SOUND';
+
+-- NOTE: Prisma's diff wants to DROP the Message."searchVector" generated
+-- tsvector column + GIN index here because generated columns can't be
+-- expressed in schema.prisma (see migration 20260307210420_restore_search_vector).
+-- Those statements are intentionally omitted so full-text search keeps working.
+
+-- CreateTable
+CREATE TABLE "SoundboardSound" (
+    "id" TEXT NOT NULL,
+    "communityId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "emoji" TEXT,
+    "fileId" TEXT NOT NULL,
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SoundboardSound_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SoundboardSound_communityId_idx" ON "SoundboardSound"("communityId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SoundboardSound_communityId_name_key" ON "SoundboardSound"("communityId", "name");
+
+-- AddForeignKey
+ALTER TABLE "SoundboardSound" ADD CONSTRAINT "SoundboardSound_communityId_fkey" FOREIGN KEY ("communityId") REFERENCES "Community"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SoundboardSound" ADD CONSTRAINT "SoundboardSound_fileId_fkey" FOREIGN KEY ("fileId") REFERENCES "File"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SoundboardSound" ADD CONSTRAINT "SoundboardSound_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -304,6 +304,9 @@ model User {
   egressSessions EgressSession[]
   replayClips    ReplayClip[]
 
+  // Soundboard sounds uploaded by this user
+  soundboardSounds SoundboardSound[] @relation("SoundboardSoundCreator")
+
   // Push notification subscriptions
   pushSubscriptions PushSubscription[] @relation("UserPushSubscriptions")
 
@@ -461,6 +464,8 @@ model Community {
   aliasGroups   AliasGroup[]  @relation("AliasGroupCommunity")
   resourceFiles File[]        @relation("FileResourceCommunity")
   customEmojis  CustomEmoji[] @relation("CommunityCustomEmojis")
+
+  soundboardSounds SoundboardSound[] @relation("SoundboardSoundCommunity")
 
   @@unique([name])
 }
@@ -654,6 +659,7 @@ model File {
   replayClips        ReplayClip[]
   messageAttachments MessageAttachment[]
   customEmojis       CustomEmoji[]       @relation("CustomEmojiFile")
+  soundboardSounds   SoundboardSound[]
 
   // Avatar/banner back-references
   userAvatars      User[]      @relation("UserAvatar")
@@ -703,6 +709,22 @@ model ReplayClip {
   channel Channel? @relation("ReplayClipChannel", fields: [channelId], references: [id], onDelete: SetNull)
 
   @@index([userId, capturedAt])
+}
+
+model SoundboardSound {
+  id          String   @id @default(uuid())
+  communityId String
+  community   Community @relation("SoundboardSoundCommunity", fields: [communityId], references: [id], onDelete: Cascade)
+  name        String
+  emoji       String? // Optional emoji shown on the sound button
+  fileId      String
+  file        File     @relation(fields: [fileId], references: [id], onDelete: Cascade)
+  createdBy   String? // User who uploaded the sound (SetNull when user deleted)
+  creator     User?    @relation("SoundboardSoundCreator", fields: [createdBy], references: [id], onDelete: SetNull)
+  createdAt   DateTime @default(now())
+
+  @@unique([communityId, name])
+  @@index([communityId])
 }
 
 model CommunityBan {
@@ -775,6 +797,7 @@ enum ResourceType {
   MESSAGE_ATTACHMENT
   CUSTOM_EMOJI
   REPLAY_CLIP
+  SOUNDBOARD_SOUND
 }
 
 enum StorageType {
@@ -851,6 +874,9 @@ enum RbacActions {
   VIEW_MODERATION_LOGS
   MUTE_PARTICIPANT
   MANAGE_EMOJIS
+  CREATE_SOUNDBOARD_SOUND
+  DELETE_SOUNDBOARD_SOUND
+  READ_SOUNDBOARD_SOUND
 }
 
 enum InstanceRole {

--- a/backend/prisma/seed-e2e.ts
+++ b/backend/prisma/seed-e2e.ts
@@ -74,6 +74,7 @@ const TEST_COMMUNITIES = [
       { name: 'voice-edge', type: 'VOICE' },
       { name: 'voice-matrix', type: 'VOICE' },
       { name: 'voice-perms', type: 'VOICE' },
+      { name: 'voice-soundboard', type: 'VOICE' },
     ],
   },
   {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -48,6 +48,7 @@ import { ThreadsModule } from './threads/threads.module';
 import { StorageQuotaModule } from './storage-quota/storage-quota.module';
 import { AliasGroupsModule } from './alias-groups/alias-groups.module';
 import { CustomEmojiModule } from './custom-emoji/custom-emoji.module';
+import { SoundboardModule } from './soundboard/soundboard.module';
 import { DebugModule } from './debug/debug.module';
 import { MetricsModule } from './metrics/metrics.module';
 import { JwtAuthGuard } from './auth/jwt-auth.guard';
@@ -120,6 +121,7 @@ import { JwtAuthGuard } from './auth/jwt-auth.guard';
     StorageQuotaModule,
     AliasGroupsModule,
     CustomEmojiModule,
+    SoundboardModule,
     ...(process.env.ADMIN_DEBUG_PANEL === 'true' ? [DebugModule] : []),
     // Prometheus metrics (/api/metrics) — opt-in only; when disabled the
     // module isn't imported, so the endpoint does not exist.

--- a/backend/src/common/enums/swagger-enums.ts
+++ b/backend/src/common/enums/swagger-enums.ts
@@ -33,6 +33,7 @@ export const ResourceTypeValues = [
   'MESSAGE_ATTACHMENT',
   'CUSTOM_EMOJI',
   'REPLAY_CLIP',
+  'SOUNDBOARD_SOUND',
 ] as const;
 
 export const StorageTypeValues = ['LOCAL', 'S3', 'AZURE_BLOB'] as const;
@@ -104,6 +105,9 @@ export const RbacActionsValues = [
   'VIEW_MODERATION_LOGS',
   'MUTE_PARTICIPANT',
   'MANAGE_EMOJIS',
+  'CREATE_SOUNDBOARD_SOUND',
+  'DELETE_SOUNDBOARD_SOUND',
+  'READ_SOUNDBOARD_SOUND',
 ] as const;
 
 export const InstanceRoleValues = ['OWNER', 'USER'] as const;

--- a/backend/src/file-upload/file-upload.module.ts
+++ b/backend/src/file-upload/file-upload.module.ts
@@ -13,6 +13,7 @@ import { ThumbnailBackfillService } from '@/file/thumbnail-backfill.service';
 @Module({
   controllers: [FileUploadController],
   providers: [FileUploadService, ThumbnailService, ThumbnailBackfillService],
+  exports: [FileUploadService],
   imports: [
     MulterModule.registerAsync({
       imports: [ConfigModule],

--- a/backend/src/file-upload/file-upload.service.ts
+++ b/backend/src/file-upload/file-upload.service.ts
@@ -248,6 +248,7 @@ export class FileUploadService {
       case ResourceType.COMMUNITY_AVATAR:
       case ResourceType.COMMUNITY_BANNER:
       case ResourceType.CUSTOM_EMOJI:
+      case ResourceType.SOUNDBOARD_SOUND:
         return { fileCommunityId: resourceId };
       case ResourceType.MESSAGE_ATTACHMENT:
         return { fileMessageId: resourceId };

--- a/backend/src/file-upload/validators/resource-type-file.validator.ts
+++ b/backend/src/file-upload/validators/resource-type-file.validator.ts
@@ -6,6 +6,7 @@ import {
   UserAvatarValidationStrategy,
   CommunityBannerValidationStrategy,
   CustomEmojiValidationStrategy,
+  SoundboardSoundValidationStrategy,
 } from './strategies';
 import { matchesDeclaredImageType, readFileHeader } from './magic-bytes.util';
 
@@ -46,6 +47,7 @@ export class ResourceTypeFileValidator extends FileValidator<ResourceTypeFileVal
       [ResourceType.COMMUNITY_AVATAR, new CommunityBannerValidationStrategy()],
       [ResourceType.COMMUNITY_BANNER, new CommunityBannerValidationStrategy()],
       [ResourceType.CUSTOM_EMOJI, new CustomEmojiValidationStrategy()],
+      [ResourceType.SOUNDBOARD_SOUND, new SoundboardSoundValidationStrategy()],
     ]);
   }
 

--- a/backend/src/file-upload/validators/strategies/index.ts
+++ b/backend/src/file-upload/validators/strategies/index.ts
@@ -3,3 +3,4 @@ export { MessageAttachmentValidationStrategy } from './message-attachment-valida
 export { UserAvatarValidationStrategy } from './user-avatar-validation.strategy';
 export { CommunityBannerValidationStrategy } from './community-banner-validation.strategy';
 export { CustomEmojiValidationStrategy } from './custom-emoji-validation.strategy';
+export { SoundboardSoundValidationStrategy } from './soundboard-sound-validation.strategy';

--- a/backend/src/file-upload/validators/strategies/soundboard-sound-validation.strategy.spec.ts
+++ b/backend/src/file-upload/validators/strategies/soundboard-sound-validation.strategy.spec.ts
@@ -1,0 +1,52 @@
+import { SoundboardSoundValidationStrategy } from './soundboard-sound-validation.strategy';
+
+describe('SoundboardSoundValidationStrategy', () => {
+  let strategy: SoundboardSoundValidationStrategy;
+
+  beforeEach(() => {
+    strategy = new SoundboardSoundValidationStrategy();
+  });
+
+  it('should be defined', () => {
+    expect(strategy).toBeDefined();
+  });
+
+  describe('getAllowedMimeTypes', () => {
+    it('allows common short-clip audio formats', () => {
+      const mimeTypes = strategy.getAllowedMimeTypes();
+
+      expect(mimeTypes).toContain('audio/mpeg');
+      expect(mimeTypes).toContain('audio/wav');
+      expect(mimeTypes).toContain('audio/ogg');
+      expect(mimeTypes).toContain('audio/webm');
+      expect(mimeTypes).toContain('audio/aac');
+    });
+
+    it('only includes audio formats', () => {
+      const mimeTypes = strategy.getAllowedMimeTypes();
+
+      mimeTypes.forEach((type) => {
+        expect(type.startsWith('audio/')).toBe(true);
+      });
+    });
+
+    it('does not allow images or video', () => {
+      const mimeTypes = strategy.getAllowedMimeTypes();
+
+      expect(mimeTypes).not.toContain('image/png');
+      expect(mimeTypes).not.toContain('video/mp4');
+    });
+  });
+
+  describe('getMaxFileSize', () => {
+    it('caps clips at 1MB to keep them short', () => {
+      expect(strategy.getMaxFileSize()).toBe(1024 * 1024);
+    });
+  });
+
+  describe('getValidationDescription', () => {
+    it('returns a human-readable description', () => {
+      expect(strategy.getValidationDescription()).toContain('audio');
+    });
+  });
+});

--- a/backend/src/file-upload/validators/strategies/soundboard-sound-validation.strategy.ts
+++ b/backend/src/file-upload/validators/strategies/soundboard-sound-validation.strategy.ts
@@ -1,0 +1,30 @@
+import { IFileValidationStrategy } from './file-validation-strategy.interface';
+
+/**
+ * Validation strategy for soundboard sounds.
+ * Short audio clips only, small size cap to keep them snappy and cheap to serve.
+ */
+export class SoundboardSoundValidationStrategy implements IFileValidationStrategy {
+  private readonly MAX_SIZE = 1024 * 1024; // 1MB
+
+  private readonly allowedMimeTypes = [
+    'audio/mpeg', // .mp3
+    'audio/wav',
+    'audio/x-wav',
+    'audio/ogg',
+    'audio/webm',
+    'audio/aac',
+  ];
+
+  getAllowedMimeTypes(): string[] {
+    return this.allowedMimeTypes;
+  }
+
+  getMaxFileSize(): number {
+    return this.MAX_SIZE;
+  }
+
+  getValidationDescription(): string {
+    return 'MP3, WAV, OGG, WebM, or AAC audio only, max 1MB (keep clips short)';
+  }
+}

--- a/backend/src/file/file-access/file-access.guard.ts
+++ b/backend/src/file/file-access/file-access.guard.ts
@@ -64,6 +64,7 @@ export class FileAccessGuard implements CanActivate {
       [ResourceType.COMMUNITY_AVATAR, communityStrategy],
       [ResourceType.COMMUNITY_BANNER, communityStrategy],
       [ResourceType.CUSTOM_EMOJI, communityStrategy],
+      [ResourceType.SOUNDBOARD_SOUND, communityStrategy],
       [ResourceType.MESSAGE_ATTACHMENT, messageStrategy],
       [ResourceType.REPLAY_CLIP, replayClipStrategy],
     ]);

--- a/backend/src/roles/default-roles.config.ts
+++ b/backend/src/roles/default-roles.config.ts
@@ -113,6 +113,11 @@ export const DEFAULT_COMMUNITY_CREATOR_ROLE: DefaultRoleConfig = {
     RbacActions.VIEW_BAN_LIST,
     RbacActions.VIEW_MODERATION_LOGS,
     RbacActions.MUTE_PARTICIPANT,
+
+    // Soundboard management
+    RbacActions.CREATE_SOUNDBOARD_SOUND,
+    RbacActions.DELETE_SOUNDBOARD_SOUND,
+    RbacActions.READ_SOUNDBOARD_SOUND,
   ],
 };
 
@@ -243,6 +248,11 @@ export const DEFAULT_ADMIN_ROLE: DefaultRoleConfig = {
     RbacActions.VIEW_BAN_LIST,
     RbacActions.VIEW_MODERATION_LOGS,
     RbacActions.MUTE_PARTICIPANT,
+
+    // Soundboard management
+    RbacActions.CREATE_SOUNDBOARD_SOUND,
+    RbacActions.DELETE_SOUNDBOARD_SOUND,
+    RbacActions.READ_SOUNDBOARD_SOUND,
   ],
 };
 
@@ -294,6 +304,11 @@ export const DEFAULT_MODERATOR_ROLE: DefaultRoleConfig = {
     RbacActions.DELETE_ANY_MESSAGE,
     RbacActions.VIEW_BAN_LIST,
     RbacActions.MUTE_PARTICIPANT,
+
+    // Soundboard (read to list, manage to add/remove)
+    RbacActions.READ_SOUNDBOARD_SOUND,
+    RbacActions.CREATE_SOUNDBOARD_SOUND,
+    RbacActions.DELETE_SOUNDBOARD_SOUND,
   ],
 };
 
@@ -326,6 +341,9 @@ export const DEFAULT_MEMBER_ROLE: DefaultRoleConfig = {
 
     // Replay capture permission
     RbacActions.CAPTURE_REPLAY,
+
+    // Soundboard: members can list and play sounds (playing is client-side)
+    RbacActions.READ_SOUNDBOARD_SOUND,
   ],
 };
 

--- a/backend/src/soundboard/dto/create-soundboard-sound.dto.ts
+++ b/backend/src/soundboard/dto/create-soundboard-sound.dto.ts
@@ -1,0 +1,27 @@
+import {
+  IsString,
+  IsOptional,
+  IsUUID,
+  MinLength,
+  MaxLength,
+  Matches,
+} from 'class-validator';
+
+export class CreateSoundboardSoundDto {
+  @IsString()
+  @MinLength(1, { message: 'Sound name must not be empty' })
+  @MaxLength(50, { message: 'Sound name must not exceed 50 characters' })
+  @Matches(/^[a-zA-Z0-9 _-]+$/, {
+    message:
+      'Sound name can only contain letters, numbers, spaces, underscores, and hyphens',
+  })
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(16, { message: 'Emoji must not exceed 16 characters' })
+  emoji?: string;
+
+  @IsUUID('all')
+  fileId: string;
+}

--- a/backend/src/soundboard/dto/soundboard-sound-response.dto.ts
+++ b/backend/src/soundboard/dto/soundboard-sound-response.dto.ts
@@ -1,0 +1,9 @@
+export class SoundboardSoundDto {
+  id: string;
+  communityId: string;
+  name: string;
+  emoji: string | null;
+  fileId: string;
+  createdBy: string | null;
+  createdAt: Date;
+}

--- a/backend/src/soundboard/soundboard.controller.spec.ts
+++ b/backend/src/soundboard/soundboard.controller.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@suites/unit';
+import type { Mocked } from '@suites/doubles.jest';
+import { SoundboardController } from './soundboard.controller';
+import { SoundboardService } from './soundboard.service';
+import type { AuthenticatedRequest } from '@/types';
+
+describe('SoundboardController', () => {
+  let controller: SoundboardController;
+  let service: Mocked<SoundboardService>;
+
+  const communityId = 'comm-1';
+  const mockSound = {
+    id: 'sound-1',
+    communityId,
+    name: 'airhorn',
+    emoji: '📯',
+    fileId: 'file-1',
+    createdBy: 'user-1',
+    createdAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const { unit, unitRef } =
+      await TestBed.solitary(SoundboardController).compile();
+
+    controller = unit;
+    service = unitRef.get(SoundboardService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('listCommunitySounds delegates to the service', async () => {
+    service.listCommunitySounds = jest.fn().mockResolvedValue([mockSound]);
+
+    const result = await controller.listCommunitySounds(communityId);
+
+    expect(service.listCommunitySounds).toHaveBeenCalledWith(communityId);
+    expect(result).toEqual([mockSound]);
+  });
+
+  it('createSound passes communityId, userId, and dto to the service', async () => {
+    service.createSound = jest.fn().mockResolvedValue(mockSound);
+    const dto = { name: 'airhorn', emoji: '📯', fileId: 'file-1' };
+    const req = { user: { id: 'user-1' } } as AuthenticatedRequest;
+
+    const result = await controller.createSound(communityId, dto, req);
+
+    expect(service.createSound).toHaveBeenCalledWith(
+      communityId,
+      'user-1',
+      dto,
+    );
+    expect(result).toEqual(mockSound);
+  });
+
+  it('deleteSound delegates to the service with community scope', async () => {
+    service.deleteSound = jest.fn().mockResolvedValue(undefined);
+
+    await controller.deleteSound(communityId, 'sound-1');
+
+    expect(service.deleteSound).toHaveBeenCalledWith(communityId, 'sound-1');
+  });
+});

--- a/backend/src/soundboard/soundboard.controller.ts
+++ b/backend/src/soundboard/soundboard.controller.ts
@@ -1,0 +1,86 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Param,
+  Req,
+  HttpCode,
+  UseGuards,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { ApiOkResponse, ApiCreatedResponse } from '@nestjs/swagger';
+import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
+import { RbacGuard } from '@/auth/rbac.guard';
+import { RequiredActions } from '@/auth/rbac-action.decorator';
+import {
+  RbacResource,
+  RbacResourceType,
+  ResourceIdSource,
+} from '@/auth/rbac-resource.decorator';
+import { RbacActions } from '@prisma/client';
+import { AuthenticatedRequest } from '@/types';
+import { SoundboardService } from './soundboard.service';
+import { CreateSoundboardSoundDto } from './dto/create-soundboard-sound.dto';
+import { SoundboardSoundDto } from './dto/soundboard-sound-response.dto';
+
+@Controller('soundboard')
+@UseGuards(JwtAuthGuard, RbacGuard)
+export class SoundboardController {
+  constructor(private readonly soundboardService: SoundboardService) {}
+
+  /**
+   * List all soundboard sounds for a community.
+   */
+  @Get('community/:communityId')
+  @ApiOkResponse({ type: [SoundboardSoundDto] })
+  @RequiredActions(RbacActions.READ_SOUNDBOARD_SOUND)
+  @RbacResource({
+    type: RbacResourceType.COMMUNITY,
+    idKey: 'communityId',
+    source: ResourceIdSource.PARAM,
+  })
+  async listCommunitySounds(
+    @Param('communityId', ParseUUIDPipe) communityId: string,
+  ): Promise<SoundboardSoundDto[]> {
+    return this.soundboardService.listCommunitySounds(communityId);
+  }
+
+  /**
+   * Create a new soundboard sound from a previously uploaded audio file.
+   */
+  @Post('community/:communityId')
+  @ApiCreatedResponse({ type: SoundboardSoundDto })
+  @RequiredActions(RbacActions.CREATE_SOUNDBOARD_SOUND)
+  @RbacResource({
+    type: RbacResourceType.COMMUNITY,
+    idKey: 'communityId',
+    source: ResourceIdSource.PARAM,
+  })
+  async createSound(
+    @Param('communityId', ParseUUIDPipe) communityId: string,
+    @Body() dto: CreateSoundboardSoundDto,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<SoundboardSoundDto> {
+    return this.soundboardService.createSound(communityId, req.user.id, dto);
+  }
+
+  /**
+   * Delete a soundboard sound.
+   */
+  @Delete('community/:communityId/:soundId')
+  @HttpCode(204)
+  @RequiredActions(RbacActions.DELETE_SOUNDBOARD_SOUND)
+  @RbacResource({
+    type: RbacResourceType.COMMUNITY,
+    idKey: 'communityId',
+    source: ResourceIdSource.PARAM,
+  })
+  async deleteSound(
+    @Param('communityId', ParseUUIDPipe) communityId: string,
+    @Param('soundId', ParseUUIDPipe) soundId: string,
+  ): Promise<void> {
+    return this.soundboardService.deleteSound(communityId, soundId);
+  }
+}

--- a/backend/src/soundboard/soundboard.module.ts
+++ b/backend/src/soundboard/soundboard.module.ts
@@ -3,9 +3,10 @@ import { SoundboardController } from './soundboard.controller';
 import { SoundboardService } from './soundboard.service';
 import { DatabaseModule } from '@/database/database.module';
 import { RolesModule } from '@/roles/roles.module';
+import { FileUploadModule } from '@/file-upload/file-upload.module';
 
 @Module({
-  imports: [DatabaseModule, RolesModule],
+  imports: [DatabaseModule, RolesModule, FileUploadModule],
   controllers: [SoundboardController],
   providers: [SoundboardService],
   exports: [SoundboardService],

--- a/backend/src/soundboard/soundboard.module.ts
+++ b/backend/src/soundboard/soundboard.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { SoundboardController } from './soundboard.controller';
+import { SoundboardService } from './soundboard.service';
+import { DatabaseModule } from '@/database/database.module';
+import { RolesModule } from '@/roles/roles.module';
+
+@Module({
+  imports: [DatabaseModule, RolesModule],
+  controllers: [SoundboardController],
+  providers: [SoundboardService],
+  exports: [SoundboardService],
+})
+export class SoundboardModule {}

--- a/backend/src/soundboard/soundboard.service.spec.ts
+++ b/backend/src/soundboard/soundboard.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@suites/unit';
+import type { Mocked } from '@suites/doubles.jest';
 import {
   ConflictException,
   NotFoundException,
@@ -7,11 +8,13 @@ import {
 import { ResourceType } from '@prisma/client';
 import { SoundboardService } from './soundboard.service';
 import { DatabaseService } from '@/database/database.service';
+import { FileUploadService } from '@/file-upload/file-upload.service';
 import { createMockDatabase } from '@/test-utils';
 
 describe('SoundboardService', () => {
   let service: SoundboardService;
   let mockDatabase: ReturnType<typeof createMockDatabase>;
+  let fileUploadService: Mocked<FileUploadService>;
 
   const communityId = 'community-1';
   const userId = 'user-1';
@@ -39,12 +42,13 @@ describe('SoundboardService', () => {
   beforeEach(async () => {
     mockDatabase = createMockDatabase();
 
-    const { unit } = await TestBed.solitary(SoundboardService)
+    const { unit, unitRef } = await TestBed.solitary(SoundboardService)
       .mock(DatabaseService)
       .final(mockDatabase)
       .compile();
 
     service = unit;
+    fileUploadService = unitRef.get(FileUploadService);
   });
 
   afterEach(() => {
@@ -149,22 +153,91 @@ describe('SoundboardService', () => {
         service.createSound(communityId, userId, dto),
       ).rejects.toThrow(ConflictException);
     });
+
+    it('translates a concurrent P2002 unique violation into ConflictException', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(null);
+      mockDatabase.file.findUnique.mockResolvedValue(buildFile());
+      mockDatabase.soundboardSound.findFirst.mockResolvedValue(null);
+      mockDatabase.soundboardSound.create.mockRejectedValue(
+        Object.assign(new Error('Unique constraint failed'), {
+          code: 'P2002',
+          clientVersion: 'test',
+        }),
+      );
+
+      await expect(
+        service.createSound(communityId, userId, dto),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('rethrows non-P2002 create errors unchanged', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(null);
+      mockDatabase.file.findUnique.mockResolvedValue(buildFile());
+      mockDatabase.soundboardSound.findFirst.mockResolvedValue(null);
+      mockDatabase.soundboardSound.create.mockRejectedValue(
+        new Error('db down'),
+      );
+
+      await expect(
+        service.createSound(communityId, userId, dto),
+      ).rejects.toThrow('db down');
+    });
   });
 
   describe('deleteSound', () => {
-    it('deletes the sound and its backing file', async () => {
+    it('deletes the sound and soft-deletes the backing file as the uploader (quota credited)', async () => {
       mockDatabase.soundboardSound.findUnique.mockResolvedValue(buildSound());
+      mockDatabase.file.findUnique.mockResolvedValue({
+        uploadedById: 'uploader-9',
+        deletedAt: null,
+      });
       mockDatabase.soundboardSound.delete.mockResolvedValue(buildSound());
-      mockDatabase.file.delete.mockResolvedValue(buildFile());
+      fileUploadService.remove.mockResolvedValue(undefined as never);
 
       await service.deleteSound(communityId, 'sound-1');
 
       expect(mockDatabase.soundboardSound.delete).toHaveBeenCalledWith({
         where: { id: 'sound-1' },
       });
-      expect(mockDatabase.file.delete).toHaveBeenCalledWith({
-        where: { id: fileId },
+      // Soft-delete path with the UPLOADER's id, not the deleter's
+      expect(fileUploadService.remove).toHaveBeenCalledWith(
+        fileId,
+        'uploader-9',
+      );
+      // Never hard-deletes the file row
+      expect(mockDatabase.file.delete).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a direct soft-delete when the uploader was deleted (uploadedById null)', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(buildSound());
+      mockDatabase.file.findUnique.mockResolvedValue({
+        uploadedById: null,
+        deletedAt: null,
       });
+      mockDatabase.soundboardSound.delete.mockResolvedValue(buildSound());
+
+      await service.deleteSound(communityId, 'sound-1');
+
+      expect(fileUploadService.remove).not.toHaveBeenCalled();
+      expect(mockDatabase.file.update).toHaveBeenCalledWith({
+        where: { id: fileId },
+        data: { deletedAt: expect.any(Date) },
+      });
+      expect(mockDatabase.file.delete).not.toHaveBeenCalled();
+    });
+
+    it('skips file cleanup when the backing file is already soft-deleted', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(buildSound());
+      mockDatabase.file.findUnique.mockResolvedValue({
+        uploadedById: 'uploader-9',
+        deletedAt: new Date(),
+      });
+      mockDatabase.soundboardSound.delete.mockResolvedValue(buildSound());
+
+      await service.deleteSound(communityId, 'sound-1');
+
+      expect(fileUploadService.remove).not.toHaveBeenCalled();
+      expect(mockDatabase.file.update).not.toHaveBeenCalled();
     });
 
     it('throws NotFoundException when the sound does not exist', async () => {
@@ -186,10 +259,14 @@ describe('SoundboardService', () => {
       expect(mockDatabase.soundboardSound.delete).not.toHaveBeenCalled();
     });
 
-    it('still resolves when backing file deletion fails', async () => {
+    it('still resolves when backing file soft-deletion fails', async () => {
       mockDatabase.soundboardSound.findUnique.mockResolvedValue(buildSound());
+      mockDatabase.file.findUnique.mockResolvedValue({
+        uploadedById: 'uploader-9',
+        deletedAt: null,
+      });
       mockDatabase.soundboardSound.delete.mockResolvedValue(buildSound());
-      mockDatabase.file.delete.mockRejectedValue(new Error('file gone'));
+      fileUploadService.remove.mockRejectedValue(new Error('file gone'));
 
       await expect(
         service.deleteSound(communityId, 'sound-1'),

--- a/backend/src/soundboard/soundboard.service.spec.ts
+++ b/backend/src/soundboard/soundboard.service.spec.ts
@@ -1,0 +1,199 @@
+import { TestBed } from '@suites/unit';
+import {
+  ConflictException,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { ResourceType } from '@prisma/client';
+import { SoundboardService } from './soundboard.service';
+import { DatabaseService } from '@/database/database.service';
+import { createMockDatabase } from '@/test-utils';
+
+describe('SoundboardService', () => {
+  let service: SoundboardService;
+  let mockDatabase: ReturnType<typeof createMockDatabase>;
+
+  const communityId = 'community-1';
+  const userId = 'user-1';
+  const fileId = 'file-1';
+
+  const buildSound = (overrides = {}) => ({
+    id: 'sound-1',
+    communityId,
+    name: 'airhorn',
+    emoji: '📯',
+    fileId,
+    createdBy: userId,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  });
+
+  const buildFile = (overrides = {}) => ({
+    id: fileId,
+    resourceType: ResourceType.SOUNDBOARD_SOUND,
+    fileCommunityId: communityId,
+    deletedAt: null,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    mockDatabase = createMockDatabase();
+
+    const { unit } = await TestBed.solitary(SoundboardService)
+      .mock(DatabaseService)
+      .final(mockDatabase)
+      .compile();
+
+    service = unit;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listCommunitySounds', () => {
+    it('returns all sounds for a community as DTOs', async () => {
+      mockDatabase.soundboardSound.findMany.mockResolvedValue([
+        buildSound(),
+        buildSound({ id: 'sound-2', name: 'boo', emoji: null }),
+      ]);
+
+      const result = await service.listCommunitySounds(communityId);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          id: 'sound-1',
+          name: 'airhorn',
+          emoji: '📯',
+        }),
+      );
+      expect(mockDatabase.soundboardSound.findMany).toHaveBeenCalledWith({
+        where: { communityId },
+        orderBy: { name: 'asc' },
+      });
+    });
+  });
+
+  describe('createSound', () => {
+    const dto = { name: 'airhorn', emoji: '📯', fileId };
+
+    it('creates a sound when name is unique and file is valid', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(null);
+      mockDatabase.file.findUnique.mockResolvedValue(buildFile());
+      mockDatabase.soundboardSound.findFirst.mockResolvedValue(null);
+      mockDatabase.soundboardSound.create.mockResolvedValue(buildSound());
+
+      const result = await service.createSound(communityId, userId, dto);
+
+      expect(result.name).toBe('airhorn');
+      expect(mockDatabase.soundboardSound.create).toHaveBeenCalledWith({
+        data: {
+          communityId,
+          name: 'airhorn',
+          emoji: '📯',
+          fileId,
+          createdBy: userId,
+        },
+      });
+    });
+
+    it('throws ConflictException when the name already exists', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(buildSound());
+
+      await expect(
+        service.createSound(communityId, userId, dto),
+      ).rejects.toThrow(ConflictException);
+      expect(mockDatabase.soundboardSound.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when the file does not exist', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(null);
+      mockDatabase.file.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.createSound(communityId, userId, dto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when the file belongs to another community', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(null);
+      mockDatabase.file.findUnique.mockResolvedValue(
+        buildFile({ fileCommunityId: 'other-community' }),
+      );
+
+      await expect(
+        service.createSound(communityId, userId, dto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when the file is not a soundboard file', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(null);
+      mockDatabase.file.findUnique.mockResolvedValue(
+        buildFile({ resourceType: ResourceType.CUSTOM_EMOJI }),
+      );
+
+      await expect(
+        service.createSound(communityId, userId, dto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws ConflictException when the file is already used by another sound', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(null);
+      mockDatabase.file.findUnique.mockResolvedValue(buildFile());
+      mockDatabase.soundboardSound.findFirst.mockResolvedValue(
+        buildSound({ id: 'other-sound' }),
+      );
+
+      await expect(
+        service.createSound(communityId, userId, dto),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('deleteSound', () => {
+    it('deletes the sound and its backing file', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(buildSound());
+      mockDatabase.soundboardSound.delete.mockResolvedValue(buildSound());
+      mockDatabase.file.delete.mockResolvedValue(buildFile());
+
+      await service.deleteSound(communityId, 'sound-1');
+
+      expect(mockDatabase.soundboardSound.delete).toHaveBeenCalledWith({
+        where: { id: 'sound-1' },
+      });
+      expect(mockDatabase.file.delete).toHaveBeenCalledWith({
+        where: { id: fileId },
+      });
+    });
+
+    it('throws NotFoundException when the sound does not exist', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(null);
+
+      await expect(service.deleteSound(communityId, 'missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException when the sound belongs to another community', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(
+        buildSound({ communityId: 'other-community' }),
+      );
+
+      await expect(service.deleteSound(communityId, 'sound-1')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockDatabase.soundboardSound.delete).not.toHaveBeenCalled();
+    });
+
+    it('still resolves when backing file deletion fails', async () => {
+      mockDatabase.soundboardSound.findUnique.mockResolvedValue(buildSound());
+      mockDatabase.soundboardSound.delete.mockResolvedValue(buildSound());
+      mockDatabase.file.delete.mockRejectedValue(new Error('file gone'));
+
+      await expect(
+        service.deleteSound(communityId, 'sound-1'),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/backend/src/soundboard/soundboard.service.ts
+++ b/backend/src/soundboard/soundboard.service.ts
@@ -7,6 +7,8 @@ import {
 } from '@nestjs/common';
 import { ResourceType } from '@prisma/client';
 import { DatabaseService } from '@/database/database.service';
+import { FileUploadService } from '@/file-upload/file-upload.service';
+import { isPrismaError } from '@/common/utils/prisma.utils';
 import { CreateSoundboardSoundDto } from './dto/create-soundboard-sound.dto';
 import { SoundboardSoundDto } from './dto/soundboard-sound-response.dto';
 
@@ -14,7 +16,10 @@ import { SoundboardSoundDto } from './dto/soundboard-sound-response.dto';
 export class SoundboardService {
   private readonly logger = new Logger(SoundboardService.name);
 
-  constructor(private readonly databaseService: DatabaseService) {}
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly fileUploadService: FileUploadService,
+  ) {}
 
   private toDto(sound: {
     id: string;
@@ -103,25 +108,39 @@ export class SoundboardService {
       );
     }
 
-    const sound = await this.databaseService.soundboardSound.create({
-      data: {
-        communityId,
-        name: dto.name,
-        emoji: dto.emoji ?? null,
-        fileId: dto.fileId,
-        createdBy: userId,
-      },
-    });
+    try {
+      const sound = await this.databaseService.soundboardSound.create({
+        data: {
+          communityId,
+          name: dto.name,
+          emoji: dto.emoji ?? null,
+          fileId: dto.fileId,
+          createdBy: userId,
+        },
+      });
 
-    this.logger.log(
-      `Created soundboard sound "${dto.name}" in community ${communityId}`,
-    );
-    return this.toDto(sound);
+      this.logger.log(
+        `Created soundboard sound "${dto.name}" in community ${communityId}`,
+      );
+      return this.toDto(sound);
+    } catch (error) {
+      // The name pre-check above is not atomic with the create; a concurrent
+      // request can still hit the @@unique([communityId, name]) constraint.
+      if (isPrismaError(error, 'P2002')) {
+        throw new ConflictException(
+          `A soundboard sound named "${dto.name}" already exists in this community`,
+        );
+      }
+      throw error;
+    }
   }
 
   /**
-   * Delete a soundboard sound (scoped to its community). Also removes the
-   * backing file so storage does not leak.
+   * Delete a soundboard sound (scoped to its community), then soft-delete the
+   * backing file via FileUploadService.remove so the storage reaper picks up
+   * the physical blob and the uploader's storage quota is credited back.
+   * (A raw file.delete would hard-delete the row, orphaning the blob on disk
+   * and never decrementing quota.)
    */
   async deleteSound(communityId: string, soundId: string): Promise<void> {
     const sound = await this.databaseService.soundboardSound.findUnique({
@@ -131,21 +150,40 @@ export class SoundboardService {
       throw new NotFoundException('Soundboard sound not found');
     }
 
-    // Deleting the sound row first; then soft/hard delete the backing file.
+    // Look up the uploader before deleting the sound row: remove() enforces
+    // owner-only deletion, so it must be called with the uploader's id (not
+    // the admin performing this delete).
+    const file = await this.databaseService.file.findUnique({
+      where: { id: sound.fileId },
+      select: { uploadedById: true, deletedAt: true },
+    });
+
+    // Delete the sound row first so the soundboard entry disappears even if
+    // the file cleanup below fails.
     await this.databaseService.soundboardSound.delete({
       where: { id: soundId },
     });
 
-    // Remove the backing file record (cascade-safe: sound row already gone).
-    await this.databaseService.file
-      .delete({ where: { id: sound.fileId } })
-      .catch((err: unknown) => {
+    if (file && !file.deletedAt) {
+      try {
+        if (file.uploadedById) {
+          await this.fileUploadService.remove(sound.fileId, file.uploadedById);
+        } else {
+          // Uploader account deleted (uploadedById SetNull): soft-delete
+          // directly so the reaper still removes the blob; no quota to credit.
+          await this.databaseService.file.update({
+            where: { id: sound.fileId },
+            data: { deletedAt: new Date() },
+          });
+        }
+      } catch (err: unknown) {
         this.logger.warn(
-          `Failed to delete backing file ${sound.fileId} for sound ${soundId}: ${String(
+          `Failed to soft-delete backing file ${sound.fileId} for sound ${soundId}: ${String(
             err,
           )}`,
         );
-      });
+      }
+    }
 
     this.logger.log(
       `Deleted soundboard sound "${sound.name}" (${soundId}) from community ${communityId}`,

--- a/backend/src/soundboard/soundboard.service.ts
+++ b/backend/src/soundboard/soundboard.service.ts
@@ -1,0 +1,154 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { ResourceType } from '@prisma/client';
+import { DatabaseService } from '@/database/database.service';
+import { CreateSoundboardSoundDto } from './dto/create-soundboard-sound.dto';
+import { SoundboardSoundDto } from './dto/soundboard-sound-response.dto';
+
+@Injectable()
+export class SoundboardService {
+  private readonly logger = new Logger(SoundboardService.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  private toDto(sound: {
+    id: string;
+    communityId: string;
+    name: string;
+    emoji: string | null;
+    fileId: string;
+    createdBy: string | null;
+    createdAt: Date;
+  }): SoundboardSoundDto {
+    return {
+      id: sound.id,
+      communityId: sound.communityId,
+      name: sound.name,
+      emoji: sound.emoji,
+      fileId: sound.fileId,
+      createdBy: sound.createdBy,
+      createdAt: sound.createdAt,
+    };
+  }
+
+  /**
+   * List all soundboard sounds for a community.
+   */
+  async listCommunitySounds(
+    communityId: string,
+  ): Promise<SoundboardSoundDto[]> {
+    const sounds = await this.databaseService.soundboardSound.findMany({
+      where: { communityId },
+      orderBy: { name: 'asc' },
+    });
+    return sounds.map((s) => this.toDto(s));
+  }
+
+  /**
+   * Create a soundboard sound. The audio file must already be uploaded via
+   * /file-upload with resourceType SOUNDBOARD_SOUND for this community.
+   */
+  async createSound(
+    communityId: string,
+    userId: string,
+    dto: CreateSoundboardSoundDto,
+  ): Promise<SoundboardSoundDto> {
+    // Enforce unique sound name within the community
+    const existing = await this.databaseService.soundboardSound.findUnique({
+      where: {
+        communityId_name: { communityId, name: dto.name },
+      },
+    });
+    if (existing) {
+      throw new ConflictException(
+        `A soundboard sound named "${dto.name}" already exists in this community`,
+      );
+    }
+
+    // Validate the referenced file: must exist, be an audio soundboard file,
+    // and belong to this community (prevents cross-community file references).
+    const file = await this.databaseService.file.findUnique({
+      where: { id: dto.fileId },
+      select: {
+        id: true,
+        resourceType: true,
+        fileCommunityId: true,
+        deletedAt: true,
+      },
+    });
+    if (!file || file.deletedAt) {
+      throw new NotFoundException('Referenced file not found');
+    }
+    if (
+      file.resourceType !== ResourceType.SOUNDBOARD_SOUND ||
+      file.fileCommunityId !== communityId
+    ) {
+      throw new BadRequestException(
+        'File is not a soundboard sound for this community',
+      );
+    }
+
+    // Guard against reusing the same file for multiple sounds
+    const fileInUse = await this.databaseService.soundboardSound.findFirst({
+      where: { fileId: dto.fileId },
+    });
+    if (fileInUse) {
+      throw new ConflictException(
+        'This audio file is already used by another soundboard sound',
+      );
+    }
+
+    const sound = await this.databaseService.soundboardSound.create({
+      data: {
+        communityId,
+        name: dto.name,
+        emoji: dto.emoji ?? null,
+        fileId: dto.fileId,
+        createdBy: userId,
+      },
+    });
+
+    this.logger.log(
+      `Created soundboard sound "${dto.name}" in community ${communityId}`,
+    );
+    return this.toDto(sound);
+  }
+
+  /**
+   * Delete a soundboard sound (scoped to its community). Also removes the
+   * backing file so storage does not leak.
+   */
+  async deleteSound(communityId: string, soundId: string): Promise<void> {
+    const sound = await this.databaseService.soundboardSound.findUnique({
+      where: { id: soundId },
+    });
+    if (!sound || sound.communityId !== communityId) {
+      throw new NotFoundException('Soundboard sound not found');
+    }
+
+    // Deleting the sound row first; then soft/hard delete the backing file.
+    await this.databaseService.soundboardSound.delete({
+      where: { id: soundId },
+    });
+
+    // Remove the backing file record (cascade-safe: sound row already gone).
+    await this.databaseService.file
+      .delete({ where: { id: sound.fileId } })
+      .catch((err: unknown) => {
+        this.logger.warn(
+          `Failed to delete backing file ${sound.fileId} for sound ${soundId}: ${String(
+            err,
+          )}`,
+        );
+      });
+
+    this.logger.log(
+      `Deleted soundboard sound "${sound.name}" (${soundId}) from community ${communityId}`,
+    );
+  }
+}

--- a/backend/src/test-utils/mocks/database.mock.ts
+++ b/backend/src/test-utils/mocks/database.mock.ts
@@ -73,6 +73,7 @@ export type MockDatabaseService = {
   communityTimeout: MockPrismaModel;
   moderationLog: MockPrismaModel;
   replayClip: MockPrismaModel;
+  soundboardSound: MockPrismaModel;
   // Junction table models (PostgreSQL)
   messageSpan: MockPrismaModel;
   messageReaction: MockPrismaModel;
@@ -146,6 +147,7 @@ export function createMockDatabase(): MockDatabaseService {
     communityTimeout: createMockPrismaModel(),
     moderationLog: createMockPrismaModel(),
     replayClip: createMockPrismaModel(),
+    soundboardSound: createMockPrismaModel(),
     // Junction table models (PostgreSQL)
     messageSpan: createMockPrismaModel(),
     messageReaction: createMockPrismaModel(),

--- a/frontend/e2e/fixtures/voice.fixture.ts
+++ b/frontend/e2e/fixtures/voice.fixture.ts
@@ -548,6 +548,111 @@ export async function expectNoVideoToNonWatcher(
   ).toBeLessThanOrEqual(toleranceBytes);
 }
 
+export interface SoundboardTrackState {
+  published: boolean;
+  subscribed: boolean;
+  hasTrack: boolean;
+}
+
+export interface SoundboardInboundSample {
+  bytesReceived: number;
+  totalAudioEnergy: number;
+  audioLevel?: number;
+}
+
+/**
+ * State of `remoteIdentity`'s SOUNDBOARD publication as seen by `from`.
+ * Soundboard tracks are published as Source.Unknown and identified purely by
+ * `trackName === 'soundboard'` (LiveKit's Source enum is fixed), so this walks
+ * the raw `__lkRoom` state like countScreenShareAudio() does.
+ */
+export async function getSoundboardTrackState(
+  from: Participant,
+  remoteIdentity: string,
+): Promise<SoundboardTrackState> {
+  return from.page.evaluate((id) => {
+    const out = { published: false, subscribed: false, hasTrack: false };
+    const room = window.__lkRoom;
+    if (!room) return out;
+    for (const [, participant] of room.remoteParticipants) {
+      const p = participant as {
+        identity: string;
+        audioTrackPublications: Map<
+          string,
+          { trackName?: string; isSubscribed?: boolean; track?: unknown }
+        >;
+      };
+      if (p.identity !== id) continue;
+      for (const [, pub] of p.audioTrackPublications) {
+        if (pub.trackName !== 'soundboard') continue;
+        out.published = true;
+        out.subscribed = !!pub.isSubscribed;
+        out.hasTrack = !!pub.track;
+      }
+    }
+    return out;
+  }, remoteIdentity);
+}
+
+/**
+ * Inbound RTP stats for `remoteIdentity`'s soundboard track on `from`'s page —
+ * "is `from` actually RECEIVING soundboard audio". totalAudioEnergy is the
+ * decisive signal: the warmed-up track carries silence (≈0 energy), so energy
+ * only accrues while a clip is actually playing.
+ */
+export async function getSoundboardInbound(
+  from: Participant,
+  remoteIdentity: string,
+): Promise<SoundboardInboundSample | undefined> {
+  return from.page.evaluate(async (id) => {
+    const room = window.__lkRoom;
+    if (!room) return undefined;
+    for (const [, participant] of room.remoteParticipants) {
+      const p = participant as {
+        identity: string;
+        audioTrackPublications: Map<
+          string,
+          {
+            trackName?: string;
+            track?: { getRTCStatsReport?: () => Promise<RTCStatsReport | undefined> };
+          }
+        >;
+      };
+      if (p.identity !== id) continue;
+      for (const [, pub] of p.audioTrackPublications) {
+        if (pub.trackName !== 'soundboard') continue;
+        if (!pub.track || typeof pub.track.getRTCStatsReport !== 'function') return undefined;
+        try {
+          const report = await pub.track.getRTCStatsReport();
+          if (!report) return undefined;
+          let out: { bytesReceived: number; totalAudioEnergy: number; audioLevel?: number } | undefined;
+          report.forEach((stat) => {
+            const s = stat as {
+              type: string;
+              kind?: string;
+              mediaType?: string;
+              bytesReceived?: number;
+              totalAudioEnergy?: number;
+              audioLevel?: number;
+            };
+            if (s.type === 'inbound-rtp' && (s.kind === 'audio' || s.mediaType === 'audio')) {
+              out = {
+                bytesReceived: s.bytesReceived ?? 0,
+                totalAudioEnergy: s.totalAudioEnergy ?? 0,
+                audioLevel: s.audioLevel,
+              };
+            }
+          });
+          return out;
+        } catch {
+          return undefined;
+        }
+      }
+    }
+    return undefined;
+  }, remoteIdentity);
+}
+
 /** Trigger a deterministic LiveKit reconnect on a participant (PR #352 repro). */
 export async function forceReconnect(
   p: Participant,

--- a/frontend/e2e/voice/soundboard.spec.ts
+++ b/frontend/e2e/voice/soundboard.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Soundboard — remote audibility through real LiveKit (#292 / PR #406).
+ *
+ * The soundboard publishes a WebAudio-sourced track as Track.Source.Unknown
+ * NAMED 'soundboard'; with autoSubscribe:false this only works if
+ * useTrackSubscription auto-subscribes it by name and AudioRenderer renders it.
+ * None of that is provable in unit tests, so this spec drives two real browsers
+ * into a real LiveKit room and asserts:
+ *
+ *   1. warmup: A's soundboard track is published + subscribed on B BEFORE the
+ *      first clip is triggered (the eager-publish fix for the first-clip race);
+ *   2. the FIRST clip, triggered through the real SoundboardButton UI, carries
+ *      actual signal to B (inbound totalAudioEnergy accrues — the warmed track
+ *      is silent, so energy growth == the clip was audible);
+ *   3. a second clip also plays (stop-and-restart path);
+ *   4. B's mic path still works afterwards (no regression from the extra
+ *      audio publication).
+ *
+ * Seeding: the community's sound is created at test time via the real APIs
+ * (multipart /file-upload with a synthesized 1.6s sine-tone WAV, then
+ * POST /soundboard/community/:id). testuser is InstanceRole.OWNER, which
+ * bypasses community RBAC for the create.
+ *
+ * Requires the real-LiveKit stack: scripts/run-voice-e2e.sh soundboard
+ */
+import { test, expect } from '@playwright/test';
+import {
+  launchParticipant,
+  joinVoiceChannel,
+  closeParticipant,
+  waitForAudioFlow,
+  getSoundboardTrackState,
+  getSoundboardInbound,
+  TEST_USER,
+  TEST_USER_2,
+  type Participant,
+} from '../fixtures/voice.fixture';
+import { API_BASE } from '../fixtures/auth.fixture';
+
+test.describe.configure({ mode: 'serial' });
+
+/** Synthesize a 16-bit PCM mono WAV of a sine tone (RIFF/WAVE, no deps). */
+function makeToneWav(durationSec = 1.6, freq = 440, sampleRate = 24000): Buffer {
+  const numSamples = Math.floor(durationSec * sampleRate);
+  const dataSize = numSamples * 2;
+  const buf = Buffer.alloc(44 + dataSize);
+  buf.write('RIFF', 0);
+  buf.writeUInt32LE(36 + dataSize, 4);
+  buf.write('WAVE', 8);
+  buf.write('fmt ', 12);
+  buf.writeUInt32LE(16, 16); // fmt chunk size
+  buf.writeUInt16LE(1, 20); // PCM
+  buf.writeUInt16LE(1, 22); // mono
+  buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(sampleRate * 2, 28); // byte rate
+  buf.writeUInt16LE(2, 32); // block align
+  buf.writeUInt16LE(16, 34); // bits per sample
+  buf.write('data', 36);
+  buf.writeUInt32LE(dataSize, 40);
+  for (let i = 0; i < numSamples; i++) {
+    const v = Math.round(Math.sin((2 * Math.PI * freq * i) / sampleRate) * 0.8 * 32767);
+    buf.writeInt16LE(v, 44 + i * 2);
+  }
+  return buf;
+}
+
+test.describe('Soundboard — clip is audible to remote participants', () => {
+  let a: Participant; // testuser — triggers the sound
+  let b: Participant; // testuser2 — must HEAR the sound
+  // Unique per run so re-runs never hit the @@unique([communityId, name]) 409.
+  const soundName = `e2e-tone-${Date.now()}`;
+
+  test.beforeAll(async () => {
+    a = await launchParticipant(TEST_USER, 'sample-a.wav');
+    b = await launchParticipant(TEST_USER_2, 'sample-b.wav');
+
+    // --- Seed the soundboard sound via the real APIs (as A, an OWNER). ---
+    const auth = { Authorization: `Bearer ${a.accessToken}` };
+
+    const communitiesRes = await a.context.request.get(`${API_BASE}/community`, {
+      headers: auth,
+    });
+    expect(communitiesRes.ok(), 'GET /community failed').toBeTruthy();
+    const communities = (await communitiesRes.json()) as Array<{ id: string; name: string }>;
+    const community = communities.find((c) => c.name === 'Test Community');
+    expect(community, 'seeded Test Community not found').toBeTruthy();
+
+    const uploadRes = await a.context.request.post(`${API_BASE}/file-upload`, {
+      headers: auth,
+      multipart: {
+        file: {
+          name: 'e2e-tone.wav',
+          mimeType: 'audio/wav',
+          buffer: makeToneWav(),
+        },
+        resourceType: 'SOUNDBOARD_SOUND',
+        resourceId: community!.id,
+      },
+    });
+    expect(
+      uploadRes.ok(),
+      `file-upload failed: ${uploadRes.status()} ${await uploadRes.text()}`,
+    ).toBeTruthy();
+    const uploaded = (await uploadRes.json()) as { id: string };
+
+    const createRes = await a.context.request.post(
+      `${API_BASE}/soundboard/community/${community!.id}`,
+      {
+        headers: auth,
+        data: { name: soundName, emoji: '🔊', fileId: uploaded.id },
+      },
+    );
+    expect(
+      createRes.ok(),
+      `soundboard create failed: ${createRes.status()} ${await createRes.text()}`,
+    ).toBeTruthy();
+
+    // --- Both users into the dedicated voice channel. ---
+    await joinVoiceChannel(a, 'voice-soundboard');
+    await joinVoiceChannel(b, 'voice-soundboard');
+  });
+
+  test.afterAll(async () => {
+    await Promise.all([a, b].filter(Boolean).map(closeParticipant));
+  });
+
+  test('baseline: A and B hear each other over mic', async () => {
+    await waitForAudioFlow(b, a);
+    await waitForAudioFlow(a, b);
+  });
+
+  test('warmup: soundboard track is published and subscribed BEFORE the first clip', async () => {
+    // Eager publish on SoundboardButton mount + name-based auto-subscribe in
+    // useTrackSubscription: B must already be subscribed to A's soundboard
+    // track without anyone having clicked anything.
+    await expect
+      .poll(
+        async () => {
+          const s = await getSoundboardTrackState(b, a.identity);
+          return s.published && s.subscribed && s.hasTrack;
+        },
+        {
+          timeout: 20_000,
+          message:
+            "B never subscribed to A's warmed-up soundboard track ",
+        },
+      )
+      .toBe(true);
+  });
+
+  test('FIRST clip triggered via the SoundboardButton UI is audible on B', async () => {
+    // Baseline: warmed-up track carries silence → ~zero accumulated energy.
+    const before = await getSoundboardInbound(b, a.identity);
+    const beforeEnergy = before?.totalAudioEnergy ?? 0;
+    const beforeBytes = before?.bytesReceived ?? 0;
+
+    // Drive the REAL UI on A: open the soundboard popover, click the sound.
+    await a.page.getByRole('button', { name: 'Open soundboard' }).click();
+    const soundButton = a.page.getByRole('button', { name: soundName });
+    await expect(soundButton).toBeVisible({ timeout: 10_000 });
+    await soundButton.click();
+
+    // The FIRST clip must carry real signal to B: totalAudioEnergy accrues only
+    // for non-silent samples, so an inaudible/clipped-to-nothing first play
+    // fails this. (0.05 ≈ 1/10th of the tone's total energy — well above float
+    // noise, robust to the clip being partially consumed before sampling.)
+    await expect
+      .poll(
+        async () => {
+          const s = await getSoundboardInbound(b, a.identity);
+          if (!s) return false;
+          const energyGrew = s.totalAudioEnergy - beforeEnergy > 0.05;
+          const bytesGrew = s.bytesReceived - beforeBytes > 1_000;
+          return energyGrew && bytesGrew;
+        },
+        {
+          timeout: 15_000,
+          message: `first soundboard clip carried no audible signal ${a.name} → ${b.name}`,
+        },
+      )
+      .toBe(true);
+  });
+
+  test('second clip also plays (stop-and-restart path)', async () => {
+    const before = await getSoundboardInbound(b, a.identity);
+    const beforeEnergy = before?.totalAudioEnergy ?? 0;
+
+    // Popover stays open after a click; re-open if it auto-closed.
+    const soundButton = a.page.getByRole('button', { name: soundName });
+    if (!(await soundButton.isVisible().catch(() => false))) {
+      await a.page.getByRole('button', { name: 'Open soundboard' }).click();
+      await expect(soundButton).toBeVisible({ timeout: 10_000 });
+    }
+    await soundButton.click();
+
+    await expect
+      .poll(
+        async () => {
+          const s = await getSoundboardInbound(b, a.identity);
+          return (s?.totalAudioEnergy ?? 0) - beforeEnergy > 0.05;
+        },
+        { timeout: 15_000, message: 'second soundboard clip carried no signal' },
+      )
+      .toBe(true);
+  });
+
+  test("B's mic still reaches A after soundboard use (no regression)", async () => {
+    await waitForAudioFlow(a, b, { timeout: 30_000 });
+    await waitForAudioFlow(b, a, { timeout: 30_000 });
+  });
+});

--- a/frontend/src/__tests__/components/AudioRenderer.test.tsx
+++ b/frontend/src/__tests__/components/AudioRenderer.test.tsx
@@ -138,6 +138,22 @@ describe('AudioRenderer', () => {
     expect(audioElements.length).toBe(0);
   });
 
+  it('always renders soundboard tracks (Source.Unknown, matched by trackName)', () => {
+    // Soundboard track: unknown source, identified by its name "soundboard"
+    const soundboardPub = {
+      source: 'unknown',
+      trackName: 'soundboard',
+      trackSid: 'sid-soundboard',
+      track: { attach: vi.fn(), detach: vi.fn(), setVolume: vi.fn() },
+    };
+    const participant = createMockRemoteParticipant('user-1', [soundboardPub]);
+    mockRoom!.remoteParticipants.set('user-1', participant);
+
+    const { container } = render(<AudioRenderer />);
+    const audioElements = container.querySelectorAll('audio');
+    expect(audioElements.length).toBe(1);
+  });
+
   it('renders screen share audio only for watched participants when multiple are present', () => {
     mockWatchingScreenShares = new Set(['user-1']);
     const screenAudioPub1 = createMockPublication('screen_share_audio');

--- a/frontend/src/__tests__/components/SoundboardManagement.test.tsx
+++ b/frontend/src/__tests__/components/SoundboardManagement.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders } from '../test-utils';
+import { server } from '../msw/server';
+import SoundboardManagement from '../../components/Community/SoundboardManagement';
+import type { SoundboardSoundDto } from '../../api-client/types.gen';
+
+vi.mock('../../api-client/client.gen', async (importOriginal) => {
+  const { createClient, createConfig } = await import('../../api-client/client');
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    client: createClient(createConfig({ baseUrl: 'http://localhost:3000' })),
+  };
+});
+
+// All permissions granted by default
+vi.mock('../../features/roles/useUserPermissions', () => ({
+  useUserPermissions: vi.fn(() => ({ hasPermissions: true })),
+}));
+
+// Avoid the authenticated-file/blob dependency of the real preview button
+vi.mock('../../components/Community/SoundPreviewButton', () => ({
+  SoundPreviewButton: ({ fileId }: { fileId: string }) => (
+    <div data-testid={`preview-${fileId}`} />
+  ),
+}));
+
+const uploadFileMock = vi.fn();
+vi.mock('../../hooks/useFileUpload', () => ({
+  useFileUpload: () => ({
+    uploadFile: uploadFileMock,
+    isUploading: false,
+    error: null,
+    resetError: vi.fn(),
+  }),
+}));
+
+const communityId = 'comm-1';
+
+function makeSound(overrides: Partial<SoundboardSoundDto> = {}): SoundboardSoundDto {
+  return {
+    id: 'sound-1',
+    communityId,
+    name: 'airhorn',
+    emoji: '📯',
+    fileId: 'file-1',
+    createdBy: 'user-1',
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+const listUrl = `http://localhost:3000/api/soundboard/community/${communityId}`;
+
+describe('SoundboardManagement', () => {
+  beforeEach(() => {
+    uploadFileMock.mockReset();
+  });
+
+  it('renders the list of community sounds', async () => {
+    server.use(
+      http.get(listUrl, () =>
+        HttpResponse.json([makeSound(), makeSound({ id: 'sound-2', name: 'boo', emoji: null })]),
+      ),
+    );
+
+    renderWithProviders(<SoundboardManagement communityId={communityId} />);
+
+    expect(await screen.findByText('airhorn')).toBeInTheDocument();
+    expect(screen.getByText('boo')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no sounds', async () => {
+    server.use(http.get(listUrl, () => HttpResponse.json([])));
+
+    renderWithProviders(<SoundboardManagement communityId={communityId} />);
+
+    expect(await screen.findByText('No sounds yet')).toBeInTheDocument();
+  });
+
+  it('uploads and creates a sound through the add dialog', async () => {
+    uploadFileMock.mockResolvedValue({ id: 'file-new' });
+    const createCalls: unknown[] = [];
+
+    server.use(
+      http.get(listUrl, () => HttpResponse.json([])),
+      http.post(listUrl, async ({ request }) => {
+        const body = await request.json();
+        createCalls.push(body);
+        return HttpResponse.json(makeSound({ id: 'sound-new', name: 'yay', fileId: 'file-new' }));
+      }),
+    );
+
+    const { user } = renderWithProviders(
+      <SoundboardManagement communityId={communityId} />,
+    );
+
+    await screen.findByText('No sounds yet');
+    await user.click(screen.getByRole('button', { name: /add your first sound/i }));
+
+    const nameInput = await screen.findByLabelText('Name');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'yay');
+
+    const file = new File([new Uint8Array([1, 2, 3])], 'yay.mp3', { type: 'audio/mpeg' });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(fileInput, file);
+
+    await user.click(screen.getByRole('button', { name: /^add sound$/i }));
+
+    await waitFor(() => {
+      expect(uploadFileMock).toHaveBeenCalledWith(file, {
+        resourceType: 'SOUNDBOARD_SOUND',
+        resourceId: communityId,
+      });
+    });
+    await waitFor(() => {
+      expect(createCalls).toHaveLength(1);
+    });
+    expect(createCalls[0]).toMatchObject({ name: 'yay', fileId: 'file-new' });
+  });
+
+  it('deletes a sound after confirmation', async () => {
+    let deleted = false;
+    server.use(
+      http.get(listUrl, () => HttpResponse.json([makeSound()])),
+      http.delete(
+        `${listUrl}/sound-1`,
+        () => {
+          deleted = true;
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    const { user } = renderWithProviders(
+      <SoundboardManagement communityId={communityId} />,
+    );
+
+    await screen.findByText('airhorn');
+    await user.click(screen.getByRole('button', { name: /delete sound/i }));
+
+    // Confirm dialog
+    const confirmButton = await screen.findByRole('button', { name: /^delete$/i });
+    await user.click(confirmButton);
+
+    await waitFor(() => expect(deleted).toBe(true));
+  });
+});

--- a/frontend/src/__tests__/features/soundboardPlayer.test.ts
+++ b/frontend/src/__tests__/features/soundboardPlayer.test.ts
@@ -127,4 +127,37 @@ describe('soundboardPlayer', () => {
   it('does nothing harmful when disposed without ever playing', async () => {
     await expect(soundboardPlayer.dispose(null)).resolves.toBeUndefined();
   });
+
+  it('warmup eagerly publishes the track without playing anything', async () => {
+    const room = createMockRoom();
+
+    await soundboardPlayer.warmup(room as never);
+
+    expect(room.localParticipant.publishTrack).toHaveBeenCalledTimes(1);
+    const [, opts] = room.localParticipant.publishTrack.mock.calls[0];
+    expect(opts.name).toBe(SOUNDBOARD_TRACK_NAME);
+    // Nothing decoded or started
+    expect(decodeSpy).not.toHaveBeenCalled();
+  });
+
+  it('play after warmup reuses the already-published track', async () => {
+    const room = createMockRoom();
+
+    await soundboardPlayer.warmup(room as never);
+    await soundboardPlayer.play(room as never, 'file-1', new ArrayBuffer(8));
+
+    expect(room.localParticipant.publishTrack).toHaveBeenCalledTimes(1);
+    expect(lastSource.start).toHaveBeenCalled();
+  });
+
+  it('warmup swallows publish errors (play retries later)', async () => {
+    const room = createMockRoom();
+    room.localParticipant.publishTrack.mockRejectedValueOnce(
+      new Error('not connected'),
+    );
+
+    await expect(
+      soundboardPlayer.warmup(room as never),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/frontend/src/__tests__/features/soundboardPlayer.test.ts
+++ b/frontend/src/__tests__/features/soundboardPlayer.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Track } from 'livekit-client';
+import {
+  soundboardPlayer,
+  SOUNDBOARD_TRACK_NAME,
+} from '../../features/voice/soundboardPlayer';
+
+// --- Mock WebAudio (jsdom has no AudioContext) ---
+const decodedBuffer = { duration: 1 } as unknown as AudioBuffer;
+
+function createMockSource() {
+  return {
+    buffer: null,
+    connect: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    onended: null as null | (() => void),
+  };
+}
+
+let lastSource: ReturnType<typeof createMockSource>;
+let mockDestinationTrack: { id: string };
+const closeSpy = vi.fn();
+const resumeSpy = vi.fn().mockResolvedValue(undefined);
+const decodeSpy = vi.fn().mockResolvedValue(decodedBuffer);
+
+class MockAudioContext {
+  state = 'running';
+  destination = { name: 'ctx-destination' };
+  createMediaStreamDestination() {
+    mockDestinationTrack = { id: 'sb-track' };
+    return { stream: { getAudioTracks: () => [mockDestinationTrack] } };
+  }
+  createBufferSource() {
+    lastSource = createMockSource();
+    return lastSource;
+  }
+  decodeAudioData(buf: ArrayBuffer) {
+    return decodeSpy(buf);
+  }
+  resume() {
+    return resumeSpy();
+  }
+  close() {
+    this.state = 'closed';
+    return closeSpy();
+  }
+}
+
+// --- Mock LiveKit Room / localParticipant ---
+function createMockRoom() {
+  const publications = new Map<string, unknown>();
+  const publishTrack = vi.fn().mockImplementation((_track, opts) => {
+    const pub = {
+      trackSid: 'pub-sid',
+      trackName: opts.name,
+      source: opts.source,
+      track: { mediaStreamTrack: _track },
+    };
+    publications.set(pub.trackSid, pub);
+    return Promise.resolve(pub);
+  });
+  const unpublishTrack = vi.fn().mockResolvedValue(undefined);
+  return {
+    localParticipant: {
+      trackPublications: publications,
+      publishTrack,
+      unpublishTrack,
+    },
+  };
+}
+
+describe('soundboardPlayer', () => {
+  beforeEach(() => {
+    vi.stubGlobal('AudioContext', MockAudioContext);
+    decodeSpy.mockClear();
+    resumeSpy.mockClear();
+    closeSpy.mockClear();
+  });
+
+  afterEach(async () => {
+    await soundboardPlayer.dispose(null);
+    vi.unstubAllGlobals();
+  });
+
+  it('publishes a track named "soundboard" with Source.Unknown on first play', async () => {
+    const room = createMockRoom();
+    const buf = new ArrayBuffer(8);
+
+    await soundboardPlayer.play(room as never, 'file-1', buf);
+
+    expect(room.localParticipant.publishTrack).toHaveBeenCalledTimes(1);
+    const [, opts] = room.localParticipant.publishTrack.mock.calls[0];
+    expect(opts.name).toBe(SOUNDBOARD_TRACK_NAME);
+    expect(opts.source).toBe(Track.Source.Unknown);
+    expect(lastSource.start).toHaveBeenCalled();
+    // Connects to both the remote destination and the local monitor
+    expect(lastSource.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it('reuses the published track and caches the decoded buffer on repeat plays', async () => {
+    const room = createMockRoom();
+    const buf = new ArrayBuffer(8);
+
+    await soundboardPlayer.play(room as never, 'file-1', buf);
+    const firstSource = lastSource;
+    await soundboardPlayer.play(room as never, 'file-1', buf);
+
+    // Only published once for the session
+    expect(room.localParticipant.publishTrack).toHaveBeenCalledTimes(1);
+    // Decoded once (cached by fileId)
+    expect(decodeSpy).toHaveBeenCalledTimes(1);
+    // Previous source was stopped (stop-and-restart)
+    expect(firstSource.stop).toHaveBeenCalled();
+  });
+
+  it('unpublishes the track and closes the context on dispose', async () => {
+    const room = createMockRoom();
+    await soundboardPlayer.play(room as never, 'file-1', new ArrayBuffer(8));
+
+    await soundboardPlayer.dispose(room as never);
+
+    expect(room.localParticipant.unpublishTrack).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it('does nothing harmful when disposed without ever playing', async () => {
+    await expect(soundboardPlayer.dispose(null)).resolves.toBeUndefined();
+  });
+});

--- a/frontend/src/__tests__/hooks/useDeafenEffect.test.ts
+++ b/frontend/src/__tests__/hooks/useDeafenEffect.test.ts
@@ -197,6 +197,48 @@ describe('useDeafenEffect', () => {
     expect(cameraTrack.track.setVolume).not.toHaveBeenCalled();
   });
 
+  it('mutes soundboard tracks (Source.Unknown, matched by trackName) when deafened', () => {
+    const soundboardTrack = {
+      source: 'unknown',
+      trackName: 'soundboard',
+      track: { setVolume: vi.fn() },
+    };
+    addParticipant('user-1', [soundboardTrack as never]);
+    mockIsDeafened = true;
+
+    renderHook(() => useDeafenEffect());
+
+    expect(soundboardTrack.track.setVolume).toHaveBeenCalledWith(0);
+  });
+
+  it('restores soundboard tracks to 100% when undeafened', () => {
+    const soundboardTrack = {
+      source: 'unknown',
+      trackName: 'soundboard',
+      track: { setVolume: vi.fn() },
+    };
+    addParticipant('user-1', [soundboardTrack as never]);
+    mockIsDeafened = false;
+
+    renderHook(() => useDeafenEffect());
+
+    expect(audioBoostManager.applyVolume).toHaveBeenCalledWith(
+      soundboardTrack.track,
+      'user-1:unknown',
+      100,
+    );
+  });
+
+  it('does not mute an unnamed Source.Unknown track when deafened', () => {
+    const unknownTrack = { source: 'unknown', track: { setVolume: vi.fn() } };
+    addParticipant('user-1', [unknownTrack as never]);
+    mockIsDeafened = true;
+
+    renderHook(() => useDeafenEffect());
+
+    expect(unknownTrack.track.setVolume).not.toHaveBeenCalled();
+  });
+
   it('does nothing when no room is available', () => {
     mockRoom = null;
 

--- a/frontend/src/components/Community/SoundPreviewButton.tsx
+++ b/frontend/src/components/Community/SoundPreviewButton.tsx
@@ -1,0 +1,69 @@
+import React, { useRef, useState, useCallback } from "react";
+import { IconButton, Tooltip, CircularProgress } from "@mui/material";
+import {
+  PlayArrow as PlayArrowIcon,
+  Stop as StopIcon,
+} from "@mui/icons-material";
+import { useAuthenticatedFile } from "../../hooks/useAuthenticatedFile";
+
+interface SoundPreviewButtonProps {
+  fileId: string;
+}
+
+/**
+ * Plays a soundboard clip locally (management preview only — does NOT publish to
+ * a voice channel). Fetches the authenticated blob lazily on first play.
+ */
+export const SoundPreviewButton: React.FC<SoundPreviewButtonProps> = ({
+  fileId,
+}) => {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const { blobUrl, isLoading, error } = useAuthenticatedFile(fileId, {
+    fetchBlob: true,
+  });
+
+  const handleToggle = useCallback(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    if (isPlaying) {
+      el.pause();
+      el.currentTime = 0;
+      setIsPlaying(false);
+    } else {
+      el.play().catch(() => setIsPlaying(false));
+      setIsPlaying(true);
+    }
+  }, [isPlaying]);
+
+  if (isLoading) {
+    return <CircularProgress size={18} />;
+  }
+
+  return (
+    <>
+      <Tooltip title={error ? "Failed to load" : isPlaying ? "Stop" : "Preview"}>
+        <span>
+          <IconButton
+            size="small"
+            onClick={handleToggle}
+            disabled={!blobUrl || Boolean(error)}
+            aria-label={isPlaying ? "Stop preview" : "Play preview"}
+          >
+            {isPlaying ? <StopIcon /> : <PlayArrowIcon />}
+          </IconButton>
+        </span>
+      </Tooltip>
+      {blobUrl && (
+        <audio
+          ref={audioRef}
+          src={blobUrl}
+          onEnded={() => setIsPlaying(false)}
+          hidden
+        />
+      )}
+    </>
+  );
+};
+
+export default SoundPreviewButton;

--- a/frontend/src/components/Community/SoundboardManagement.tsx
+++ b/frontend/src/components/Community/SoundboardManagement.tsx
@@ -1,0 +1,407 @@
+import React, { useState, useCallback, useRef } from "react";
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Button,
+  Alert,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  IconButton,
+  Tooltip,
+  TextField,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from "@mui/material";
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  MusicNote as MusicNoteIcon,
+  UploadFile as UploadFileIcon,
+} from "@mui/icons-material";
+import { useUserPermissions } from "../../features/roles/useUserPermissions";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  soundboardControllerListCommunitySoundsOptions,
+  soundboardControllerListCommunitySoundsQueryKey,
+  soundboardControllerCreateSoundMutation,
+  soundboardControllerDeleteSoundMutation,
+} from "../../api-client/@tanstack/react-query.gen";
+import type { SoundboardSoundDto } from "../../api-client/types.gen";
+import { useFileUpload } from "../../hooks/useFileUpload";
+import ConfirmDialog from "../Common/ConfirmDialog";
+import { SoundPreviewButton } from "./SoundPreviewButton";
+
+interface SoundboardManagementProps {
+  communityId: string;
+}
+
+const MAX_SOUND_BYTES = 1024 * 1024; // Mirror backend cap (1MB)
+
+const SoundboardManagement: React.FC<SoundboardManagementProps> = ({
+  communityId,
+}) => {
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [emoji, setEmoji] = useState("");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [soundToDelete, setSoundToDelete] =
+    useState<SoundboardSoundDto | null>(null);
+
+  const { hasPermissions: canRead } = useUserPermissions({
+    resourceType: "COMMUNITY",
+    resourceId: communityId,
+    actions: ["READ_SOUNDBOARD_SOUND"],
+  });
+  const { hasPermissions: canCreate } = useUserPermissions({
+    resourceType: "COMMUNITY",
+    resourceId: communityId,
+    actions: ["CREATE_SOUNDBOARD_SOUND"],
+  });
+  const { hasPermissions: canDelete } = useUserPermissions({
+    resourceType: "COMMUNITY",
+    resourceId: communityId,
+    actions: ["DELETE_SOUNDBOARD_SOUND"],
+  });
+
+  const {
+    data: sounds,
+    isLoading,
+    error,
+  } = useQuery({
+    ...soundboardControllerListCommunitySoundsOptions({
+      path: { communityId },
+    }),
+    enabled: canRead,
+  });
+
+  const { uploadFile, isUploading } = useFileUpload();
+
+  const invalidate = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: soundboardControllerListCommunitySoundsQueryKey({
+        path: { communityId },
+      }),
+    });
+  }, [queryClient, communityId]);
+
+  const { mutateAsync: createSound, isPending: isCreating } = useMutation({
+    ...soundboardControllerCreateSoundMutation(),
+    onSuccess: invalidate,
+  });
+
+  const { mutateAsync: deleteSound, isPending: isDeleting } = useMutation({
+    ...soundboardControllerDeleteSoundMutation(),
+    onSuccess: invalidate,
+  });
+
+  const resetForm = useCallback(() => {
+    setName("");
+    setEmoji("");
+    setSelectedFile(null);
+    setFormError(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }, []);
+
+  const handleCloseCreate = useCallback(() => {
+    setCreateOpen(false);
+    resetForm();
+  }, [resetForm]);
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0] ?? null;
+      setFormError(null);
+      if (file && file.size > MAX_SOUND_BYTES) {
+        setFormError("Sound is too large. Maximum size is 1MB.");
+        setSelectedFile(null);
+        return;
+      }
+      setSelectedFile(file);
+      if (file && !name) {
+        // Default the name to the file's base name for convenience
+        setName(file.name.replace(/\.[^.]+$/, "").slice(0, 50));
+      }
+    },
+    [name]
+  );
+
+  const handleCreate = useCallback(async () => {
+    setFormError(null);
+    if (!name.trim()) {
+      setFormError("Please enter a name.");
+      return;
+    }
+    if (!selectedFile) {
+      setFormError("Please choose an audio file.");
+      return;
+    }
+
+    try {
+      const uploaded = await uploadFile(selectedFile, {
+        resourceType: "SOUNDBOARD_SOUND",
+        resourceId: communityId,
+      });
+      await createSound({
+        path: { communityId },
+        body: {
+          name: name.trim(),
+          emoji: emoji.trim() || undefined,
+          fileId: uploaded.id,
+        },
+      });
+      handleCloseCreate();
+    } catch (err) {
+      setFormError(
+        err instanceof Error ? err.message : "Failed to create sound."
+      );
+    }
+  }, [
+    name,
+    emoji,
+    selectedFile,
+    uploadFile,
+    createSound,
+    communityId,
+    handleCloseCreate,
+  ]);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!soundToDelete) return;
+    try {
+      await deleteSound({
+        path: { communityId, soundId: soundToDelete.id },
+      });
+      setSoundToDelete(null);
+    } catch {
+      // surfaced via mutation error state; keep dialog open
+    }
+  }, [soundToDelete, deleteSound, communityId]);
+
+  if (!canRead) {
+    return (
+      <Card>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            Soundboard
+          </Typography>
+          <Alert severity="info">
+            You don't have permission to view the soundboard in this community.
+          </Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" p={2}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert severity="error">Failed to load soundboard. Please try again.</Alert>
+    );
+  }
+
+  const busy = isUploading || isCreating;
+
+  return (
+    <>
+      <Card>
+        <CardContent>
+          <Box
+            display="flex"
+            justifyContent="space-between"
+            alignItems="center"
+            mb={3}
+          >
+            <Box>
+              <Typography variant="h6">Soundboard</Typography>
+              <Typography variant="body2" color="text.secondary">
+                Upload short audio clips (max 1MB). Members can play them for
+                everyone while connected to a voice channel.
+              </Typography>
+            </Box>
+            {canCreate && (
+              <Button
+                variant="contained"
+                startIcon={<AddIcon />}
+                onClick={() => setCreateOpen(true)}
+              >
+                Add Sound
+              </Button>
+            )}
+          </Box>
+
+          {sounds && sounds.length > 0 ? (
+            <TableContainer component={Paper} variant="outlined">
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Sound</TableCell>
+                    <TableCell align="center">Preview</TableCell>
+                    <TableCell align="right">Actions</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {sounds.map((sound) => (
+                    <TableRow key={sound.id}>
+                      <TableCell>
+                        <Box display="flex" alignItems="center" gap={1}>
+                          <span aria-hidden style={{ fontSize: "1.25rem" }}>
+                            {sound.emoji || "🔊"}
+                          </span>
+                          <Typography variant="body2" fontWeight="medium">
+                            {sound.name}
+                          </Typography>
+                        </Box>
+                      </TableCell>
+                      <TableCell align="center">
+                        <SoundPreviewButton fileId={sound.fileId} />
+                      </TableCell>
+                      <TableCell align="right">
+                        {canDelete && (
+                          <Tooltip title="Delete sound">
+                            <IconButton
+                              size="small"
+                              color="error"
+                              onClick={() => setSoundToDelete(sound)}
+                            >
+                              <DeleteIcon />
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          ) : (
+            <Box
+              display="flex"
+              flexDirection="column"
+              alignItems="center"
+              justifyContent="center"
+              py={4}
+            >
+              <MusicNoteIcon
+                sx={{ fontSize: 48, color: "text.secondary", mb: 2 }}
+              />
+              <Typography variant="h6" color="text.secondary" gutterBottom>
+                No sounds yet
+              </Typography>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                align="center"
+                mb={3}
+              >
+                Add short audio clips that members can play in voice channels.
+              </Typography>
+              {canCreate && (
+                <Button
+                  variant="contained"
+                  startIcon={<AddIcon />}
+                  onClick={() => setCreateOpen(true)}
+                >
+                  Add Your First Sound
+                </Button>
+              )}
+            </Box>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={createOpen} onClose={handleCloseCreate} fullWidth maxWidth="sm">
+        <DialogTitle>Add Sound</DialogTitle>
+        <DialogContent>
+          <Box display="flex" flexDirection="column" gap={2} mt={1}>
+            {formError && <Alert severity="error">{formError}</Alert>}
+            <TextField
+              label="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              inputProps={{ maxLength: 50 }}
+              fullWidth
+              autoFocus
+            />
+            <TextField
+              label="Emoji (optional)"
+              value={emoji}
+              onChange={(e) => setEmoji(e.target.value)}
+              inputProps={{ maxLength: 16 }}
+              placeholder="📯"
+              sx={{ width: 160 }}
+            />
+            <Button
+              variant="outlined"
+              startIcon={<UploadFileIcon />}
+              component="label"
+            >
+              {selectedFile ? selectedFile.name : "Choose Audio File"}
+              <input
+                ref={fileInputRef}
+                type="file"
+                hidden
+                accept="audio/mpeg,audio/wav,audio/ogg,audio/webm,audio/aac"
+                onChange={handleFileChange}
+              />
+            </Button>
+            <Typography variant="caption" color="text.secondary">
+              MP3, WAV, OGG, WebM, or AAC. Max 1MB.
+            </Typography>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseCreate} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleCreate}
+            disabled={busy}
+            startIcon={busy ? <CircularProgress size={16} /> : undefined}
+          >
+            {busy ? "Uploading..." : "Add Sound"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <ConfirmDialog
+        open={Boolean(soundToDelete)}
+        title="Delete Sound"
+        description={
+          <>
+            Are you sure you want to delete <strong>{soundToDelete?.name}</strong>
+            ? This cannot be undone.
+          </>
+        }
+        confirmLabel="Delete"
+        confirmColor="error"
+        isLoading={isDeleting}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setSoundToDelete(null)}
+      />
+    </>
+  );
+};
+
+export default SoundboardManagement;

--- a/frontend/src/components/Community/index.ts
+++ b/frontend/src/components/Community/index.ts
@@ -9,5 +9,6 @@ export { default as ChannelManagement } from "./ChannelManagement";
 export { default as PrivateChannelMembership } from "./PrivateChannelMembership";
 export { default as RoleManagement } from "./RoleManagement";
 export { default as AliasGroupManagement } from "./AliasGroupManagement";
+export { default as SoundboardManagement } from "./SoundboardManagement";
 export { default as AliasGroupEditor } from "./AliasGroupEditor";
 export { default as CustomEmojiManagement } from "./CustomEmojiManagement";

--- a/frontend/src/components/Voice/AudioRenderer.tsx
+++ b/frontend/src/components/Voice/AudioRenderer.tsx
@@ -5,6 +5,7 @@ import { useVoice } from '../../contexts/VoiceContext';
 import { audioBoostManager, boostKey } from '../../features/voice/audioBoostManager';
 import { isBoostableAudioTrack } from '../../features/voice/isBoostableAudioTrack';
 import { getStoredVolumePercent } from '../../features/voice/volumeStorage';
+import { SOUNDBOARD_TRACK_NAME } from '../../features/voice/soundboardPlayer';
 import { logger } from '../../utils/logger';
 
 /**
@@ -121,7 +122,9 @@ export const AudioRenderer: React.FC = () => {
         // Include microphone tracks always; screen share audio only when watching that participant's screen share
         const isMic = publication.source === Track.Source.Microphone;
         const isScreenShareAudio = publication.source === Track.Source.ScreenShareAudio && currentWatching.has(participant.identity);
-        if ((isMic || isScreenShareAudio) && publication.track) {
+        // Soundboard tracks are Source.Unknown, identified by name — always audible.
+        const isSoundboard = publication.trackName === SOUNDBOARD_TRACK_NAME;
+        if ((isMic || isScreenShareAudio || isSoundboard) && publication.track) {
           const key = `${participant.identity}-${publication.trackSid}`;
           newTracks.set(key, { participant, publication });
           logger.debug('[AudioRenderer] Found audio track for:', participant.identity);

--- a/frontend/src/components/Voice/SoundboardButton.tsx
+++ b/frontend/src/components/Voice/SoundboardButton.tsx
@@ -1,0 +1,132 @@
+import React, { useState, useCallback } from "react";
+import {
+  IconButton,
+  Tooltip,
+  Popover,
+  Box,
+  Typography,
+  CircularProgress,
+  Button,
+} from "@mui/material";
+import { LibraryMusic as LibraryMusicIcon } from "@mui/icons-material";
+import { useQuery } from "@tanstack/react-query";
+import { soundboardControllerListCommunitySoundsOptions } from "../../api-client/@tanstack/react-query.gen";
+import { logger } from "../../utils/logger";
+
+interface SoundboardButtonProps {
+  communityId: string;
+  /** Publishes the given sound to everyone in the voice channel. */
+  onPlay: (fileId: string) => Promise<void> | void;
+  isMobile?: boolean;
+}
+
+/**
+ * Bottom-bar soundboard control: a popover grid of the community's sounds.
+ * Clicking a sound triggers playback (published to the whole voice channel).
+ */
+export const SoundboardButton: React.FC<SoundboardButtonProps> = ({
+  communityId,
+  onPlay,
+  isMobile = false,
+}) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const open = Boolean(anchorEl);
+
+  const { data: sounds, isLoading } = useQuery({
+    ...soundboardControllerListCommunitySoundsOptions({
+      path: { communityId },
+    }),
+    enabled: open, // only fetch when the popover is opened
+  });
+
+  const handlePlay = useCallback(
+    async (fileId: string) => {
+      try {
+        await onPlay(fileId);
+      } catch (err) {
+        logger.error("[SoundboardButton] Failed to play sound", err);
+      }
+    },
+    [onPlay]
+  );
+
+  return (
+    <>
+      <Tooltip title="Soundboard" arrow={!isMobile}>
+        <IconButton
+          onClick={(e) => setAnchorEl(e.currentTarget)}
+          size="medium"
+          aria-label="Open soundboard"
+          sx={{
+            minWidth: isMobile ? 48 : "auto",
+            minHeight: isMobile ? 48 : "auto",
+            "&:hover": { backgroundColor: "action.hover" },
+          }}
+        >
+          <LibraryMusicIcon />
+        </IconButton>
+      </Tooltip>
+
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        transformOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        <Box sx={{ p: 2, maxWidth: 320 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Soundboard
+          </Typography>
+
+          {isLoading ? (
+            <Box display="flex" justifyContent="center" py={2}>
+              <CircularProgress size={24} />
+            </Box>
+          ) : sounds && sounds.length > 0 ? (
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: "repeat(3, 1fr)",
+                gap: 1,
+              }}
+            >
+              {sounds.map((sound) => (
+                <Button
+                  key={sound.id}
+                  variant="outlined"
+                  size="small"
+                  onClick={() => handlePlay(sound.fileId)}
+                  sx={{
+                    flexDirection: "column",
+                    textTransform: "none",
+                    minWidth: 0,
+                    px: 1,
+                  }}
+                >
+                  <span aria-hidden style={{ fontSize: "1.3rem" }}>
+                    {sound.emoji || "🔊"}
+                  </span>
+                  <Typography
+                    variant="caption"
+                    noWrap
+                    sx={{ maxWidth: 80 }}
+                    title={sound.name}
+                  >
+                    {sound.name}
+                  </Typography>
+                </Button>
+              ))}
+            </Box>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              No sounds yet. An admin can add some in community settings.
+            </Typography>
+          )}
+        </Box>
+      </Popover>
+    </>
+  );
+};
+
+export default SoundboardButton;

--- a/frontend/src/components/Voice/SoundboardButton.tsx
+++ b/frontend/src/components/Voice/SoundboardButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import {
   IconButton,
   Tooltip,
@@ -11,6 +11,8 @@ import {
 import { LibraryMusic as LibraryMusicIcon } from "@mui/icons-material";
 import { useQuery } from "@tanstack/react-query";
 import { soundboardControllerListCommunitySoundsOptions } from "../../api-client/@tanstack/react-query.gen";
+import { useRoom } from "../../hooks/useRoom";
+import { soundboardPlayer } from "../../features/voice/soundboardPlayer";
 import { logger } from "../../utils/logger";
 
 interface SoundboardButtonProps {
@@ -31,6 +33,17 @@ export const SoundboardButton: React.FC<SoundboardButtonProps> = ({
 }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const open = Boolean(anchorEl);
+  const { room } = useRoom();
+
+  // Eager-publish the (silent) soundboard track as soon as the button mounts
+  // (i.e. connected to community voice) so remote clients have already
+  // subscribed before the first clip plays — a lazy publish on first play
+  // races remote subscription (~100-500ms) and clips the sound. Disposal
+  // stays with the leave actions (leaveVoiceChannel/leaveDmVoice), not here.
+  useEffect(() => {
+    if (!room) return;
+    void soundboardPlayer.warmup(room);
+  }, [room]);
 
   const { data: sounds, isLoading } = useQuery({
     ...soundboardControllerListCommunitySoundsOptions({

--- a/frontend/src/components/Voice/VoiceBottomBar.tsx
+++ b/frontend/src/components/Voice/VoiceBottomBar.tsx
@@ -39,6 +39,7 @@ import { useReplayBufferState } from "../../contexts/ReplayBufferContext";
 import { useDebugPanelShortcut } from "../../hooks/useDebugPanelShortcut";
 import { usePushToTalk } from "../../hooks/usePushToTalk";
 import { DeviceSettingsDialog } from "./DeviceSettingsDialog";
+import { SoundboardButton } from "./SoundboardButton";
 import { ScreenSourcePicker } from "./ScreenSourcePicker";
 import { VoiceDebugPanel } from "./VoiceDebugPanel";
 import { CaptureReplayModal } from "./CaptureReplayModal";
@@ -517,6 +518,15 @@ export const VoiceBottomBar: React.FC = () => {
                   <MovieCreation />
                 </IconButton>
               </Tooltip>
+            )}
+
+            {/* Soundboard - community voice channels only */}
+            {state.isConnected && state.communityId && actions.playSoundboard && (
+              <SoundboardButton
+                communityId={state.communityId}
+                onPlay={actions.playSoundboard}
+                isMobile={isMobile}
+              />
             )}
 
             {/* Show Video Tiles - visible when tiles are hidden and user is connected */}

--- a/frontend/src/constants/rbacActions.ts
+++ b/frontend/src/constants/rbacActions.ts
@@ -88,6 +88,11 @@ export const RBAC_ACTIONS = {
   // Voice / Replay
   CAPTURE_REPLAY: 'CAPTURE_REPLAY',
 
+  // Soundboard
+  CREATE_SOUNDBOARD_SOUND: 'CREATE_SOUNDBOARD_SOUND',
+  DELETE_SOUNDBOARD_SOUND: 'DELETE_SOUNDBOARD_SOUND',
+  READ_SOUNDBOARD_SOUND: 'READ_SOUNDBOARD_SOUND',
+
   // Instance Administration
   READ_INSTANCE_SETTINGS: 'READ_INSTANCE_SETTINGS',
   UPDATE_INSTANCE_SETTINGS: 'UPDATE_INSTANCE_SETTINGS',
@@ -171,6 +176,11 @@ export const PERMISSION_GROUPS = {
     RBAC_ACTIONS.VIEW_MODERATION_LOGS,
     RBAC_ACTIONS.MUTE_PARTICIPANT,
   ],
+  'Soundboard': [
+    RBAC_ACTIONS.READ_SOUNDBOARD_SOUND,
+    RBAC_ACTIONS.CREATE_SOUNDBOARD_SOUND,
+    RBAC_ACTIONS.DELETE_SOUNDBOARD_SOUND,
+  ],
 };
 
 // Human readable action names
@@ -250,6 +260,11 @@ export const ACTION_LABELS: Record<RbacAction, string> = {
 
   // Voice / Replay
   [RBAC_ACTIONS.CAPTURE_REPLAY]: 'Capture voice replays',
+
+  // Soundboard
+  [RBAC_ACTIONS.READ_SOUNDBOARD_SOUND]: 'View soundboard sounds',
+  [RBAC_ACTIONS.CREATE_SOUNDBOARD_SOUND]: 'Add soundboard sounds',
+  [RBAC_ACTIONS.DELETE_SOUNDBOARD_SOUND]: 'Delete soundboard sounds',
 
   // Instance Administration
   [RBAC_ACTIONS.READ_INSTANCE_SETTINGS]: 'View instance settings',

--- a/frontend/src/features/voice/soundboardPlayer.ts
+++ b/frontend/src/features/voice/soundboardPlayer.ts
@@ -74,6 +74,28 @@ class SoundboardPlayer {
   }
 
   /**
+   * Eagerly build the WebAudio graph and publish the (silent) soundboard track.
+   *
+   * Called when a community voice session becomes active so the remote
+   * TrackPublished → subscribe → attach pipeline is already warm before the
+   * first clip is triggered — publishing lazily on first play() would race
+   * remote subscription (~100-500ms) and clip or swallow the first sound.
+   *
+   * Safe to call repeatedly; errors are logged, not thrown (play() retries
+   * ensurePublished as a fallback). The AudioContext may start suspended
+   * without a user gesture — that's fine: the published track just carries
+   * silence until play() resumes it on click.
+   */
+  async warmup(room: Room): Promise<void> {
+    try {
+      this.ensureContext();
+      await this.ensurePublished(room);
+    } catch (err) {
+      logger.warn('[Soundboard] Warmup failed (will retry on first play)', err);
+    }
+  }
+
+  /**
    * Fetch already handled by the caller; `arrayBuffer` is the raw encoded audio.
    * Decodes (and caches by fileId) then plays the clip, publishing the track on
    * first use. Rapid re-triggers stop the currently-playing clip and start the

--- a/frontend/src/features/voice/soundboardPlayer.ts
+++ b/frontend/src/features/voice/soundboardPlayer.ts
@@ -1,0 +1,157 @@
+import { Room, Track, LocalTrackPublication } from 'livekit-client';
+import { logger } from '../../utils/logger';
+
+/**
+ * The LiveKit `Track.Source` enum is fixed and cannot be extended, so the
+ * soundboard track is published as `Source.Unknown` and distinguished purely by
+ * this track NAME on both the publish side and the remote subscribe/render side.
+ *
+ * Both `useTrackSubscription` (auto-subscribe) and `AudioRenderer` (attach to a
+ * hidden <audio> element) match on this exact name — keep them in sync.
+ */
+export const SOUNDBOARD_TRACK_NAME = 'soundboard';
+
+/**
+ * Soundboard playback engine.
+ *
+ * Screen-share audio uses LiveKit's built-in capture; the soundboard has no such
+ * helper, so we build a WebAudio graph by hand:
+ *
+ *   decoded AudioBuffer
+ *     → AudioBufferSourceNode
+ *       ├→ MediaStreamAudioDestinationNode → MediaStreamTrack → publishTrack()  (remote participants)
+ *       └→ AudioContext.destination                                            (local monitor)
+ *
+ * The published track is kept alive for the whole voice session (published lazily
+ * on first play) rather than published/unpublished per clip. This avoids a
+ * subscribe race — republishing on every trigger would make remote clients
+ * re-subscribe each time and clip the first ~200ms of audio — and makes rapid
+ * re-triggering a cheap stop-and-restart of the source node. The track is torn
+ * down (and the AudioContext closed) when the user leaves/disconnects.
+ */
+class SoundboardPlayer {
+  private audioContext: AudioContext | null = null;
+  private destination: MediaStreamAudioDestinationNode | null = null;
+  private publication: LocalTrackPublication | null = null;
+  private currentSource: AudioBufferSourceNode | null = null;
+  private readonly bufferCache = new Map<string, AudioBuffer>();
+
+  private ensureContext(): AudioContext {
+    if (!this.audioContext || this.audioContext.state === 'closed') {
+      const Ctor =
+        window.AudioContext ||
+        (window as unknown as { webkitAudioContext: typeof AudioContext })
+          .webkitAudioContext;
+      this.audioContext = new Ctor();
+      this.destination = this.audioContext.createMediaStreamDestination();
+    }
+    if (!this.destination) {
+      this.destination = this.audioContext.createMediaStreamDestination();
+    }
+    return this.audioContext;
+  }
+
+  private async ensurePublished(room: Room): Promise<void> {
+    // Re-publish if we have no publication or it belongs to a stale room.
+    const stillPublished =
+      this.publication &&
+      room.localParticipant.trackPublications.has(this.publication.trackSid);
+    if (stillPublished) return;
+
+    this.ensureContext();
+    const track = this.destination!.stream.getAudioTracks()[0];
+    if (!track) {
+      throw new Error('Soundboard: no audio track on destination node');
+    }
+    logger.info('[Soundboard] Publishing soundboard track');
+    this.publication = await room.localParticipant.publishTrack(track, {
+      name: SOUNDBOARD_TRACK_NAME,
+      source: Track.Source.Unknown,
+      stopMicTrackOnMute: false,
+      dtx: false,
+      red: false,
+    });
+  }
+
+  /**
+   * Fetch already handled by the caller; `arrayBuffer` is the raw encoded audio.
+   * Decodes (and caches by fileId) then plays the clip, publishing the track on
+   * first use. Rapid re-triggers stop the currently-playing clip and start the
+   * new one.
+   */
+  async play(room: Room, fileId: string, arrayBuffer: ArrayBuffer): Promise<void> {
+    const ctx = this.ensureContext();
+    if (ctx.state === 'suspended') {
+      await ctx.resume();
+    }
+    await this.ensurePublished(room);
+
+    let buffer = this.bufferCache.get(fileId);
+    if (!buffer) {
+      // decodeAudioData detaches the passed buffer, so decode a copy to keep the
+      // original intact for potential retries.
+      buffer = await ctx.decodeAudioData(arrayBuffer.slice(0));
+      this.bufferCache.set(fileId, buffer);
+    }
+
+    this.stopCurrentSource();
+
+    const source = ctx.createBufferSource();
+    source.buffer = buffer;
+    source.connect(this.destination!); // → remote participants
+    source.connect(ctx.destination); // → local speakers (monitor)
+    source.onended = () => {
+      if (this.currentSource === source) {
+        this.currentSource = null;
+      }
+    };
+    this.currentSource = source;
+    source.start();
+    logger.info('[Soundboard] Playing sound', fileId);
+  }
+
+  private stopCurrentSource(): void {
+    if (this.currentSource) {
+      try {
+        this.currentSource.onended = null;
+        this.currentSource.stop();
+      } catch {
+        // already stopped
+      }
+      this.currentSource = null;
+    }
+  }
+
+  /**
+   * Stop playback, unpublish the track, and close the AudioContext. Safe to call
+   * repeatedly and when nothing has been published.
+   */
+  async dispose(room: Room | null): Promise<void> {
+    this.stopCurrentSource();
+
+    if (this.publication && room) {
+      try {
+        const track = this.publication.track;
+        if (track) {
+          await room.localParticipant.unpublishTrack(track);
+        }
+      } catch (err) {
+        logger.warn('[Soundboard] Failed to unpublish soundboard track', err);
+      }
+    }
+    this.publication = null;
+
+    if (this.audioContext && this.audioContext.state !== 'closed') {
+      try {
+        await this.audioContext.close();
+      } catch (err) {
+        logger.warn('[Soundboard] Failed to close AudioContext', err);
+      }
+    }
+    this.audioContext = null;
+    this.destination = null;
+    this.bufferCache.clear();
+  }
+}
+
+export const soundboardPlayer = new SoundboardPlayer();

--- a/frontend/src/features/voice/voiceActions.ts
+++ b/frontend/src/features/voice/voiceActions.ts
@@ -8,7 +8,9 @@ import { getResolutionConfig, getScreenShareAudioConfig } from "../../utils/scre
 import { logger } from "../../utils/logger";
 import { isElectron } from "../../utils/platform";
 import { getCachedItem, setCachedItem, removeCachedItem } from "../../utils/storage";
-import { refreshToken as refreshAuthToken } from "../../utils/tokenService";
+import { refreshToken as refreshAuthToken, getAccessToken } from "../../utils/tokenService";
+import { getApiUrl } from "../../config/env";
+import { soundboardPlayer } from "./soundboardPlayer";
 import { installLivekitWorkerTimers } from "../../utils/livekitWorkerTimers";
 import { playSound, Sounds } from "../../hooks/useSound";
 import { setUpdateDeferred } from "../../utils/swUpdate";
@@ -408,6 +410,10 @@ export async function leaveVoiceChannel(deps: VoiceActionDeps) {
       logger.warn('[Voice] Failed to remove voice presence (webhook will handle it):', err);
     }
 
+    // Tear down the soundboard graph before disconnecting so the published
+    // track/AudioContext don't leak across sessions.
+    await soundboardPlayer.dispose(room).catch(() => {});
+
     logger.info('[Voice] Disconnecting from LiveKit room...');
     await room.disconnect();
     logger.info('[Voice] Disconnected from LiveKit');
@@ -511,6 +517,7 @@ export async function leaveDmVoice(deps: VoiceActionDeps) {
   if (!currentDmGroupId || !room) return;
 
   try {
+    await soundboardPlayer.dispose(room).catch(() => {});
     await room.disconnect();
     setRoom(null);
     dispatch({ type: VoiceActionType.SetDisconnected });
@@ -562,6 +569,36 @@ export async function toggleMicrophone(deps: VoiceActionDeps) {
     logger.error("[Voice] Failed to toggle microphone:", error);
     throw error;
   }
+}
+
+/**
+ * Play a soundboard sound to everyone in the voice channel.
+ *
+ * Fetches the authenticated audio blob for `fileId`, then hands it to the
+ * WebAudio-backed soundboard player which publishes a mixed track into the
+ * LiveKit room (audible to remote participants) and monitors locally.
+ */
+export async function playSoundboard(fileId: string, deps: VoiceActionDeps) {
+  const room = deps.getRoom();
+  if (!room) {
+    logger.warn('[Voice] playSoundboard: not connected to a room');
+    return;
+  }
+
+  const token = getAccessToken();
+  if (!token) {
+    throw new Error('Not authenticated');
+  }
+
+  const response = await fetch(getApiUrl(`/file/${fileId}`), {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch soundboard sound (${response.status})`);
+  }
+  const arrayBuffer = await response.arrayBuffer();
+
+  await soundboardPlayer.play(room, fileId, arrayBuffer);
 }
 
 export async function toggleCameraUnified(deps: VoiceActionDeps) {

--- a/frontend/src/hooks/useDeafenEffect.ts
+++ b/frontend/src/hooks/useDeafenEffect.ts
@@ -6,9 +6,25 @@ import { Track } from 'livekit-client';
 import { audioBoostManager, boostKey } from '../features/voice/audioBoostManager';
 import { isBoostableAudioTrack } from '../features/voice/isBoostableAudioTrack';
 import { getStoredVolumePercent } from '../features/voice/volumeStorage';
+import { SOUNDBOARD_TRACK_NAME } from '../features/voice/soundboardPlayer';
 
 function isBoostableAudioSource(source: Track.Source | string): boolean {
   return source === Track.Source.Microphone || source === Track.Source.ScreenShareAudio;
+}
+
+/**
+ * Deafen must silence every remote audio path. Soundboard tracks are published
+ * as Source.Unknown and identified by their publication NAME, so match on that
+ * in addition to the boostable sources.
+ */
+function isDeafenableAudioPublication(publication: {
+  source: Track.Source | string;
+  trackName?: string;
+}): boolean {
+  return (
+    isBoostableAudioSource(publication.source) ||
+    publication.trackName === SOUNDBOARD_TRACK_NAME
+  );
 }
 
 /**
@@ -43,7 +59,7 @@ export const useDeafenEffect = () => {
       room.remoteParticipants.forEach((participant) => {
         participant.audioTrackPublications.forEach((publication) => {
           const { track } = publication;
-          if (track && isBoostableAudioTrack(track) && isBoostableAudioSource(publication.source)) {
+          if (track && isBoostableAudioTrack(track) && isDeafenableAudioPublication(publication)) {
             track.setVolume(0);
           }
         });
@@ -55,7 +71,8 @@ export const useDeafenEffect = () => {
       room.remoteParticipants.forEach((participant) => {
         participant.audioTrackPublications.forEach((publication) => {
           const { track } = publication;
-          if (track && isBoostableAudioTrack(track) && isBoostableAudioSource(publication.source)) {
+          if (track && isBoostableAudioTrack(track) && isDeafenableAudioPublication(publication)) {
+            // Soundboard tracks have no per-user stored volume; fall back to 100%.
             const volumePercent =
               getStoredVolumePercent(participant.identity, publication.source) ?? 100;
             audioBoostManager.applyVolume(

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -8,7 +8,8 @@ export type ResourceType =
   | "COMMUNITY_AVATAR"
   | "COMMUNITY_BANNER"
   | "MESSAGE_ATTACHMENT"
-  | "CUSTOM_EMOJI";
+  | "CUSTOM_EMOJI"
+  | "SOUNDBOARD_SOUND";
 
 interface UploadFileOptions {
   resourceType: ResourceType;

--- a/frontend/src/hooks/useTrackSubscription.ts
+++ b/frontend/src/hooks/useTrackSubscription.ts
@@ -9,6 +9,18 @@ import {
 import { useRoom } from './useRoom';
 import { useVoiceDispatch, VoiceActionType } from '../contexts/VoiceContext';
 import { logger } from '../utils/logger';
+import { SOUNDBOARD_TRACK_NAME } from '../features/voice/soundboardPlayer';
+
+/**
+ * Soundboard tracks are published as Track.Source.Unknown (the enum is fixed and
+ * can't be extended), so they're identified by their publication NAME. They must
+ * be auto-subscribed like the mic, otherwise remote clients never hear them.
+ */
+function isSoundboardPublication(publication: {
+  trackName?: string;
+}): boolean {
+  return publication.trackName === SOUNDBOARD_TRACK_NAME;
+}
 
 /**
  * Duck-types a TrackPublication as a RemoteTrackPublication. Avoids relying on
@@ -97,11 +109,14 @@ function forceResubscribePublication(publication: RemoteTrackPublication, reason
 function applySubscriptionPolicy(participant: RemoteParticipant, force = false) {
   for (const [, publication] of participant.trackPublications) {
     if (!isRemotePublication(publication)) continue;
-    if (publication.source === Track.Source.Microphone) {
+    if (
+      publication.source === Track.Source.Microphone ||
+      isSoundboardPublication(publication)
+    ) {
       if (force) {
-        forceResubscribePublication(publication, `reconnect-resubscribe-mic:${participant.identity}`);
+        forceResubscribePublication(publication, `reconnect-resubscribe:${participant.identity}`);
       } else {
-        subscribePublication(publication, `auto-subscribe-mic:${participant.identity}`);
+        subscribePublication(publication, `auto-subscribe:${participant.identity}`);
       }
     } else if (isOptInSource(publication.source)) {
       unsubscribePublication(publication, `initial-unsubscribe:${participant.identity}`);
@@ -153,9 +168,12 @@ export function useTrackSubscription(): TrackSubscriptionActions {
       participant: RemoteParticipant,
     ) => {
       if (!isRemotePublication(publication)) return;
-      logger.info('[TrackSubscription] TrackPublished', participant.identity, publication.source, publication.trackSid);
-      if (publication.source === Track.Source.Microphone) {
-        subscribePublication(publication, `published-mic:${participant.identity}`);
+      logger.info('[TrackSubscription] TrackPublished', participant.identity, publication.source, publication.trackSid, publication.trackName);
+      if (
+        publication.source === Track.Source.Microphone ||
+        isSoundboardPublication(publication)
+      ) {
+        subscribePublication(publication, `published-audio:${participant.identity}`);
       } else if (isOptInSource(publication.source)) {
         unsubscribePublication(publication, `published:${participant.identity}`);
         // Surface new screen shares: open the video panel so the viewer sees

--- a/frontend/src/hooks/useVoiceConnection.ts
+++ b/frontend/src/hooks/useVoiceConnection.ts
@@ -17,6 +17,7 @@ import {
   switchAudioInputDevice,
   switchAudioOutputDevice,
   switchVideoInputDevice,
+  playSoundboard,
 } from "../features/voice/voiceActions";
 import { useTrackSubscriptionActions } from "./useTrackSubscription";
 
@@ -205,6 +206,13 @@ export const useVoiceConnection = () => {
     dispatch({ type: VoiceActionType.SetRequestMaximize, payload: true });
   }, [dispatch]);
 
+  const handlePlaySoundboard = useCallback(
+    async (fileId: string) => {
+      await playSoundboard(fileId, getDeps());
+    },
+    [getDeps]
+  );
+
   const trackActions = useTrackSubscriptionActions();
 
   return {
@@ -223,6 +231,7 @@ export const useVoiceConnection = () => {
       switchAudioOutputDevice: handleSwitchAudioOutputDevice,
       switchVideoInputDevice: handleSwitchVideoInputDevice,
       requestMaximize: handleRequestMaximize,
+      playSoundboard: handlePlaySoundboard,
       watchCamera: trackActions?.watchCamera ?? undefined,
       stopWatchingCamera: trackActions?.stopWatchingCamera ?? undefined,
       watchScreenShare: trackActions?.watchScreenShare ?? undefined,

--- a/frontend/src/pages/EditCommunityPage.tsx
+++ b/frontend/src/pages/EditCommunityPage.tsx
@@ -33,6 +33,7 @@ import {
   RoleManagement,
   AliasGroupManagement,
   CustomEmojiManagement,
+  SoundboardManagement,
 } from "../components/Community";
 import {
   BanListPanel,
@@ -273,6 +274,7 @@ const EditCommunityPage: React.FC = () => {
             <Tab label="Mention Groups" {...a11yProps(5)} />
             <Tab label="Custom Emoji" {...a11yProps(6)} disabled={!canManageEmojis} />
             <Tab label="Moderation" {...a11yProps(7)} disabled={!canViewModeration} />
+            <Tab label="Soundboard" {...a11yProps(8)} />
           </Tabs>
         </Box>
 
@@ -386,6 +388,10 @@ const EditCommunityPage: React.FC = () => {
               You don't have permission to view moderation tools.
             </Alert>
           )}
+        </TabPanel>
+
+        <TabPanel value={tabValue} index={8}>
+          <SoundboardManagement communityId={communityId!} />
         </TabPanel>
       </Paper>
     </Root>


### PR DESCRIPTION
Closes #292.

Discord-style soundboard: admins upload short audio clips to a community; while connected to one of that community's voice channels, any member can click a sound and it plays **audibly to everyone in the channel**.

## How "audible to remote participants" works (the risky part)

The app connects to LiveKit with `autoSubscribe: false` and renders remote audio through an explicit allowlist, so a naively published track would be silent to everyone. Three coordinated pieces fix that:

1. **Publish (net-new WebAudio path)** — `frontend/src/features/voice/soundboardPlayer.ts` decodes the clip into an `AudioBuffer`, plays it through `AudioBufferSourceNode → MediaStreamAudioDestinationNode`, and publishes that node's `MediaStreamTrack` via `room.localParticipant.publishTrack(track, { name: 'soundboard', source: Track.Source.Unknown })`. LiveKit's `Track.Source` enum is fixed, so the track is identified **by its name** (`SOUNDBOARD_TRACK_NAME = 'soundboard'`), not its source — publishing as `Source.Microphone` would collide with the real mic. The source node also connects to `ctx.destination` so the sender hears their own clip.
2. **Subscribe** — `useTrackSubscription.ts` now auto-subscribes any remote publication whose `trackName === 'soundboard'` (same treatment as mics: on publish, on participant connect, and force-resubscribe after reconnect). Without this, remote clients never receive the audio.
3. **Render** — `AudioRenderer.tsx`'s allowlist now includes soundboard tracks (matched by name), so a hidden `<audio autoPlay>` element is attached like mic audio. Not gated on `watchingScreenShares`.

Lifecycle: the track is published lazily on first play and kept for the whole session (republishing per clip would race remote re-subscription and clip the first ~200ms). Rapid re-trigger = stop-and-restart of the source node; decoded buffers are cached per fileId. `soundboardPlayer.dispose()` (unpublish + close AudioContext + clear cache) runs in both `leaveVoiceChannel` and `leaveDmVoice`. Mic device switching, deafen, and per-user volume paths are untouched (deafen/volume-boost only handle Microphone/ScreenShareAudio sources; the soundboard track plays at element default).

## Backend

- **Model**: `SoundboardSound { id, communityId, name, emoji?, fileId → File, createdBy?, createdAt, @@unique([communityId, name]) }`; migration `20260705024702_soundboard`. The auto-generated migration wanted to drop `Message.searchVector` (known Prisma drift with the generated tsvector column, see `20260307210420_restore_search_vector`) — those statements were hand-pruned.
- **Endpoints** (`/api/soundboard`): `GET community/:communityId` (list), `POST community/:communityId` (create from a previously-uploaded fileId), `DELETE community/:communityId/:soundId`. All community-scoped via `@RbacResource(COMMUNITY)`.
- **RBAC**: new `READ/CREATE/DELETE_SOUNDBOARD_SOUND` actions. Default roles: Community Admin + Moderator get manage; Member gets READ. Community Creator instance role gets manage.
- **Files**: `ResourceType.SOUNDBOARD_SOUND` maps to the `fileCommunityId` FK; validation strategy allows `audio/mpeg|wav|x-wav|ogg|webm|aac`, ≤1MB; file access uses the community-membership strategy; serving reuses the existing `GET /file/:id` streaming endpoint.
- Create flow validates the referenced file exists, is a `SOUNDBOARD_SOUND` belonging to the same community, and isn't already used by another sound; delete also removes the backing file row.

## UI

- **Voice bar**: `SoundboardButton` popover (grid of emoji+name buttons) in `VoiceBottomBar`, shown only when connected to a community voice channel (not DM calls).
- **Management**: new "Soundboard" tab (index 7) in `EditCommunityPage` → `SoundboardManagement` (list/upload/delete, permission-gated per action, local preview button using the authenticated-blob hook).

## Tests

- Backend: `soundboard.service.spec.ts` (create/list/delete, name uniqueness, cross-community file rejection, file-reuse conflict, community scoping on delete), `soundboard.controller.spec.ts`, `soundboard-sound-validation.strategy.spec.ts`; existing validator/guard/default-roles specs updated and passing (97 tests across the 6 affected suites).
- Frontend: `soundboardPlayer.test.ts` (publishes named `Source.Unknown` track once per session, buffer caching, stop-and-restart, dispose unpublishes + closes context), `SoundboardManagement.test.tsx` (list/empty/create-with-upload/delete via MSW), new `AudioRenderer` case locking in the render allowlist. 47 tests across the 4 targeted files pass; `type-check` and `lint` clean. Full frontend suite not run in one shot due to the known WSL2 OOM/timeout baseline — my files were verified in isolation.

## Needs manual verification (two browsers)

The end-to-end audible-to-remote path (real SFU forwarding of the WebAudio-sourced track, subscription timing on the first-ever play, no clipped onset) is **not** covered by unit tests and needs a two-browser check against the dev stack:
1. Both users in the same voice channel, user A opens the soundboard and plays a clip → B hears it, A hears it locally.
2. Play immediately again mid-clip (stop-and-restart), and after a reconnect (force-resubscribe path).
3. Confirm B's mic/deafen/per-user-volume still behave, and A's mic device switch mid-session doesn't kill the soundboard track.

~~Also worth a look: whether soundboard should respect the receiver's deafen state.~~ **Resolved in review fixes**: deafen now silences soundboard tracks too (`useDeafenEffect` matches them by track name).

## Review fixes (second commit)

- **Deafen coverage**: soundboard tracks (Source.Unknown, matched by `trackName === 'soundboard'`) are now muted/restored by `useDeafenEffect`; unnamed Unknown tracks unaffected. Tests added.
- **Delete no longer leaks storage/quota**: `deleteSound` soft-deletes the backing file via `fileUploadService.remove()` using the **uploader's** id (quota credited back, storage reaper collects the blob), with a direct `deletedAt` fallback when the uploader account was deleted. No more raw `file.delete`.
- **First-clip race**: `soundboardPlayer.warmup()` eagerly publishes the silent track when `SoundboardButton` mounts, so remote subscribe/attach is warm before the first play. Dispose semantics unchanged.
- **P2002 TOCTOU**: concurrent duplicate-name creates now return 409 Conflict instead of 500.

## Release note

⚠️ **Existing communities will not have the new `READ/CREATE/DELETE_SOUNDBOARD_SOUND` permissions** until an admin runs reset-default-roles for the community (matches repo precedent for prior RBAC action additions). The k8s instance needs this after deploy — until then, existing members won't see/manage soundboard even though the endpoints exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDq3CGGinSAbEWtoPrMmDb
