### PR TITLE
feat(community): custom emojis (#300)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7052,6 +7052,111 @@
           "AliasGroups"
         ]
       }
+    },
+    "/api/custom-emoji/community/{communityId}": {
+      "get": {
+        "operationId": "CustomEmojiController_listCommunityEmojis",
+        "parameters": [
+          {
+            "name": "communityId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomEmojiDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List all custom emojis for a community. Available to any community member.",
+        "tags": [
+          "CustomEmoji"
+        ]
+      },
+      "post": {
+        "operationId": "CustomEmojiController_createEmoji",
+        "parameters": [
+          {
+            "name": "communityId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCustomEmojiDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomEmojiDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Register a new custom emoji from an uploaded CUSTOM_EMOJI file.",
+        "tags": [
+          "CustomEmoji"
+        ]
+      }
+    },
+    "/api/custom-emoji/community/{communityId}/{emojiId}": {
+      "delete": {
+        "operationId": "CustomEmojiController_deleteEmoji",
+        "parameters": [
+          {
+            "name": "communityId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "emojiId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Delete a custom emoji from a community.",
+        "tags": [
+          "CustomEmoji"
+        ]
+      }
     }
   },
   "info": {
@@ -7699,7 +7804,8 @@
                 "DELETE_ANY_MESSAGE",
                 "VIEW_BAN_LIST",
                 "VIEW_MODERATION_LOGS",
-                "MUTE_PARTICIPANT"
+                "MUTE_PARTICIPANT",
+                "MANAGE_EMOJIS"
               ]
             }
           },
@@ -7858,7 +7964,8 @@
                 "DELETE_ANY_MESSAGE",
                 "VIEW_BAN_LIST",
                 "VIEW_MODERATION_LOGS",
-                "MUTE_PARTICIPANT"
+                "MUTE_PARTICIPANT",
+                "MANAGE_EMOJIS"
               ]
             }
           },
@@ -7939,7 +8046,8 @@
                 "DELETE_ANY_MESSAGE",
                 "VIEW_BAN_LIST",
                 "VIEW_MODERATION_LOGS",
-                "MUTE_PARTICIPANT"
+                "MUTE_PARTICIPANT",
+                "MANAGE_EMOJIS"
               ]
             }
           },
@@ -8316,7 +8424,8 @@
               "SPECIAL_MENTION",
               "COMMUNITY_MENTION",
               "ALIAS_MENTION",
-              "CODE_BLOCK"
+              "CODE_BLOCK",
+              "EMOJI"
             ]
           },
           "text": {
@@ -8336,6 +8445,10 @@
             "nullable": true
           },
           "aliasId": {
+            "type": "string",
+            "nullable": true
+          },
+          "emojiId": {
             "type": "string",
             "nullable": true
           },
@@ -8362,7 +8475,8 @@
           "userId",
           "specialKind",
           "communityId",
-          "aliasId"
+          "aliasId",
+          "emojiId"
         ]
       },
       "CreateMessageDto": {
@@ -8519,8 +8633,13 @@
               "SPECIAL_MENTION",
               "COMMUNITY_MENTION",
               "ALIAS_MENTION",
-              "CODE_BLOCK"
+              "CODE_BLOCK",
+              "EMOJI"
             ]
+          },
+          "emojiId": {
+            "type": "string",
+            "nullable": true
           },
           "bold": {
             "type": "boolean",
@@ -12559,6 +12678,56 @@
         },
         "required": [
           "memberIds"
+        ]
+      },
+      "CustomEmojiDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "communityId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "fileId": {
+            "type": "string"
+          },
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "communityId",
+          "name",
+          "fileId",
+          "createdBy",
+          "createdAt"
+        ]
+      },
+      "CreateCustomEmojiDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "CUSTOM_EMOJI_NAME_REGEX"
+          },
+          "fileId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "name",
+          "fileId"
         ]
       }
     }

--- a/backend/prisma/migrations/20260705082747_custom_emojis/migration.sql
+++ b/backend/prisma/migrations/20260705082747_custom_emojis/migration.sql
@@ -1,0 +1,35 @@
+-- AlterEnum
+ALTER TYPE "RbacActions" ADD VALUE 'MANAGE_EMOJIS';
+
+-- AlterEnum
+ALTER TYPE "SpanType" ADD VALUE 'EMOJI';
+
+-- AlterTable
+ALTER TABLE "MessageSpan" ADD COLUMN     "emojiId" TEXT;
+
+-- CreateTable
+CREATE TABLE "CustomEmoji" (
+    "id" TEXT NOT NULL,
+    "communityId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "fileId" TEXT NOT NULL,
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CustomEmoji_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CustomEmoji_communityId_idx" ON "CustomEmoji"("communityId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CustomEmoji_communityId_name_key" ON "CustomEmoji"("communityId", "name");
+
+-- AddForeignKey
+ALTER TABLE "MessageSpan" ADD CONSTRAINT "MessageSpan_emojiId_fkey" FOREIGN KEY ("emojiId") REFERENCES "CustomEmoji"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CustomEmoji" ADD CONSTRAINT "CustomEmoji_communityId_fkey" FOREIGN KEY ("communityId") REFERENCES "Community"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CustomEmoji" ADD CONSTRAINT "CustomEmoji_fileId_fkey" FOREIGN KEY ("fileId") REFERENCES "File"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -89,6 +89,7 @@ model MessageSpan {
   specialKind String? // For SPECIAL_MENTION: "here", "channel"
   communityId String? // For COMMUNITY_MENTION
   aliasId     String? // For ALIAS_MENTION
+  emojiId     String? // For EMOJI (community custom emoji)
 
   // Composable inline-formatting flags (PLAINTEXT spans). CODE_BLOCK spans use
   // the CODE_BLOCK type; `code` marks an inline code run.
@@ -97,10 +98,11 @@ model MessageSpan {
   strikethrough Boolean? // For PLAINTEXT: strikethrough run
   code          Boolean? // For PLAINTEXT: inline `code` run
 
-  message    Message     @relation(fields: [messageId], references: [id], onDelete: Cascade)
-  user       User?       @relation("SpanUser", fields: [userId], references: [id], onDelete: SetNull)
-  community  Community?  @relation("SpanCommunity", fields: [communityId], references: [id], onDelete: SetNull)
-  aliasGroup AliasGroup? @relation("SpanAlias", fields: [aliasId], references: [id], onDelete: SetNull)
+  message    Message      @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  user       User?        @relation("SpanUser", fields: [userId], references: [id], onDelete: SetNull)
+  community  Community?   @relation("SpanCommunity", fields: [communityId], references: [id], onDelete: SetNull)
+  aliasGroup AliasGroup?  @relation("SpanAlias", fields: [aliasId], references: [id], onDelete: SetNull)
+  emoji      CustomEmoji? @relation("SpanEmoji", fields: [emojiId], references: [id], onDelete: SetNull)
 
   @@index([messageId])
 }
@@ -458,8 +460,25 @@ model Community {
   mentionSpans  MessageSpan[] @relation("SpanCommunity")
   aliasGroups   AliasGroup[]  @relation("AliasGroupCommunity")
   resourceFiles File[]        @relation("FileResourceCommunity")
+  customEmojis  CustomEmoji[] @relation("CommunityCustomEmojis")
 
   @@unique([name])
+}
+
+model CustomEmoji {
+  id          String   @id @default(uuid())
+  communityId String
+  name        String // shortcode (without colons), e.g. "party_blob"
+  fileId      String
+  createdBy   String? // userId of the creator (audit only, no FK)
+  createdAt   DateTime @default(now())
+
+  community Community     @relation("CommunityCustomEmojis", fields: [communityId], references: [id], onDelete: Cascade)
+  file      File          @relation("CustomEmojiFile", fields: [fileId], references: [id], onDelete: Cascade)
+  spans     MessageSpan[] @relation("SpanEmoji")
+
+  @@unique([communityId, name])
+  @@index([communityId])
 }
 
 model Channel {
@@ -634,6 +653,7 @@ model File {
   // Relations
   replayClips        ReplayClip[]
   messageAttachments MessageAttachment[]
+  customEmojis       CustomEmoji[]       @relation("CustomEmojiFile")
 
   // Avatar/banner back-references
   userAvatars      User[]      @relation("UserAvatar")
@@ -830,6 +850,7 @@ enum RbacActions {
   VIEW_BAN_LIST
   VIEW_MODERATION_LOGS
   MUTE_PARTICIPANT
+  MANAGE_EMOJIS
 }
 
 enum InstanceRole {
@@ -877,4 +898,5 @@ enum SpanType {
   COMMUNITY_MENTION
   ALIAS_MENTION
   CODE_BLOCK
+  EMOJI
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -47,6 +47,7 @@ import { FriendsModule } from './friends/friends.module';
 import { ThreadsModule } from './threads/threads.module';
 import { StorageQuotaModule } from './storage-quota/storage-quota.module';
 import { AliasGroupsModule } from './alias-groups/alias-groups.module';
+import { CustomEmojiModule } from './custom-emoji/custom-emoji.module';
 import { DebugModule } from './debug/debug.module';
 import { MetricsModule } from './metrics/metrics.module';
 import { JwtAuthGuard } from './auth/jwt-auth.guard';
@@ -118,6 +119,7 @@ import { JwtAuthGuard } from './auth/jwt-auth.guard';
     ThreadsModule,
     StorageQuotaModule,
     AliasGroupsModule,
+    CustomEmojiModule,
     ...(process.env.ADMIN_DEBUG_PANEL === 'true' ? [DebugModule] : []),
     // Prometheus metrics (/api/metrics) — opt-in only; when disabled the
     // module isn't imported, so the endpoint does not exist.

--- a/backend/src/common/enums/swagger-enums.ts
+++ b/backend/src/common/enums/swagger-enums.ts
@@ -14,6 +14,7 @@ export const SpanTypeValues = [
   'COMMUNITY_MENTION',
   'ALIAS_MENTION',
   'CODE_BLOCK',
+  'EMOJI',
 ] as const;
 
 export const FileTypeValues = [
@@ -102,6 +103,7 @@ export const RbacActionsValues = [
   'VIEW_BAN_LIST',
   'VIEW_MODERATION_LOGS',
   'MUTE_PARTICIPANT',
+  'MANAGE_EMOJIS',
 ] as const;
 
 export const InstanceRoleValues = ['OWNER', 'USER'] as const;

--- a/backend/src/common/utils/emoji-span.utils.spec.ts
+++ b/backend/src/common/utils/emoji-span.utils.spec.ts
@@ -1,0 +1,145 @@
+import { SpanType } from '@prisma/client';
+import { sanitizeEmojiSpans } from './emoji-span.utils';
+
+/** Minimal db double matching the surface sanitizeEmojiSpans consumes. */
+function createDb(overrides?: {
+  communityId?: string | null;
+  validEmojiIds?: string[];
+}) {
+  return {
+    channel: {
+      findUnique: jest
+        .fn()
+        .mockResolvedValue(
+          overrides && 'communityId' in overrides
+            ? { communityId: overrides.communityId ?? null }
+            : { communityId: 'community-1' },
+        ),
+    },
+    customEmoji: {
+      findMany: jest
+        .fn()
+        .mockResolvedValue(
+          (overrides?.validEmojiIds ?? []).map((id) => ({ id })),
+        ),
+    },
+  };
+}
+
+const plaintext = (text: string) => ({
+  type: SpanType.PLAINTEXT,
+  text,
+  emojiId: null,
+});
+
+const emoji = (text: string, emojiId: string | null) => ({
+  type: SpanType.EMOJI,
+  text,
+  emojiId,
+});
+
+describe('sanitizeEmojiSpans', () => {
+  it('is a no-op (no DB round-trips) when there are no EMOJI spans', async () => {
+    const db = createDb();
+    const spans = [plaintext('hello'), plaintext('world')];
+
+    const result = await sanitizeEmojiSpans(db, spans, 'channel-1');
+
+    expect(result).toBe(spans);
+    expect(db.channel.findUnique).not.toHaveBeenCalled();
+    expect(db.customEmoji.findMany).not.toHaveBeenCalled();
+  });
+
+  it('keeps EMOJI spans whose emojiId belongs to the channel community', async () => {
+    const db = createDb({ validEmojiIds: ['emoji-1'] });
+    const spans = [plaintext('hi '), emoji(':smile:', 'emoji-1')];
+
+    const result = await sanitizeEmojiSpans(db, spans, 'channel-1');
+
+    expect(result[1]).toEqual(emoji(':smile:', 'emoji-1'));
+    expect(db.customEmoji.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ['emoji-1'] }, communityId: 'community-1' },
+      select: { id: true },
+    });
+  });
+
+  it('downgrades EMOJI spans with a non-existent emojiId to PLAINTEXT, keeping text', async () => {
+    const db = createDb({ validEmojiIds: [] });
+    const spans = [emoji(':ghost:', 'does-not-exist')];
+
+    const result = await sanitizeEmojiSpans(db, spans, 'channel-1');
+
+    expect(result[0]).toEqual({
+      type: SpanType.PLAINTEXT,
+      text: ':ghost:',
+      emojiId: null,
+    });
+  });
+
+  it("downgrades EMOJI spans referencing another community's emoji", async () => {
+    // findMany scoped by communityId returns nothing for the foreign emoji
+    const db = createDb({ validEmojiIds: [] });
+    const spans = [emoji(':foreign:', 'emoji-from-other-community')];
+
+    const result = await sanitizeEmojiSpans(db, spans, 'channel-1');
+
+    expect(result[0].type).toBe(SpanType.PLAINTEXT);
+    expect(result[0].emojiId).toBeNull();
+  });
+
+  it('downgrades an EMOJI span with a null emojiId without querying emojis', async () => {
+    const db = createDb();
+    const spans = [emoji(':empty:', null)];
+
+    const result = await sanitizeEmojiSpans(db, spans, 'channel-1');
+
+    expect(result[0].type).toBe(SpanType.PLAINTEXT);
+    expect(db.customEmoji.findMany).not.toHaveBeenCalled();
+  });
+
+  it('downgrades all EMOJI spans in a DM (no channelId, no community)', async () => {
+    const db = createDb();
+    const spans = [emoji(':smile:', 'emoji-1')];
+
+    const result = await sanitizeEmojiSpans(db, spans, null);
+
+    expect(result[0]).toEqual({
+      type: SpanType.PLAINTEXT,
+      text: ':smile:',
+      emojiId: null,
+    });
+    expect(db.channel.findUnique).not.toHaveBeenCalled();
+    expect(db.customEmoji.findMany).not.toHaveBeenCalled();
+  });
+
+  it('downgrades all EMOJI spans when the channel has no community', async () => {
+    const db = createDb({ communityId: null });
+    const spans = [emoji(':smile:', 'emoji-1')];
+
+    const result = await sanitizeEmojiSpans(db, spans, 'channel-1');
+
+    expect(result[0].type).toBe(SpanType.PLAINTEXT);
+    expect(db.customEmoji.findMany).not.toHaveBeenCalled();
+  });
+
+  it('validates a mix: keeps valid, downgrades invalid, leaves plaintext untouched', async () => {
+    const db = createDb({ validEmojiIds: ['good'] });
+    const spans = [
+      plaintext('a '),
+      emoji(':good:', 'good'),
+      plaintext(' b '),
+      emoji(':bad:', 'bad'),
+    ];
+
+    const result = await sanitizeEmojiSpans(db, spans, 'channel-1');
+
+    expect(result[0]).toEqual(plaintext('a '));
+    expect(result[1]).toEqual(emoji(':good:', 'good'));
+    expect(result[2]).toEqual(plaintext(' b '));
+    expect(result[3]).toEqual({
+      type: SpanType.PLAINTEXT,
+      text: ':bad:',
+      emojiId: null,
+    });
+  });
+});

--- a/backend/src/common/utils/emoji-span.utils.ts
+++ b/backend/src/common/utils/emoji-span.utils.ts
@@ -1,0 +1,73 @@
+import { $Enums, SpanType } from '@prisma/client';
+
+interface EmojiSpanLike {
+  type: $Enums.SpanType;
+  emojiId?: string | null;
+}
+
+/** Minimal Prisma-client surface needed for emoji span validation. */
+interface EmojiSpanDb {
+  channel: {
+    findUnique(args: {
+      where: { id: string };
+      select: { communityId: true };
+    }): Promise<{ communityId: string | null } | null>;
+  };
+  customEmoji: {
+    findMany(args: {
+      where: { id: { in: string[] }; communityId: string };
+      select: { id: true };
+    }): Promise<{ id: string }[]>;
+  };
+}
+
+/**
+ * Validate EMOJI spans' `emojiId` against the target channel's community
+ * before persisting.
+ *
+ * Without this, a hand-crafted EMOJI span referencing a non-existent emoji
+ * hits the `MessageSpan.emojiId` FK (Prisma P2003) and surfaces as a 500,
+ * and a valid emoji from a *different* community would leak cross-community.
+ *
+ * Invalid EMOJI spans are converted to PLAINTEXT (keeping their
+ * `:shortcode:` text) rather than rejecting the whole message. In DMs
+ * (no channel) all EMOJI spans are converted.
+ *
+ * No-op (no DB round-trips) when the message contains no EMOJI spans.
+ */
+export async function sanitizeEmojiSpans<T extends EmojiSpanLike>(
+  db: EmojiSpanDb,
+  spans: T[],
+  channelId: string | null | undefined,
+): Promise<T[]> {
+  if (!spans.some((s) => s.type === SpanType.EMOJI)) return spans;
+
+  const emojiIds = [
+    ...new Set(
+      spans
+        .filter((s) => s.type === SpanType.EMOJI && s.emojiId)
+        .map((s) => s.emojiId as string),
+    ),
+  ];
+
+  let validIds = new Set<string>();
+  if (channelId && emojiIds.length > 0) {
+    const channel = await db.channel.findUnique({
+      where: { id: channelId },
+      select: { communityId: true },
+    });
+    if (channel?.communityId) {
+      const emojis = await db.customEmoji.findMany({
+        where: { id: { in: emojiIds }, communityId: channel.communityId },
+        select: { id: true },
+      });
+      validIds = new Set(emojis.map((e) => e.id));
+    }
+  }
+
+  return spans.map((s) =>
+    s.type === SpanType.EMOJI && (!s.emojiId || !validIds.has(s.emojiId))
+      ? { ...s, type: SpanType.PLAINTEXT, emojiId: null }
+      : s,
+  );
+}

--- a/backend/src/custom-emoji/custom-emoji.controller.spec.ts
+++ b/backend/src/custom-emoji/custom-emoji.controller.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed } from '@suites/unit';
+import type { Mocked } from '@suites/doubles.jest';
+import { CustomEmojiController } from './custom-emoji.controller';
+import { CustomEmojiService } from './custom-emoji.service';
+import type { AuthenticatedRequest } from '@/types';
+
+describe('CustomEmojiController', () => {
+  let controller: CustomEmojiController;
+  let service: Mocked<CustomEmojiService>;
+
+  const communityId = 'comm-1';
+  const emojiId = 'emoji-1';
+  const userId = 'user-1';
+  const req = { user: { id: userId } } as AuthenticatedRequest;
+
+  const mockEmoji = {
+    id: emojiId,
+    communityId,
+    name: 'party_blob',
+    fileId: 'file-1',
+    createdBy: userId,
+    createdAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(
+      CustomEmojiController,
+    ).compile();
+
+    controller = unit;
+    service = unitRef.get(CustomEmojiService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('lists community emojis', async () => {
+    service.listCommunityEmojis = jest.fn().mockResolvedValue([mockEmoji]);
+
+    const result = await controller.listCommunityEmojis(communityId);
+
+    expect(service.listCommunityEmojis).toHaveBeenCalledWith(communityId);
+    expect(result).toEqual([mockEmoji]);
+  });
+
+  it('creates an emoji, passing the authenticated user id', async () => {
+    service.createEmoji = jest.fn().mockResolvedValue(mockEmoji);
+    const dto = { name: 'party_blob', fileId: 'file-1' };
+
+    const result = await controller.createEmoji(communityId, dto, req);
+
+    expect(service.createEmoji).toHaveBeenCalledWith(communityId, dto, userId);
+    expect(result).toEqual(mockEmoji);
+  });
+
+  it('deletes an emoji scoped to its community', async () => {
+    service.deleteEmoji = jest.fn().mockResolvedValue(undefined);
+
+    await controller.deleteEmoji(communityId, emojiId);
+
+    expect(service.deleteEmoji).toHaveBeenCalledWith(communityId, emojiId);
+  });
+});

--- a/backend/src/custom-emoji/custom-emoji.controller.ts
+++ b/backend/src/custom-emoji/custom-emoji.controller.ts
@@ -1,0 +1,86 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Param,
+  Req,
+  HttpCode,
+  UseGuards,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { ApiOkResponse, ApiCreatedResponse } from '@nestjs/swagger';
+import { RbacActions } from '@prisma/client';
+import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
+import { RbacGuard } from '@/auth/rbac.guard';
+import { RequiredActions } from '@/auth/rbac-action.decorator';
+import {
+  RbacResource,
+  RbacResourceType,
+  ResourceIdSource,
+} from '@/auth/rbac-resource.decorator';
+import { AuthenticatedRequest } from '@/types';
+import { CustomEmojiService } from './custom-emoji.service';
+import { CreateCustomEmojiDto } from './dto/create-custom-emoji.dto';
+import { CustomEmojiDto } from './dto/custom-emoji-response.dto';
+
+@Controller('custom-emoji')
+@UseGuards(JwtAuthGuard, RbacGuard)
+export class CustomEmojiController {
+  constructor(private readonly customEmojiService: CustomEmojiService) {}
+
+  /**
+   * List all custom emojis for a community. Available to any community member.
+   */
+  @Get('community/:communityId')
+  @ApiOkResponse({ type: [CustomEmojiDto] })
+  @RequiredActions(RbacActions.READ_COMMUNITY)
+  @RbacResource({
+    type: RbacResourceType.COMMUNITY,
+    idKey: 'communityId',
+    source: ResourceIdSource.PARAM,
+  })
+  async listCommunityEmojis(
+    @Param('communityId', ParseUUIDPipe) communityId: string,
+  ): Promise<CustomEmojiDto[]> {
+    return this.customEmojiService.listCommunityEmojis(communityId);
+  }
+
+  /**
+   * Register a new custom emoji from an uploaded CUSTOM_EMOJI file.
+   */
+  @Post('community/:communityId')
+  @ApiCreatedResponse({ type: CustomEmojiDto })
+  @RequiredActions(RbacActions.MANAGE_EMOJIS)
+  @RbacResource({
+    type: RbacResourceType.COMMUNITY,
+    idKey: 'communityId',
+    source: ResourceIdSource.PARAM,
+  })
+  async createEmoji(
+    @Param('communityId', ParseUUIDPipe) communityId: string,
+    @Body() dto: CreateCustomEmojiDto,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<CustomEmojiDto> {
+    return this.customEmojiService.createEmoji(communityId, dto, req.user.id);
+  }
+
+  /**
+   * Delete a custom emoji from a community.
+   */
+  @Delete('community/:communityId/:emojiId')
+  @HttpCode(204)
+  @RequiredActions(RbacActions.MANAGE_EMOJIS)
+  @RbacResource({
+    type: RbacResourceType.COMMUNITY,
+    idKey: 'communityId',
+    source: ResourceIdSource.PARAM,
+  })
+  async deleteEmoji(
+    @Param('communityId', ParseUUIDPipe) communityId: string,
+    @Param('emojiId', ParseUUIDPipe) emojiId: string,
+  ): Promise<void> {
+    return this.customEmojiService.deleteEmoji(communityId, emojiId);
+  }
+}

--- a/backend/src/custom-emoji/custom-emoji.module.ts
+++ b/backend/src/custom-emoji/custom-emoji.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '@/database/database.module';
+import { RolesModule } from '@/roles/roles.module';
+import { CustomEmojiController } from './custom-emoji.controller';
+import { CustomEmojiService } from './custom-emoji.service';
+
+@Module({
+  imports: [DatabaseModule, RolesModule],
+  controllers: [CustomEmojiController],
+  providers: [CustomEmojiService],
+  exports: [CustomEmojiService],
+})
+export class CustomEmojiModule {}

--- a/backend/src/custom-emoji/custom-emoji.service.spec.ts
+++ b/backend/src/custom-emoji/custom-emoji.service.spec.ts
@@ -1,0 +1,197 @@
+import { TestBed } from '@suites/unit';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ResourceType } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import { CustomEmojiService } from './custom-emoji.service';
+import { DatabaseService } from '@/database/database.service';
+
+describe('CustomEmojiService', () => {
+  let service: CustomEmojiService;
+
+  const communityId = randomUUID();
+  const otherCommunityId = randomUUID();
+  const fileId = randomUUID();
+  const emojiId = randomUUID();
+  const userId = randomUUID();
+
+  const mockDatabaseService = {
+    customEmoji: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+    },
+    file: {
+      findUnique: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const { unit } = await TestBed.solitary(CustomEmojiService)
+      .mock(DatabaseService)
+      .final(mockDatabaseService)
+      .compile();
+
+    service = unit;
+    jest.clearAllMocks();
+  });
+
+  const validFile = {
+    id: fileId,
+    deletedAt: null,
+    resourceType: ResourceType.CUSTOM_EMOJI,
+    fileCommunityId: communityId,
+  };
+
+  describe('listCommunityEmojis', () => {
+    it('returns mapped emoji DTOs for a community', async () => {
+      mockDatabaseService.customEmoji.findMany.mockResolvedValueOnce([
+        {
+          id: emojiId,
+          communityId,
+          name: 'party_blob',
+          fileId,
+          createdBy: userId,
+          createdAt: new Date(),
+        },
+      ]);
+
+      const result = await service.listCommunityEmojis(communityId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('party_blob');
+      expect(mockDatabaseService.customEmoji.findMany).toHaveBeenCalledWith({
+        where: { communityId },
+        orderBy: { name: 'asc' },
+      });
+    });
+  });
+
+  describe('createEmoji', () => {
+    it('creates an emoji from a valid CUSTOM_EMOJI file', async () => {
+      mockDatabaseService.customEmoji.findUnique.mockResolvedValueOnce(null);
+      mockDatabaseService.file.findUnique.mockResolvedValueOnce(validFile);
+      mockDatabaseService.customEmoji.create.mockResolvedValueOnce({
+        id: emojiId,
+        communityId,
+        name: 'party_blob',
+        fileId,
+        createdBy: userId,
+        createdAt: new Date(),
+      });
+
+      const result = await service.createEmoji(
+        communityId,
+        { name: 'party_blob', fileId },
+        userId,
+      );
+
+      expect(result.id).toBe(emojiId);
+      expect(mockDatabaseService.customEmoji.create).toHaveBeenCalledWith({
+        data: { communityId, name: 'party_blob', fileId, createdBy: userId },
+      });
+    });
+
+    it('rejects a duplicate name within the same community', async () => {
+      mockDatabaseService.customEmoji.findUnique.mockResolvedValueOnce({
+        id: emojiId,
+      });
+
+      await expect(
+        service.createEmoji(
+          communityId,
+          { name: 'party_blob', fileId },
+          userId,
+        ),
+      ).rejects.toThrow(ConflictException);
+      expect(mockDatabaseService.customEmoji.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the file does not exist', async () => {
+      mockDatabaseService.customEmoji.findUnique.mockResolvedValueOnce(null);
+      mockDatabaseService.file.findUnique.mockResolvedValueOnce(null);
+
+      await expect(
+        service.createEmoji(
+          communityId,
+          { name: 'party_blob', fileId },
+          userId,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects when the file is not a CUSTOM_EMOJI file', async () => {
+      mockDatabaseService.customEmoji.findUnique.mockResolvedValueOnce(null);
+      mockDatabaseService.file.findUnique.mockResolvedValueOnce({
+        ...validFile,
+        resourceType: ResourceType.MESSAGE_ATTACHMENT,
+      });
+
+      await expect(
+        service.createEmoji(
+          communityId,
+          { name: 'party_blob', fileId },
+          userId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects when the file belongs to another community', async () => {
+      mockDatabaseService.customEmoji.findUnique.mockResolvedValueOnce(null);
+      mockDatabaseService.file.findUnique.mockResolvedValueOnce({
+        ...validFile,
+        fileCommunityId: otherCommunityId,
+      });
+
+      await expect(
+        service.createEmoji(
+          communityId,
+          { name: 'party_blob', fileId },
+          userId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('deleteEmoji', () => {
+    it('deletes an emoji that belongs to the community', async () => {
+      mockDatabaseService.customEmoji.findUnique.mockResolvedValueOnce({
+        id: emojiId,
+        communityId,
+        name: 'party_blob',
+      });
+      mockDatabaseService.customEmoji.delete.mockResolvedValueOnce({});
+
+      await service.deleteEmoji(communityId, emojiId);
+
+      expect(mockDatabaseService.customEmoji.delete).toHaveBeenCalledWith({
+        where: { id: emojiId },
+      });
+    });
+
+    it('throws NotFound when the emoji is missing', async () => {
+      mockDatabaseService.customEmoji.findUnique.mockResolvedValueOnce(null);
+
+      await expect(service.deleteEmoji(communityId, emojiId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFound when the emoji belongs to another community', async () => {
+      mockDatabaseService.customEmoji.findUnique.mockResolvedValueOnce({
+        id: emojiId,
+        communityId: otherCommunityId,
+        name: 'party_blob',
+      });
+
+      await expect(service.deleteEmoji(communityId, emojiId)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockDatabaseService.customEmoji.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/custom-emoji/custom-emoji.service.ts
+++ b/backend/src/custom-emoji/custom-emoji.service.ts
@@ -1,0 +1,123 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { ResourceType } from '@prisma/client';
+import { DatabaseService } from '@/database/database.service';
+import { CreateCustomEmojiDto } from './dto/create-custom-emoji.dto';
+import { CustomEmojiDto } from './dto/custom-emoji-response.dto';
+
+/**
+ * Community-scoped custom emojis.
+ *
+ * Managers upload a small image (validated as a CUSTOM_EMOJI file) then register
+ * it under a `:shortcode:` name. Members use the shortcode inline in messages and
+ * as reactions (via the `custom:{emojiId}` sentinel).
+ */
+@Injectable()
+export class CustomEmojiService {
+  private readonly logger = new Logger(CustomEmojiService.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  private toDto(emoji: {
+    id: string;
+    communityId: string;
+    name: string;
+    fileId: string;
+    createdBy: string | null;
+    createdAt: Date;
+  }): CustomEmojiDto {
+    return {
+      id: emoji.id,
+      communityId: emoji.communityId,
+      name: emoji.name,
+      fileId: emoji.fileId,
+      createdBy: emoji.createdBy,
+      createdAt: emoji.createdAt,
+    };
+  }
+
+  /** List all custom emojis for a community, alphabetically by name. */
+  async listCommunityEmojis(communityId: string): Promise<CustomEmojiDto[]> {
+    const emojis = await this.databaseService.customEmoji.findMany({
+      where: { communityId },
+      orderBy: { name: 'asc' },
+    });
+    return emojis.map((e) => this.toDto(e));
+  }
+
+  /**
+   * Register a new custom emoji from a previously uploaded CUSTOM_EMOJI file.
+   *
+   * Validates: name uniqueness within the community, and that the referenced
+   * file is a non-deleted CUSTOM_EMOJI belonging to this community.
+   */
+  async createEmoji(
+    communityId: string,
+    dto: CreateCustomEmojiDto,
+    userId: string,
+  ): Promise<CustomEmojiDto> {
+    const existing = await this.databaseService.customEmoji.findUnique({
+      where: { communityId_name: { communityId, name: dto.name } },
+    });
+    if (existing) {
+      throw new ConflictException(
+        `An emoji named ":${dto.name}:" already exists in this community`,
+      );
+    }
+
+    const file = await this.databaseService.file.findUnique({
+      where: { id: dto.fileId },
+    });
+    if (!file || file.deletedAt) {
+      throw new NotFoundException('Emoji image file not found');
+    }
+    if (file.resourceType !== ResourceType.CUSTOM_EMOJI) {
+      throw new BadRequestException('File is not a custom emoji image');
+    }
+    if (file.fileCommunityId !== communityId) {
+      throw new BadRequestException(
+        'Emoji image does not belong to this community',
+      );
+    }
+
+    const emoji = await this.databaseService.customEmoji.create({
+      data: {
+        communityId,
+        name: dto.name,
+        fileId: dto.fileId,
+        createdBy: userId,
+      },
+    });
+
+    this.logger.log(
+      `Created custom emoji ":${dto.name}:" (${emoji.id}) in community ${communityId}`,
+    );
+
+    return this.toDto(emoji);
+  }
+
+  /**
+   * Delete a custom emoji. The emoji must belong to the given community.
+   * Existing message spans referencing it fall back to their `:shortcode:` text
+   * (the FK is ON DELETE SET NULL).
+   */
+  async deleteEmoji(communityId: string, emojiId: string): Promise<void> {
+    const emoji = await this.databaseService.customEmoji.findUnique({
+      where: { id: emojiId },
+    });
+    if (!emoji || emoji.communityId !== communityId) {
+      throw new NotFoundException('Custom emoji not found');
+    }
+
+    await this.databaseService.customEmoji.delete({ where: { id: emojiId } });
+
+    this.logger.log(
+      `Deleted custom emoji ":${emoji.name}:" (${emojiId}) from community ${communityId}`,
+    );
+  }
+}

--- a/backend/src/custom-emoji/dto/create-custom-emoji.dto.spec.ts
+++ b/backend/src/custom-emoji/dto/create-custom-emoji.dto.spec.ts
@@ -1,0 +1,42 @@
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import {
+  CreateCustomEmojiDto,
+  CUSTOM_EMOJI_NAME_REGEX,
+} from './create-custom-emoji.dto';
+
+const FILE_ID = '11111111-1111-4111-8111-111111111111';
+
+function validateName(name: string) {
+  const dto = plainToInstance(CreateCustomEmojiDto, { name, fileId: FILE_ID });
+  return validateSync(dto);
+}
+
+describe('CreateCustomEmojiDto name validation', () => {
+  it('accepts names containing at least one letter', () => {
+    for (const name of ['party_blob', 'a1', 'blob123', 'x_y', 'thumbsup2']) {
+      expect(validateName(name)).toHaveLength(0);
+      expect(CUSTOM_EMOJI_NAME_REGEX.test(name)).toBe(true);
+    }
+  });
+
+  it('rejects letterless names (digits/underscores only)', () => {
+    for (const name of ['12', '__', '1_2', '99', '____']) {
+      const errors = validateName(name);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].constraints?.matches).toContain('at least one letter');
+      expect(CUSTOM_EMOJI_NAME_REGEX.test(name)).toBe(false);
+    }
+  });
+
+  it('rejects names that are too short or too long', () => {
+    expect(validateName('a').length).toBeGreaterThan(0);
+    expect(validateName('a'.repeat(33)).length).toBeGreaterThan(0);
+  });
+
+  it('rejects names with uppercase or invalid characters', () => {
+    for (const name of ['Blob', 'blob!', 'bl ob', 'bl-ob']) {
+      expect(validateName(name).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/backend/src/custom-emoji/dto/create-custom-emoji.dto.ts
+++ b/backend/src/custom-emoji/dto/create-custom-emoji.dto.ts
@@ -2,15 +2,17 @@ import { IsString, IsUUID, Matches } from 'class-validator';
 
 /**
  * Shortcode format for custom emojis: lowercase letters, digits and
- * underscores, 2-32 chars. Used inline as `:shortcode:`.
+ * underscores, 2-32 chars, and must contain at least one letter (so a
+ * purely numeric/underscore name like `12` or `__` is rejected). Used
+ * inline as `:shortcode:`.
  */
-export const CUSTOM_EMOJI_NAME_REGEX = /^[a-z0-9_]{2,32}$/;
+export const CUSTOM_EMOJI_NAME_REGEX = /^(?=.*[a-z])[a-z0-9_]{2,32}$/;
 
 export class CreateCustomEmojiDto {
   @IsString()
   @Matches(CUSTOM_EMOJI_NAME_REGEX, {
     message:
-      'Emoji name must be 2-32 characters of lowercase letters, numbers, or underscores',
+      'Emoji name must be 2-32 characters of lowercase letters, numbers, or underscores, and include at least one letter',
   })
   name: string;
 

--- a/backend/src/custom-emoji/dto/create-custom-emoji.dto.ts
+++ b/backend/src/custom-emoji/dto/create-custom-emoji.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, IsUUID, Matches } from 'class-validator';
+
+/**
+ * Shortcode format for custom emojis: lowercase letters, digits and
+ * underscores, 2-32 chars. Used inline as `:shortcode:`.
+ */
+export const CUSTOM_EMOJI_NAME_REGEX = /^[a-z0-9_]{2,32}$/;
+
+export class CreateCustomEmojiDto {
+  @IsString()
+  @Matches(CUSTOM_EMOJI_NAME_REGEX, {
+    message:
+      'Emoji name must be 2-32 characters of lowercase letters, numbers, or underscores',
+  })
+  name: string;
+
+  @IsUUID()
+  fileId: string;
+}

--- a/backend/src/custom-emoji/dto/custom-emoji-response.dto.ts
+++ b/backend/src/custom-emoji/dto/custom-emoji-response.dto.ts
@@ -1,0 +1,12 @@
+/**
+ * Public shape of a community custom emoji. Clients resolve `:name:` shortcodes
+ * and `custom:{id}` reaction sentinels to an image via `fileId`.
+ */
+export class CustomEmojiDto {
+  id: string;
+  communityId: string;
+  name: string;
+  fileId: string;
+  createdBy: string | null;
+  createdAt: Date;
+}

--- a/backend/src/link-previews/link-previews.service.ts
+++ b/backend/src/link-previews/link-previews.service.ts
@@ -168,6 +168,7 @@ export class LinkPreviewsService {
                   specialKind: s.specialKind,
                   communityId: s.communityId,
                   aliasId: s.aliasId,
+                  emojiId: s.emojiId ?? null,
                   bold: s.bold ?? null,
                   italic: s.italic ?? null,
                   strikethrough: s.strikethrough ?? null,

--- a/backend/src/messages/clip-message.listener.ts
+++ b/backend/src/messages/clip-message.listener.ts
@@ -58,6 +58,7 @@ export class ClipMessageListener {
           specialKind: null,
           communityId: null,
           aliasId: null,
+          emojiId: null,
         },
       ],
       attachments: [event.fileId],

--- a/backend/src/messages/dto/create-message.dto.spec.ts
+++ b/backend/src/messages/dto/create-message.dto.spec.ts
@@ -126,9 +126,7 @@ describe('CreateMessageDto', () => {
   it('should preserve rich-text formatting flags on the parsed span', () => {
     const dto = createDto({
       channelId: validUUID,
-      spans: [
-        { type: 'PLAINTEXT', text: 'hi', bold: true, code: true },
-      ] as any,
+      spans: [{ type: 'PLAINTEXT', text: 'hi', bold: true, code: true }] as any,
       attachments: [],
     });
 

--- a/backend/src/messages/dto/create-message.dto.ts
+++ b/backend/src/messages/dto/create-message.dto.ts
@@ -21,6 +21,7 @@ class CreateMessageSpanDto {
   specialKind: string | null;
   communityId: string | null;
   aliasId: string | null;
+  emojiId: string | null;
 
   // Composable inline-formatting flags (optional, PLAINTEXT spans).
   @IsOptional()

--- a/backend/src/messages/dto/message-response.dto.ts
+++ b/backend/src/messages/dto/message-response.dto.ts
@@ -11,6 +11,8 @@ export class SpanDto {
   communityId: string | null;
   aliasId: string | null;
   @ApiPropertyOptional()
+  emojiId?: string | null;
+  @ApiPropertyOptional()
   bold?: boolean | null;
   @ApiPropertyOptional()
   italic?: boolean | null;

--- a/backend/src/messages/messages.controller.spec.ts
+++ b/backend/src/messages/messages.controller.spec.ts
@@ -531,6 +531,7 @@ describe('MessagesController', () => {
             specialKind: null,
             communityId: null,
             aliasId: null,
+            emojiId: null,
           },
         ],
       };

--- a/backend/src/messages/messages.service.spec.ts
+++ b/backend/src/messages/messages.service.spec.ts
@@ -148,6 +148,113 @@ describe('MessagesService', () => {
     });
   });
 
+  describe('EMOJI span sanitization', () => {
+    const emojiSpan = (emojiId: string | null) => ({
+      type: SpanType.EMOJI,
+      text: ':smile:',
+      userId: null,
+      specialKind: null,
+      channelId: null,
+      communityId: null,
+      aliasId: null,
+      emojiId,
+    });
+
+    it('keeps a valid community emoji span on create', async () => {
+      const createDto = {
+        channelId: 'channel-123',
+        authorId: 'user-123',
+        spans: [emojiSpan('emoji-1')],
+      } as any;
+      mockDatabase.channel.findUnique.mockResolvedValue({
+        communityId: 'community-1',
+      });
+      mockDatabase.customEmoji.findMany.mockResolvedValue([{ id: 'emoji-1' }]);
+      mockDatabase.message.create.mockResolvedValue(
+        buildMessageWithIncludes(createDto),
+      );
+
+      await service.create(createDto);
+
+      const createdSpans =
+        mockDatabase.message.create.mock.calls[0][0].data.spans.create;
+      expect(createdSpans[0]).toMatchObject({
+        type: SpanType.EMOJI,
+        emojiId: 'emoji-1',
+      });
+    });
+
+    it('downgrades an unknown emojiId to PLAINTEXT on create (no FK hit)', async () => {
+      const createDto = {
+        channelId: 'channel-123',
+        authorId: 'user-123',
+        spans: [emojiSpan('does-not-exist')],
+      } as any;
+      mockDatabase.channel.findUnique.mockResolvedValue({
+        communityId: 'community-1',
+      });
+      mockDatabase.customEmoji.findMany.mockResolvedValue([]);
+      mockDatabase.message.create.mockResolvedValue(
+        buildMessageWithIncludes(createDto),
+      );
+
+      await service.create(createDto);
+
+      const createdSpans =
+        mockDatabase.message.create.mock.calls[0][0].data.spans.create;
+      expect(createdSpans[0]).toMatchObject({
+        type: SpanType.PLAINTEXT,
+        text: ':smile:',
+        emojiId: null,
+      });
+    });
+
+    it('downgrades all emoji spans in a DM (no channelId)', async () => {
+      const createDto = {
+        directMessageGroupId: 'dm-1',
+        authorId: 'user-123',
+        spans: [emojiSpan('emoji-1')],
+      } as any;
+      mockDatabase.message.create.mockResolvedValue(
+        buildMessageWithIncludes(createDto),
+      );
+
+      await service.create(createDto);
+
+      const createdSpans =
+        mockDatabase.message.create.mock.calls[0][0].data.spans.create;
+      expect(createdSpans[0]).toMatchObject({
+        type: SpanType.PLAINTEXT,
+        emojiId: null,
+      });
+      expect(mockDatabase.channel.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('downgrades an unknown emojiId to PLAINTEXT on update', async () => {
+      const messageId = 'msg-emoji';
+      const updateDto = { spans: [emojiSpan('does-not-exist')] } as any;
+      mockDatabase.message.findUnique.mockResolvedValue({
+        channelId: 'channel-123',
+      });
+      mockDatabase.channel.findUnique.mockResolvedValue({
+        communityId: 'community-1',
+      });
+      mockDatabase.customEmoji.findMany.mockResolvedValue([]);
+      mockDatabase.messageSpan.deleteMany.mockResolvedValue({ count: 1 });
+      mockDatabase.messageSpan.createMany.mockResolvedValue({ count: 1 });
+      mockDatabase.message.update.mockResolvedValue(buildMessageWithIncludes());
+
+      await service.update(messageId, updateDto);
+
+      const createManyArg =
+        mockDatabase.messageSpan.createMany.mock.calls[0][0].data;
+      expect(createManyArg[0]).toMatchObject({
+        type: SpanType.PLAINTEXT,
+        emojiId: null,
+      });
+    });
+  });
+
   describe('findOne', () => {
     it('should return a message by id', async () => {
       const message = buildMessageWithIncludes();

--- a/backend/src/messages/messages.service.ts
+++ b/backend/src/messages/messages.service.ts
@@ -9,6 +9,7 @@ import { UpdateMessageDto } from './dto/update-message.dto';
 import { DatabaseService } from '@/database/database.service';
 import { FileService } from '@/file/file.service';
 import { flattenSpansToText } from '@/common/utils/text.utils';
+import { sanitizeEmojiSpans } from '@/common/utils/emoji-span.utils';
 import { FileType, Prisma } from '@prisma/client';
 import { groupReactions } from '@/common/utils/reactions.utils';
 
@@ -74,9 +75,19 @@ export class MessagesService {
       }
     }
 
-    const searchText = flattenSpansToText(createMessageDto.spans);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { id, spans, attachments, ...data } = createMessageDto;
+    const { id, spans: rawSpans, attachments, ...data } = createMessageDto;
+
+    // Convert EMOJI spans with unknown/foreign emojiIds to plaintext so a
+    // hand-crafted payload can't trip the FK (P2003 -> 500) or reference
+    // another community's emoji.
+    const spans = await sanitizeEmojiSpans(
+      this.databaseService,
+      rawSpans,
+      createMessageDto.channelId,
+    );
+
+    const searchText = flattenSpansToText(spans);
     const message = await this.databaseService.message.create({
       data: {
         ...data,
@@ -163,18 +174,33 @@ export class MessagesService {
     updateMessageDto: UpdateMessageDto,
     originalAttachments?: string[],
   ) {
+    // Validate EMOJI spans against the message's community (see create()).
+    // Only fetch the message when the edit actually contains EMOJI spans.
+    let sanitizedSpans = updateMessageDto.spans;
+    if (sanitizedSpans?.some((s) => s.type === 'EMOJI')) {
+      const existing = await this.databaseService.message.findUnique({
+        where: { id },
+        select: { channelId: true },
+      });
+      sanitizedSpans = await sanitizeEmojiSpans(
+        this.databaseService,
+        sanitizedSpans,
+        existing?.channelId ?? null,
+      );
+    }
+
     return this.databaseService.$transaction(
       async (tx: Prisma.TransactionClient) => {
         const dataToUpdate: Record<string, unknown> = {};
 
-        if (updateMessageDto.spans) {
-          dataToUpdate.searchText = flattenSpansToText(updateMessageDto.spans);
+        if (sanitizedSpans) {
+          dataToUpdate.searchText = flattenSpansToText(sanitizedSpans);
           dataToUpdate.editedAt = new Date();
 
           // Delete old spans, create new ones
           await tx.messageSpan.deleteMany({ where: { messageId: id } });
           await tx.messageSpan.createMany({
-            data: updateMessageDto.spans.map((span, i) => ({
+            data: sanitizedSpans.map((span, i) => ({
               messageId: id,
               position: i,
               ...span,

--- a/backend/src/messages/messages.service.ts
+++ b/backend/src/messages/messages.service.ts
@@ -691,6 +691,7 @@ export class MessagesService {
         specialKind: string | null;
         communityId: string | null;
         aliasId: string | null;
+        emojiId: string | null;
         bold: boolean | null;
         italic: boolean | null;
         strikethrough: boolean | null;
@@ -747,6 +748,7 @@ export class MessagesService {
                   specialKind: s.specialKind,
                   communityId: s.communityId,
                   aliasId: s.aliasId,
+                  emojiId: s.emojiId,
                   bold: s.bold,
                   italic: s.italic,
                   strikethrough: s.strikethrough,

--- a/backend/src/messages/reactions.service.spec.ts
+++ b/backend/src/messages/reactions.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@suites/unit';
 import { ReactionsService } from './reactions.service';
 import { DatabaseService } from '@/database/database.service';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 
 describe('ReactionsService', () => {
@@ -18,6 +18,15 @@ describe('ReactionsService', () => {
     messageReaction: {
       upsert: jest.fn(),
       deleteMany: jest.fn(),
+    },
+    customEmoji: {
+      findUnique: jest.fn(),
+    },
+    channel: {
+      findUnique: jest.fn(),
+    },
+    membership: {
+      findUnique: jest.fn(),
     },
   };
 
@@ -180,6 +189,103 @@ describe('ReactionsService', () => {
         service.addReaction(randomUUID(), '👍', userId1),
       ).rejects.toThrow(NotFoundException);
 
+      expect(mockDatabaseService.messageReaction.upsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('addReaction (custom emoji sentinel)', () => {
+    const emojiId = randomUUID();
+    const communityId = randomUUID();
+    const channelId = randomUUID();
+    const message = { id: messageId, channelId, directMessageGroupId: null };
+
+    it('should accept a valid custom reaction for a community member', async () => {
+      mockDatabaseService.message.findUnique
+        .mockResolvedValueOnce(message)
+        .mockResolvedValueOnce({ ...message, reactions: [] });
+      mockDatabaseService.customEmoji.findUnique.mockResolvedValueOnce({
+        id: emojiId,
+        communityId,
+      });
+      mockDatabaseService.channel.findUnique.mockResolvedValueOnce({
+        communityId,
+      });
+      mockDatabaseService.membership.findUnique.mockResolvedValueOnce({
+        userId: userId1,
+        communityId,
+      });
+      mockDatabaseService.messageReaction.upsert.mockResolvedValueOnce({});
+
+      await service.addReaction(messageId, `custom:${emojiId}`, userId1);
+
+      expect(mockDatabaseService.messageReaction.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: {
+            messageId,
+            emoji: `custom:${emojiId}`,
+            userId: userId1,
+          },
+        }),
+      );
+    });
+
+    it('should reject when the custom emoji does not exist', async () => {
+      mockDatabaseService.message.findUnique.mockResolvedValueOnce(message);
+      mockDatabaseService.customEmoji.findUnique.mockResolvedValueOnce(null);
+
+      await expect(
+        service.addReaction(messageId, `custom:${emojiId}`, userId1),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDatabaseService.messageReaction.upsert).not.toHaveBeenCalled();
+    });
+
+    it('should reject a custom reaction on a DM message', async () => {
+      mockDatabaseService.message.findUnique.mockResolvedValueOnce({
+        id: messageId,
+        channelId: null,
+        directMessageGroupId: randomUUID(),
+      });
+      mockDatabaseService.customEmoji.findUnique.mockResolvedValueOnce({
+        id: emojiId,
+        communityId,
+      });
+
+      await expect(
+        service.addReaction(messageId, `custom:${emojiId}`, userId1),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDatabaseService.messageReaction.upsert).not.toHaveBeenCalled();
+    });
+
+    it('should reject a custom emoji from another community', async () => {
+      mockDatabaseService.message.findUnique.mockResolvedValueOnce(message);
+      mockDatabaseService.customEmoji.findUnique.mockResolvedValueOnce({
+        id: emojiId,
+        communityId,
+      });
+      mockDatabaseService.channel.findUnique.mockResolvedValueOnce({
+        communityId: randomUUID(), // different community
+      });
+
+      await expect(
+        service.addReaction(messageId, `custom:${emojiId}`, userId1),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDatabaseService.messageReaction.upsert).not.toHaveBeenCalled();
+    });
+
+    it('should reject when reactor is not a community member', async () => {
+      mockDatabaseService.message.findUnique.mockResolvedValueOnce(message);
+      mockDatabaseService.customEmoji.findUnique.mockResolvedValueOnce({
+        id: emojiId,
+        communityId,
+      });
+      mockDatabaseService.channel.findUnique.mockResolvedValueOnce({
+        communityId,
+      });
+      mockDatabaseService.membership.findUnique.mockResolvedValueOnce(null);
+
+      await expect(
+        service.addReaction(messageId, `custom:${emojiId}`, userId1),
+      ).rejects.toThrow(BadRequestException);
       expect(mockDatabaseService.messageReaction.upsert).not.toHaveBeenCalled();
     });
   });

--- a/backend/src/messages/reactions.service.ts
+++ b/backend/src/messages/reactions.service.ts
@@ -1,8 +1,20 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { DatabaseService } from '@/database/database.service';
 import { Message, MessageReaction } from '@prisma/client';
 
 type MessageWithReactions = Message & { reactions: MessageReaction[] };
+
+/**
+ * Sentinel prefix for custom (community) emoji reactions. The full value stored
+ * in `MessageReaction.emoji` is `custom:{customEmojiId}`. Unicode reactions are
+ * stored verbatim.
+ */
+const CUSTOM_REACTION_PREFIX = 'custom:';
 
 /**
  * Service for managing message reactions
@@ -33,7 +45,11 @@ export class ReactionsService {
     userId: string,
   ): Promise<MessageWithReactions> {
     try {
-      await this.findMessageOrThrow(messageId);
+      const message = await this.findMessageOrThrow(messageId);
+
+      if (emoji.startsWith(CUSTOM_REACTION_PREFIX)) {
+        await this.validateCustomReaction(message, emoji, userId);
+      }
 
       await this.databaseService.messageReaction.upsert({
         where: {
@@ -85,6 +101,59 @@ export class ReactionsService {
         error,
       );
       throw error;
+    }
+  }
+
+  /**
+   * Validate a `custom:{emojiId}` reaction sentinel:
+   * - the emoji must exist,
+   * - the message must belong to a channel in a community (not a DM),
+   * - the emoji must belong to that same community,
+   * - the reactor must be a member of that community.
+   */
+  private async validateCustomReaction(
+    message: Message,
+    emoji: string,
+    userId: string,
+  ): Promise<void> {
+    const emojiId = emoji.slice(CUSTOM_REACTION_PREFIX.length);
+    if (!emojiId) {
+      throw new BadRequestException('Invalid custom emoji reaction');
+    }
+
+    const customEmoji = await this.databaseService.customEmoji.findUnique({
+      where: { id: emojiId },
+    });
+    if (!customEmoji) {
+      throw new BadRequestException('Custom emoji not found');
+    }
+
+    if (!message.channelId) {
+      throw new BadRequestException(
+        'Custom emoji reactions are only available in communities',
+      );
+    }
+
+    const channel = await this.databaseService.channel.findUnique({
+      where: { id: message.channelId },
+      select: { communityId: true },
+    });
+    if (!channel || channel.communityId !== customEmoji.communityId) {
+      throw new BadRequestException(
+        'Custom emoji does not belong to this community',
+      );
+    }
+
+    const membership = await this.databaseService.membership.findUnique({
+      where: {
+        userId_communityId: {
+          userId,
+          communityId: customEmoji.communityId,
+        },
+      },
+    });
+    if (!membership) {
+      throw new BadRequestException('You are not a member of this community');
     }
   }
 

--- a/backend/src/roles/default-roles.config.ts
+++ b/backend/src/roles/default-roles.config.ts
@@ -93,6 +93,9 @@ export const DEFAULT_COMMUNITY_CREATOR_ROLE: DefaultRoleConfig = {
     RbacActions.READ_ALIAS_GROUP_MEMBER,
     RbacActions.UPDATE_ALIAS_GROUP_MEMBER,
 
+    // Custom emoji management
+    RbacActions.MANAGE_EMOJIS,
+
     // Reaction management
     RbacActions.CREATE_REACTION,
     RbacActions.DELETE_REACTION,
@@ -219,6 +222,9 @@ export const DEFAULT_ADMIN_ROLE: DefaultRoleConfig = {
     RbacActions.DELETE_ALIAS_GROUP_MEMBER,
     RbacActions.READ_ALIAS_GROUP_MEMBER,
     RbacActions.UPDATE_ALIAS_GROUP_MEMBER,
+
+    // Custom emoji management
+    RbacActions.MANAGE_EMOJIS,
 
     // Reaction management
     RbacActions.CREATE_REACTION,

--- a/backend/src/test-utils/mocks/database.mock.ts
+++ b/backend/src/test-utils/mocks/database.mock.ts
@@ -60,6 +60,7 @@ export type MockDatabaseService = {
   instanceSettings: MockPrismaModel;
   aliasGroup: MockPrismaModel;
   aliasGroupMember: MockPrismaModel;
+  customEmoji: MockPrismaModel;
   readReceipt: MockPrismaModel;
   notification: MockPrismaModel;
   userNotificationSettings: MockPrismaModel;
@@ -132,6 +133,7 @@ export function createMockDatabase(): MockDatabaseService {
     instanceSettings: createMockPrismaModel(),
     aliasGroup: createMockPrismaModel(),
     aliasGroupMember: createMockPrismaModel(),
+    customEmoji: createMockPrismaModel(),
     readReceipt: createMockPrismaModel(),
     notification: createMockPrismaModel(),
     userNotificationSettings: createMockPrismaModel(),

--- a/backend/src/threads/threads.service.spec.ts
+++ b/backend/src/threads/threads.service.spec.ts
@@ -213,6 +213,101 @@ describe('ThreadsService', () => {
       });
     });
 
+    it('keeps a valid community emoji span in a channel thread reply', async () => {
+      const parent = MessageFactory.build({
+        id: parentMessageId,
+        channelId,
+        directMessageGroupId: null,
+        parentMessageId: null,
+      });
+      const reply = MessageFactory.build({ authorId, parentMessageId });
+      const emojiDto = {
+        parentMessageId,
+        spans: [{ type: 'EMOJI' as any, text: ':smile:', emojiId: 'emoji-1' }],
+      };
+
+      mockDatabase.message.findUnique.mockResolvedValue(parent);
+      mockDatabase.channel.findUnique.mockResolvedValue({
+        communityId: 'community-1',
+      });
+      mockDatabase.customEmoji.findMany.mockResolvedValue([{ id: 'emoji-1' }]);
+      mockDatabase.message.create.mockResolvedValue(reply);
+      mockDatabase.message.update.mockResolvedValue(parent);
+      mockDatabase.threadSubscriber.upsert.mockResolvedValue({});
+
+      await service.createThreadReply(emojiDto as any, authorId);
+
+      const spans =
+        mockDatabase.message.create.mock.calls[0][0].data.spans.create;
+      expect(spans[0]).toMatchObject({ type: 'EMOJI', emojiId: 'emoji-1' });
+    });
+
+    it('downgrades an unknown emojiId to PLAINTEXT in a thread reply', async () => {
+      const parent = MessageFactory.build({
+        id: parentMessageId,
+        channelId,
+        directMessageGroupId: null,
+        parentMessageId: null,
+      });
+      const reply = MessageFactory.build({ authorId, parentMessageId });
+      const emojiDto = {
+        parentMessageId,
+        spans: [
+          { type: 'EMOJI' as any, text: ':ghost:', emojiId: 'does-not-exist' },
+        ],
+      };
+
+      mockDatabase.message.findUnique.mockResolvedValue(parent);
+      mockDatabase.channel.findUnique.mockResolvedValue({
+        communityId: 'community-1',
+      });
+      mockDatabase.customEmoji.findMany.mockResolvedValue([]);
+      mockDatabase.message.create.mockResolvedValue(reply);
+      mockDatabase.message.update.mockResolvedValue(parent);
+      mockDatabase.threadSubscriber.upsert.mockResolvedValue({});
+
+      await service.createThreadReply(emojiDto as any, authorId);
+
+      const spans =
+        mockDatabase.message.create.mock.calls[0][0].data.spans.create;
+      expect(spans[0]).toMatchObject({
+        type: 'PLAINTEXT',
+        text: ':ghost:',
+        emojiId: null,
+      });
+    });
+
+    it('downgrades emoji spans in a DM thread reply (no community)', async () => {
+      const dmGroupId = 'dm-group-999';
+      const parent = MessageFactory.build({
+        id: parentMessageId,
+        channelId: null,
+        directMessageGroupId: dmGroupId,
+        parentMessageId: null,
+      });
+      const reply = MessageFactory.build({
+        authorId,
+        directMessageGroupId: dmGroupId,
+        parentMessageId,
+      });
+      const emojiDto = {
+        parentMessageId,
+        spans: [{ type: 'EMOJI' as any, text: ':smile:', emojiId: 'emoji-1' }],
+      };
+
+      mockDatabase.message.findUnique.mockResolvedValue(parent);
+      mockDatabase.message.create.mockResolvedValue(reply);
+      mockDatabase.message.update.mockResolvedValue(parent);
+      mockDatabase.threadSubscriber.upsert.mockResolvedValue({});
+
+      await service.createThreadReply(emojiDto as any, authorId);
+
+      const spans =
+        mockDatabase.message.create.mock.calls[0][0].data.spans.create;
+      expect(spans[0]).toMatchObject({ type: 'PLAINTEXT', emojiId: null });
+      expect(mockDatabase.channel.findUnique).not.toHaveBeenCalled();
+    });
+
     it('should throw when parent message is itself a thread reply', async () => {
       const nestedParent = MessageFactory.build({
         id: parentMessageId,

--- a/backend/src/threads/threads.service.spec.ts
+++ b/backend/src/threads/threads.service.spec.ts
@@ -205,6 +205,7 @@ describe('ThreadsService', () => {
         specialKind: null,
         communityId: null,
         aliasId: null,
+        emojiId: null,
         bold: null,
         italic: null,
         strikethrough: null,

--- a/backend/src/threads/threads.service.ts
+++ b/backend/src/threads/threads.service.ts
@@ -52,6 +52,7 @@ export class ThreadsService {
       specialKind?: string | null;
       communityId?: string | null;
       aliasId?: string | null;
+      emojiId?: string | null;
       bold?: boolean | null;
       italic?: boolean | null;
       strikethrough?: boolean | null;
@@ -65,6 +66,7 @@ export class ThreadsService {
       specialKind: span.specialKind ?? null,
       communityId: span.communityId ?? null,
       aliasId: span.aliasId ?? null,
+      emojiId: span.emojiId ?? null,
       bold: span.bold ?? null,
       italic: span.italic ?? null,
       strikethrough: span.strikethrough ?? null,

--- a/backend/src/threads/threads.service.ts
+++ b/backend/src/threads/threads.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { DatabaseService } from '@/database/database.service';
 import { flattenSpansToText } from '@/common/utils/text.utils';
+import { sanitizeEmojiSpans } from '@/common/utils/emoji-span.utils';
 import { groupReactions } from '@/common/utils/reactions.utils';
 import { CreateThreadReplyDto } from './dto/create-thread-reply.dto';
 import { Message, $Enums, FileType } from '@prisma/client';
@@ -106,7 +107,17 @@ export class ThreadsService {
     const parent = await this.getParentMessage(parentMessageId);
 
     // Sanitize spans to only include valid Prisma fields
-    const sanitizedSpans = this.sanitizeSpans(spans);
+    const fieldSanitizedSpans = this.sanitizeSpans(spans);
+
+    // Convert EMOJI spans with unknown/foreign emojiIds to plaintext so a
+    // hand-crafted payload can't trip the FK (P2003 -> 500) or reference
+    // another community's emoji. DM threads (no channelId) downgrade all
+    // EMOJI spans since there is no community to validate against.
+    const sanitizedSpans = await sanitizeEmojiSpans(
+      this.databaseService,
+      fieldSanitizedSpans,
+      parent.channelId,
+    );
     const searchText = flattenSpansToText(sanitizedSpans);
 
     // Use transaction to ensure atomicity

--- a/frontend/src/__tests__/components/CustomEmojiManagement.test.tsx
+++ b/frontend/src/__tests__/components/CustomEmojiManagement.test.tsx
@@ -99,6 +99,22 @@ describe('CustomEmojiManagement', () => {
     expect(mockUploadFile).not.toHaveBeenCalled();
   });
 
+  it('rejects a letterless shortcode (digits/underscores only)', async () => {
+    setupList([]);
+    const { user } = renderWithProviders(
+      <CustomEmojiManagement communityId={COMMUNITY_ID} />,
+    );
+    await screen.findByText(/no custom emojis yet/i);
+
+    await user.type(screen.getByLabelText(/shortcode/i), '123_45');
+    await user.click(screen.getByRole('button', { name: /add emoji/i }));
+
+    expect(
+      await screen.findByText(/at least one letter/i),
+    ).toBeInTheDocument();
+    expect(mockUploadFile).not.toHaveBeenCalled();
+  });
+
   it('uploads the file then creates the emoji on submit', async () => {
     setupList([]);
     let created: unknown = null;

--- a/frontend/src/__tests__/components/CustomEmojiManagement.test.tsx
+++ b/frontend/src/__tests__/components/CustomEmojiManagement.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders } from '../test-utils';
+import { server } from '../msw/server';
+import CustomEmojiManagement from '../../components/Community/CustomEmojiManagement';
+import type { CustomEmojiDto } from '../../api-client/types.gen';
+
+vi.mock('../../api-client/client.gen', async (importOriginal) => {
+  const { createClient, createConfig } = await import('../../api-client/client');
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    client: createClient(createConfig({ baseUrl: 'http://localhost:3000' })),
+  };
+});
+
+// Permission mock — overridden per-test where needed.
+const mockUseUserPermissions = vi.fn(() => ({ hasPermissions: true }));
+vi.mock('../../features/roles/useUserPermissions', () => ({
+  useUserPermissions: (...args: unknown[]) => mockUseUserPermissions(...(args as [])),
+}));
+
+// File-upload mock.
+const mockUploadFile = vi.fn(async () => ({ id: 'file-new' }));
+vi.mock('../../hooks/useFileUpload', () => ({
+  useFileUpload: () => ({
+    uploadFile: mockUploadFile,
+    isUploading: false,
+    error: null,
+    resetError: vi.fn(),
+  }),
+}));
+
+const COMMUNITY_ID = 'community-1';
+
+function makeEmoji(overrides: Partial<CustomEmojiDto> = {}): CustomEmojiDto {
+  return {
+    id: 'e1',
+    communityId: COMMUNITY_ID,
+    name: 'party_blob',
+    fileId: 'file-1',
+    createdBy: 'user-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function setupList(emojis: CustomEmojiDto[]) {
+  server.use(
+    http.get(
+      'http://localhost:3000/api/custom-emoji/community/:communityId',
+      () => HttpResponse.json(emojis),
+    ),
+  );
+}
+
+describe('CustomEmojiManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseUserPermissions.mockReturnValue({ hasPermissions: true });
+  });
+
+  it('shows a permission notice when the user cannot manage emojis', () => {
+    mockUseUserPermissions.mockReturnValue({ hasPermissions: false });
+    renderWithProviders(<CustomEmojiManagement communityId={COMMUNITY_ID} />);
+    expect(
+      screen.getByText(/don't have permission to manage custom emojis/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no emojis', async () => {
+    setupList([]);
+    renderWithProviders(<CustomEmojiManagement communityId={COMMUNITY_ID} />);
+    expect(await screen.findByText(/no custom emojis yet/i)).toBeInTheDocument();
+  });
+
+  it('lists existing emojis with a preview image and shortcode', async () => {
+    setupList([makeEmoji()]);
+    renderWithProviders(<CustomEmojiManagement communityId={COMMUNITY_ID} />);
+
+    const img = await screen.findByRole('img', { name: ':party_blob:' });
+    expect(img).toHaveAttribute('src', '/api/file/file-1');
+    expect(screen.getByText(':party_blob:')).toBeInTheDocument();
+  });
+
+  it('rejects an invalid shortcode without uploading', async () => {
+    setupList([]);
+    const { user } = renderWithProviders(
+      <CustomEmojiManagement communityId={COMMUNITY_ID} />,
+    );
+    await screen.findByText(/no custom emojis yet/i);
+
+    await user.type(screen.getByLabelText(/shortcode/i), 'Bad Name!');
+    await user.click(screen.getByRole('button', { name: /add emoji/i }));
+
+    expect(
+      await screen.findByText(/must be 2-32 characters/i),
+    ).toBeInTheDocument();
+    expect(mockUploadFile).not.toHaveBeenCalled();
+  });
+
+  it('uploads the file then creates the emoji on submit', async () => {
+    setupList([]);
+    let created: unknown = null;
+    server.use(
+      http.post(
+        'http://localhost:3000/api/custom-emoji/community/:communityId',
+        async ({ request }) => {
+          created = await request.json();
+          return HttpResponse.json(makeEmoji({ id: 'e2', name: 'cat_jam' }), {
+            status: 201,
+          });
+        },
+      ),
+    );
+
+    const { container, user } = renderWithProviders(
+      <CustomEmojiManagement communityId={COMMUNITY_ID} />,
+    );
+    await screen.findByText(/no custom emojis yet/i);
+
+    await user.type(screen.getByLabelText(/shortcode/i), 'cat_jam');
+    const fileInput = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(['x'], 'cat.png', { type: 'image/png' });
+    await user.upload(fileInput, file);
+
+    await user.click(screen.getByRole('button', { name: /add emoji/i }));
+
+    await waitFor(() => expect(mockUploadFile).toHaveBeenCalledTimes(1));
+    expect(mockUploadFile).toHaveBeenCalledWith(file, {
+      resourceType: 'CUSTOM_EMOJI',
+      resourceId: COMMUNITY_ID,
+    });
+    await waitFor(() =>
+      expect(created).toEqual({ name: 'cat_jam', fileId: 'file-new' }),
+    );
+  });
+});

--- a/frontend/src/__tests__/components/MessageReactions.test.tsx
+++ b/frontend/src/__tests__/components/MessageReactions.test.tsx
@@ -101,4 +101,46 @@ describe('MessageReactions', () => {
     expect(screen.getByText('😂 1')).toBeInTheDocument();
     expect(screen.getByText('🎉 2')).toBeInTheDocument();
   });
+
+  it('renders a custom (custom:{id}) reaction as an inline image', async () => {
+    const emojiById = new Map([
+      ['e1', { id: 'e1', communityId: 'c1', name: 'party_blob', fileId: 'file-9', createdBy: null, createdAt: '2026-01-01' }],
+    ]);
+    const reactions: Reaction[] = [{ emoji: 'custom:e1', userIds: ['u1', 'u2'] }];
+
+    renderWithProviders(
+      <MessageReactions
+        messageId="msg-1"
+        reactions={reactions}
+        onReactionClick={vi.fn()}
+        emojiById={emojiById}
+      />
+    );
+
+    const img = await screen.findByRole('img', { name: ':party_blob:' });
+    expect(img).toHaveAttribute('src', '/api/file/file-9');
+    // Count is still shown alongside the image.
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('sends the custom sentinel back on click', async () => {
+    const emojiById = new Map([
+      ['e1', { id: 'e1', communityId: 'c1', name: 'party_blob', fileId: 'file-9', createdBy: null, createdAt: '2026-01-01' }],
+    ]);
+    const onReactionClick = vi.fn();
+    const reactions: Reaction[] = [{ emoji: 'custom:e1', userIds: ['u1'] }];
+
+    const { user } = renderWithProviders(
+      <MessageReactions
+        messageId="msg-1"
+        reactions={reactions}
+        onReactionClick={onReactionClick}
+        emojiById={emojiById}
+      />
+    );
+
+    const img = await screen.findByRole('img', { name: ':party_blob:' });
+    await user.click(img);
+    expect(onReactionClick).toHaveBeenCalledWith('custom:e1');
+  });
 });

--- a/frontend/src/__tests__/components/MessageSpan.test.tsx
+++ b/frontend/src/__tests__/components/MessageSpan.test.tsx
@@ -143,3 +143,24 @@ describe('renderMessageSpans', () => {
     expect(screen.getByText('#general')).toBeInTheDocument();
   });
 });
+
+describe('MessageSpan custom emoji (EMOJI)', () => {
+  const emojiById = new Map([
+    ['e1', { id: 'e1', communityId: 'c1', name: 'party_blob', fileId: 'file-1', createdBy: null, createdAt: '2026-01-01' }],
+  ]);
+
+  it('renders a known EMOJI span as an inline image', () => {
+    const span: Span = { type: SpanType.EMOJI, text: ':party_blob:', emojiId: 'e1' };
+    renderWithProviders(<MessageSpan span={span} index={0} emojiById={emojiById} />);
+    const img = screen.getByRole('img', { name: ':party_blob:' });
+    expect(img).toHaveAttribute('src', '/api/file/file-1');
+    expect(img).toHaveAttribute('title', ':party_blob:');
+  });
+
+  it('falls back to shortcode text when the emoji is unknown/deleted', () => {
+    const span: Span = { type: SpanType.EMOJI, text: ':gone:', emojiId: 'missing' };
+    renderWithProviders(<MessageSpan span={span} index={0} emojiById={emojiById} />);
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(screen.getByText(':gone:')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/utils/mentionParser.test.ts
+++ b/frontend/src/__tests__/utils/mentionParser.test.ts
@@ -404,3 +404,62 @@ describe('spansToText - formatting round-trip', () => {
     expect(parseMessageWithMentions(spansToText(original))).toEqual(original);
   });
 });
+
+describe('parseMessageWithMentions custom emojis', () => {
+  const emojis = [
+    { id: 'e1', name: 'party_blob' },
+    { id: 'e2', name: 'cat_jam' },
+  ];
+
+  it('resolves a known :shortcode: to an EMOJI span', () => {
+    const result = parseMessageWithMentions('hi :party_blob:', [], [], [], emojis);
+    expect(result).toEqual([
+      { type: SpanType.PLAINTEXT, text: 'hi ' },
+      { type: SpanType.EMOJI, text: ':party_blob:', emojiId: 'e1' },
+    ]);
+  });
+
+  it('leaves an unknown :shortcode: as literal plaintext', () => {
+    const result = parseMessageWithMentions('hi :unknown_emoji:', [], [], [], emojis);
+    expect(result).toEqual([
+      { type: SpanType.PLAINTEXT, text: 'hi :unknown_emoji:' },
+    ]);
+  });
+
+  it('does not resolve emojis inside inline code', () => {
+    const result = parseMessageWithMentions('`:party_blob:`', [], [], [], emojis);
+    expect(result).toEqual([
+      { type: SpanType.PLAINTEXT, text: ':party_blob:', code: true },
+    ]);
+  });
+
+  it('does not resolve emojis inside a fenced code block', () => {
+    const result = parseMessageWithMentions('```\n:party_blob:\n```', [], [], [], emojis);
+    expect(result).toEqual([
+      { type: SpanType.CODE_BLOCK, text: ':party_blob:' },
+    ]);
+  });
+
+  it('resolves multiple emojis interleaved with mentions', () => {
+    const users = [{ id: 'u1', username: 'alice' }];
+    const result = parseMessageWithMentions(
+      ':party_blob: @alice :cat_jam:',
+      users,
+      [],
+      [],
+      emojis,
+    );
+    expect(result).toEqual([
+      { type: SpanType.EMOJI, text: ':party_blob:', emojiId: 'e1' },
+      { type: SpanType.PLAINTEXT, text: ' ' },
+      { type: SpanType.USER_MENTION, text: '@alice', userId: 'u1' },
+      { type: SpanType.PLAINTEXT, text: ' ' },
+      { type: SpanType.EMOJI, text: ':cat_jam:', emojiId: 'e2' },
+    ]);
+  });
+
+  it('round-trips an EMOJI span back to its :shortcode:', () => {
+    const spans = parseMessageWithMentions('yo :party_blob:', [], [], [], emojis);
+    expect(spansToText(spans)).toBe('yo :party_blob:');
+  });
+});

--- a/frontend/src/components/Community/CustomEmojiManagement.tsx
+++ b/frontend/src/components/Community/CustomEmojiManagement.tsx
@@ -1,0 +1,303 @@
+import React, { useState, useCallback, useRef } from "react";
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Button,
+  Alert,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  IconButton,
+  TextField,
+  Tooltip,
+  Stack,
+} from "@mui/material";
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  UploadFile as UploadFileIcon,
+} from "@mui/icons-material";
+import { useUserPermissions } from "../../features/roles/useUserPermissions";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  customEmojiControllerListCommunityEmojisOptions,
+  customEmojiControllerListCommunityEmojisQueryKey,
+  customEmojiControllerCreateEmojiMutation,
+  customEmojiControllerDeleteEmojiMutation,
+} from "../../api-client/@tanstack/react-query.gen";
+import type { CustomEmojiDto } from "../../api-client/types.gen";
+import { useFileUpload } from "../../hooks/useFileUpload";
+import { getFileUrl } from "../../utils/fileHelpers";
+import ConfirmDialog from "../Common/ConfirmDialog";
+
+interface CustomEmojiManagementProps {
+  communityId: string;
+}
+
+const NAME_REGEX = /^[a-z0-9_]{2,32}$/;
+
+const CustomEmojiManagement: React.FC<CustomEmojiManagementProps> = ({ communityId }) => {
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [name, setName] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [emojiToDelete, setEmojiToDelete] = useState<CustomEmojiDto | null>(null);
+
+  const { hasPermissions: canManage } = useUserPermissions({
+    resourceType: "COMMUNITY",
+    resourceId: communityId,
+    actions: ["MANAGE_EMOJIS"],
+  });
+
+  const {
+    data: emojis,
+    isLoading,
+    error: listError,
+  } = useQuery(
+    customEmojiControllerListCommunityEmojisOptions({ path: { communityId } }),
+  );
+
+  const invalidate = useCallback(
+    () =>
+      queryClient.invalidateQueries({
+        queryKey: customEmojiControllerListCommunityEmojisQueryKey({
+          path: { communityId },
+        }),
+      }),
+    [queryClient, communityId],
+  );
+
+  const { uploadFile, isUploading } = useFileUpload();
+  const { mutateAsync: createEmoji, isPending: creating } = useMutation({
+    ...customEmojiControllerCreateEmojiMutation(),
+    onSuccess: invalidate,
+  });
+  const { mutateAsync: deleteEmoji, isPending: deleting } = useMutation({
+    ...customEmojiControllerDeleteEmojiMutation(),
+    onSuccess: invalidate,
+  });
+
+  const resetForm = () => {
+    setName("");
+    setFile(null);
+    setFormError(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleCreate = useCallback(async () => {
+    setFormError(null);
+    if (!NAME_REGEX.test(name)) {
+      setFormError(
+        "Name must be 2-32 characters of lowercase letters, numbers, or underscores.",
+      );
+      return;
+    }
+    if (!file) {
+      setFormError("Choose an image file (PNG, GIF, or WebP, max 256KB).");
+      return;
+    }
+    try {
+      const uploaded = await uploadFile(file, {
+        resourceType: "CUSTOM_EMOJI",
+        resourceId: communityId,
+      });
+      await createEmoji({
+        path: { communityId },
+        body: { name, fileId: uploaded.id },
+      });
+      resetForm();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Failed to add emoji.");
+    }
+  }, [name, file, uploadFile, createEmoji, communityId]);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!emojiToDelete) return;
+    try {
+      await deleteEmoji({
+        path: { communityId, emojiId: emojiToDelete.id },
+      });
+      setEmojiToDelete(null);
+    } catch {
+      // surfaced via mutation error state
+    }
+  }, [emojiToDelete, deleteEmoji, communityId]);
+
+  if (!canManage) {
+    return (
+      <Card>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            Custom Emoji
+          </Typography>
+          <Alert severity="info">
+            You don't have permission to manage custom emojis in this community.
+          </Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const submitting = isUploading || creating;
+
+  return (
+    <>
+      <Card>
+        <CardContent>
+          <Box mb={3}>
+            <Typography variant="h6">Custom Emoji</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Upload small images (PNG, GIF, or WebP, max 256KB) and give them a
+              <code> :shortcode: </code> name. Members can use them in messages and
+              as reactions.
+            </Typography>
+          </Box>
+
+          {/* Upload form */}
+          <Paper variant="outlined" sx={{ p: 2, mb: 3 }}>
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems={{ sm: "center" }}>
+              <Button
+                variant="outlined"
+                component="label"
+                startIcon={<UploadFileIcon />}
+              >
+                {file ? "Change image" : "Choose image"}
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/png,image/gif,image/webp"
+                  hidden
+                  onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+                />
+              </Button>
+              {file && (
+                <Typography variant="caption" color="text.secondary" sx={{ maxWidth: 160 }} noWrap>
+                  {file.name}
+                </Typography>
+              )}
+              <TextField
+                size="small"
+                label="Shortcode"
+                placeholder="party_blob"
+                value={name}
+                onChange={(e) => setName(e.target.value.toLowerCase())}
+                InputProps={{
+                  startAdornment: <Box component="span" sx={{ color: "text.disabled", mr: 0.5 }}>:</Box>,
+                  endAdornment: <Box component="span" sx={{ color: "text.disabled", ml: 0.5 }}>:</Box>,
+                }}
+              />
+              <Button
+                variant="contained"
+                startIcon={submitting ? <CircularProgress size={16} /> : <AddIcon />}
+                onClick={handleCreate}
+                disabled={submitting}
+              >
+                Add Emoji
+              </Button>
+            </Stack>
+            {formError && (
+              <Alert severity="error" sx={{ mt: 2 }}>
+                {formError}
+              </Alert>
+            )}
+          </Paper>
+
+          {listError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              Failed to load custom emojis. Please try again.
+            </Alert>
+          )}
+
+          {isLoading ? (
+            <Box display="flex" justifyContent="center" p={2}>
+              <CircularProgress />
+            </Box>
+          ) : emojis && emojis.length > 0 ? (
+            <TableContainer component={Paper} variant="outlined">
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Preview</TableCell>
+                    <TableCell>Shortcode</TableCell>
+                    <TableCell align="right">Actions</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {emojis.map((emoji) => (
+                    <TableRow key={emoji.id}>
+                      <TableCell>
+                        <img
+                          src={getFileUrl(emoji.fileId) ?? undefined}
+                          alt={`:${emoji.name}:`}
+                          style={{ height: 28, width: "auto", objectFit: "contain" }}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+                          :{emoji.name}:
+                        </Typography>
+                      </TableCell>
+                      <TableCell align="right">
+                        <Tooltip title="Delete emoji">
+                          <IconButton
+                            size="small"
+                            color="error"
+                            onClick={() => setEmojiToDelete(emoji)}
+                          >
+                            <DeleteIcon />
+                          </IconButton>
+                        </Tooltip>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          ) : (
+            <Box
+              display="flex"
+              flexDirection="column"
+              alignItems="center"
+              justifyContent="center"
+              py={4}
+            >
+              <Typography variant="h6" color="text.secondary" gutterBottom>
+                No custom emojis yet
+              </Typography>
+              <Typography variant="body2" color="text.secondary" align="center">
+                Upload an image above to add your first custom emoji.
+              </Typography>
+            </Box>
+          )}
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        open={!!emojiToDelete}
+        title="Delete Custom Emoji"
+        description={
+          <>
+            Are you sure you want to delete <strong>:{emojiToDelete?.name}:</strong>?
+            Existing messages will fall back to showing the shortcode text.
+          </>
+        }
+        confirmLabel="Delete"
+        confirmColor="error"
+        isLoading={deleting}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setEmojiToDelete(null)}
+      />
+    </>
+  );
+};
+
+export default CustomEmojiManagement;

--- a/frontend/src/components/Community/CustomEmojiManagement.tsx
+++ b/frontend/src/components/Community/CustomEmojiManagement.tsx
@@ -41,7 +41,7 @@ interface CustomEmojiManagementProps {
   communityId: string;
 }
 
-const NAME_REGEX = /^[a-z0-9_]{2,32}$/;
+const NAME_REGEX = /^(?=.*[a-z])[a-z0-9_]{2,32}$/;
 
 const CustomEmojiManagement: React.FC<CustomEmojiManagementProps> = ({ communityId }) => {
   const queryClient = useQueryClient();
@@ -97,7 +97,7 @@ const CustomEmojiManagement: React.FC<CustomEmojiManagementProps> = ({ community
     setFormError(null);
     if (!NAME_REGEX.test(name)) {
       setFormError(
-        "Name must be 2-32 characters of lowercase letters, numbers, or underscores.",
+        "Name must be 2-32 characters of lowercase letters, numbers, or underscores, and include at least one letter.",
       );
       return;
     }

--- a/frontend/src/components/Community/index.ts
+++ b/frontend/src/components/Community/index.ts
@@ -10,3 +10,4 @@ export { default as PrivateChannelMembership } from "./PrivateChannelMembership"
 export { default as RoleManagement } from "./RoleManagement";
 export { default as AliasGroupManagement } from "./AliasGroupManagement";
 export { default as AliasGroupEditor } from "./AliasGroupEditor";
+export { default as CustomEmojiManagement } from "./CustomEmojiManagement";

--- a/frontend/src/components/Message/EmojiPicker.tsx
+++ b/frontend/src/components/Message/EmojiPicker.tsx
@@ -3,6 +3,9 @@ import { IconButton, Popover, Box, Typography, TextField, InputAdornment } from 
 import { AddReaction as AddReactionIcon, Search as SearchIcon, Clear as ClearIcon } from '@mui/icons-material';
 import { useResponsive } from '../../hooks/useResponsive';
 import { MobileSheet } from '../Mobile/common/MobileSheet';
+import { useCommunityCustomEmojis } from '../../hooks/useCommunityCustomEmojis';
+import type { CustomEmojiDto } from '../../api-client/types.gen';
+import { getFileUrl } from '../../utils/fileHelpers';
 
 // Emoji names for search functionality
 export const EMOJI_NAMES: Record<string, string[]> = {
@@ -149,8 +152,19 @@ const EmojiPickerContent: React.FC<{
   onEmojiClick: (emoji: string) => void;
   /** Touch variant: full-width, taller, larger tap targets (for MobileSheet). */
   touch?: boolean;
-}> = ({ onEmojiClick, touch = false }) => {
+  /** Community custom emojis to show in a "Custom" section (channels only). */
+  customEmojis?: CustomEmojiDto[];
+  /** Called when a custom emoji is picked. */
+  onCustomEmojiClick?: (emoji: CustomEmojiDto) => void;
+}> = ({ onEmojiClick, touch = false, customEmojis = [], onCustomEmojiClick }) => {
   const [searchQuery, setSearchQuery] = useState('');
+
+  const filteredCustomEmojis = useMemo(() => {
+    if (!onCustomEmojiClick || customEmojis.length === 0) return [];
+    const query = searchQuery.toLowerCase().trim();
+    if (!query) return customEmojis;
+    return customEmojis.filter((e) => e.name.toLowerCase().includes(query));
+  }, [customEmojis, onCustomEmojiClick, searchQuery]);
 
   // Filter emojis based on search query
   const filteredCategories = useMemo(() => {
@@ -183,7 +197,9 @@ const EmojiPickerContent: React.FC<{
     return results;
   }, [searchQuery]);
 
-  const hasResults = Object.keys(filteredCategories).length > 0;
+  const hasResults =
+    Object.keys(filteredCategories).length > 0 ||
+    filteredCustomEmojis.length > 0;
 
   return (
     <Box sx={{
@@ -274,6 +290,65 @@ const EmojiPickerContent: React.FC<{
           },
         }}
       >
+        {filteredCustomEmojis.length > 0 && (
+          <Box sx={{ mb: 1.5 }}>
+            <Typography
+              variant="caption"
+              sx={{
+                display: 'block',
+                mb: 0.75,
+                fontSize: '0.7rem',
+                fontWeight: 500,
+                color: 'text.disabled',
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+              }}
+            >
+              Custom
+            </Typography>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(8, 1fr)',
+                gap: '2px',
+                width: '100%',
+              }}
+            >
+              {filteredCustomEmojis.map((emoji) => (
+                <IconButton
+                  key={emoji.id}
+                  size="small"
+                  title={`:${emoji.name}:`}
+                  aria-label={`:${emoji.name}:`}
+                  onClick={() => onCustomEmojiClick?.(emoji)}
+                  sx={{
+                    padding: touch ? '8px' : '4px',
+                    borderRadius: '4px',
+                    aspectRatio: '1',
+                    minWidth: 'unset',
+                    width: '100%',
+                    height: 'auto',
+                    transition: 'all 0.12s cubic-bezier(0.4, 0, 0.2, 1)',
+                    '&:hover': {
+                      backgroundColor: 'rgba(88, 101, 242, 0.12)',
+                      transform: 'scale(1.1)',
+                    },
+                  }}
+                >
+                  <img
+                    src={getFileUrl(emoji.fileId) ?? undefined}
+                    alt={`:${emoji.name}:`}
+                    style={{
+                      width: touch ? '24px' : '18px',
+                      height: touch ? '24px' : '18px',
+                      objectFit: 'contain',
+                    }}
+                  />
+                </IconButton>
+              ))}
+            </Box>
+          </Box>
+        )}
         {hasResults ? (
           Object.entries(filteredCategories).map(([categoryName, emojis], index) => (
             <Box key={categoryName} sx={{ mb: 1.5 }}>
@@ -363,6 +438,10 @@ export interface EmojiPickerPopoverProps {
   anchorEl?: HTMLElement | null;
   onClose: () => void;
   onEmojiSelect: (emoji: string) => void;
+  /** When set, a "Custom" section shows this community's emojis (channels only). */
+  communityId?: string | null;
+  /** Called when a custom emoji is picked (composer inserts `:name:`, reactions send the sentinel). */
+  onCustomEmojiSelect?: (emoji: CustomEmojiDto) => void;
   /** Sheet title on touch devices. */
   title?: string;
 }
@@ -379,13 +458,29 @@ export const EmojiPickerPopover: React.FC<EmojiPickerPopoverProps> = ({
   anchorEl,
   onClose,
   onEmojiSelect,
+  communityId,
+  onCustomEmojiSelect,
   title = 'Add Reaction',
 }) => {
   const { shouldUseTouchUI } = useResponsive();
+  const { emojis: customEmojis } = useCommunityCustomEmojis(
+    onCustomEmojiSelect ? communityId : undefined,
+  );
 
   const handleEmojiClick = (emoji: string) => {
     onEmojiSelect(emoji);
     onClose();
+  };
+
+  const handleCustomEmojiClick = (emoji: CustomEmojiDto) => {
+    onCustomEmojiSelect?.(emoji);
+    onClose();
+  };
+
+  const contentProps = {
+    onEmojiClick: handleEmojiClick,
+    customEmojis,
+    onCustomEmojiClick: onCustomEmojiSelect ? handleCustomEmojiClick : undefined,
   };
 
   // On touch devices, present the picker as a full-width bottom sheet instead
@@ -393,7 +488,7 @@ export const EmojiPickerPopover: React.FC<EmojiPickerPopoverProps> = ({
   if (shouldUseTouchUI) {
     return (
       <MobileSheet open={open} onClose={onClose} title={title} maxHeight="70vh">
-        <EmojiPickerContent onEmojiClick={handleEmojiClick} touch />
+        <EmojiPickerContent {...contentProps} touch />
       </MobileSheet>
     );
   }
@@ -418,7 +513,7 @@ export const EmojiPickerPopover: React.FC<EmojiPickerPopoverProps> = ({
           horizontal: 'left',
         }}
       >
-        <EmojiPickerContent onEmojiClick={handleEmojiClick} />
+        <EmojiPickerContent {...contentProps} />
       </Popover>
     );
   }
@@ -434,21 +529,32 @@ export const EmojiPickerPopover: React.FC<EmojiPickerPopoverProps> = ({
         horizontal: 'left',
       }}
     >
-      <EmojiPickerContent onEmojiClick={handleEmojiClick} />
+      <EmojiPickerContent {...contentProps} />
     </Popover>
   );
 };
 
 interface EmojiPickerProps {
   onEmojiSelect: (emoji: string) => void;
+  /** When set, a "Custom" section shows this community's emojis (channels only). */
+  communityId?: string | null;
+  /** Called when a custom emoji is picked. */
+  onCustomEmojiSelect?: (emoji: CustomEmojiDto) => void;
 }
 
 /**
  * Self-contained emoji picker with its own trigger button.
  * Used in the message hover toolbar.
  */
-export const EmojiPicker: React.FC<EmojiPickerProps> = ({ onEmojiSelect }) => {
+export const EmojiPicker: React.FC<EmojiPickerProps> = ({
+  onEmojiSelect,
+  communityId,
+  onCustomEmojiSelect,
+}) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const { emojis: customEmojis } = useCommunityCustomEmojis(
+    onCustomEmojiSelect ? communityId : undefined,
+  );
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
@@ -460,6 +566,11 @@ export const EmojiPicker: React.FC<EmojiPickerProps> = ({ onEmojiSelect }) => {
 
   const handleEmojiClick = (emoji: string) => {
     onEmojiSelect(emoji);
+    handleClose();
+  };
+
+  const handleCustomEmojiClick = (emoji: CustomEmojiDto) => {
+    onCustomEmojiSelect?.(emoji);
     handleClose();
   };
 
@@ -483,7 +594,11 @@ export const EmojiPicker: React.FC<EmojiPickerProps> = ({ onEmojiSelect }) => {
           horizontal: 'left',
         }}
       >
-        <EmojiPickerContent onEmojiClick={handleEmojiClick} />
+        <EmojiPickerContent
+          onEmojiClick={handleEmojiClick}
+          customEmojis={customEmojis}
+          onCustomEmojiClick={onCustomEmojiSelect ? handleCustomEmojiClick : undefined}
+        />
       </Popover>
     </>
   );

--- a/frontend/src/components/Message/MessageComponent.tsx
+++ b/frontend/src/components/Message/MessageComponent.tsx
@@ -34,6 +34,7 @@ import MessageActionsSheet from "./MessageActionsSheet";
 import { EmojiPickerPopover } from "./EmojiPicker";
 import { useResponsive } from "../../hooks/useResponsive";
 import { useLongPress } from "../../hooks/useSwipeGesture";
+import { useCommunityCustomEmojis } from "../../hooks/useCommunityCustomEmojis";
 
 interface MessageProps {
   message: MessageType;
@@ -54,12 +55,15 @@ function MessageComponentInner({
   isAuthor,
   isSearchHighlight,
   contextId,
+  communityId,
   isThreadParent,
   isThreadReply,
   onOpenThread,
   onQuoteReply,
   contextType,
 }: MessageProps) {
+  // Community custom emojis (for rendering EMOJI spans + custom reactions).
+  const { byId: emojiById } = useCommunityCustomEmojis(communityId);
   const { data: author } = useQuery({
     ...userControllerGetUserByIdOptions({ path: { id: message.authorId! } }),
     enabled: !!message.authorId,
@@ -264,7 +268,7 @@ function MessageComponentInner({
         ) : (
           <>
             <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word', wordBreak: 'break-word' }}>
-              {renderMessageSpans(message.spans)}
+              {renderMessageSpans(message.spans, emojiById)}
             </Typography>
             <MessageAttachments attachments={message.attachments} />
             <MessageLinkPreviews linkPreviews={message.linkPreviews} />
@@ -272,6 +276,7 @@ function MessageComponentInner({
               messageId={message.id}
               reactions={message.reactions}
               onReactionClick={handleReactionClick}
+              emojiById={emojiById}
             />
             {/* Show thread reply badge if message has replies and not in thread context */}
             {hasReplies && !isThreadParent && !isThreadReply && (
@@ -301,6 +306,7 @@ function MessageComponentInner({
           onUnpin={handleUnpin}
           onReplyInThread={handleOpenThread}
           onQuoteReply={onQuoteReply && !message.deletedAt ? () => onQuoteReply(message) : undefined}
+          communityId={communityId}
         />
       )}
       <ConfirmDialog
@@ -359,6 +365,11 @@ function MessageComponentInner({
         onClose={handleCloseEmojiPicker}
         onEmojiSelect={(emoji) => {
           handleEmojiSelect(emoji);
+          handleCloseEmojiPicker();
+        }}
+        communityId={communityId}
+        onCustomEmojiSelect={(emoji) => {
+          handleEmojiSelect(`custom:${emoji.id}`);
           handleCloseEmojiPicker();
         }}
       />

--- a/frontend/src/components/Message/MessageInput.tsx
+++ b/frontend/src/components/Message/MessageInput.tsx
@@ -31,10 +31,12 @@ import type {
   UserMention,
   ChannelMention,
   AliasMention,
+  EmojiMention,
 } from "../../utils/mentionParser";
 import { wrapSelection, markerForShortcut } from "../../utils/richTextShortcuts";
 import { useQuery } from "@tanstack/react-query";
 import { aliasGroupsControllerGetCommunityAliasGroupsOptions } from "../../api-client/@tanstack/react-query.gen";
+import { useCommunityCustomEmojis } from "../../hooks/useCommunityCustomEmojis";
 import { logger } from "../../utils/logger";
 import { ACCEPTED_FILE_TYPES } from "../../constants/messages";
 import { useNotification } from "../../contexts/NotificationContext";
@@ -191,6 +193,16 @@ export default function MessageInput({
     ? aliasGroups.map(group => ({ id: group.id, name: group.name }))
     : [];
 
+  // Custom emojis (channel only) — used to resolve `:shortcode:` at send time
+  // and to power the picker's Custom section.
+  const { emojis: customEmojis } = useCommunityCustomEmojis(
+    isChannel ? communityId : undefined,
+  );
+  const emojiMentions: EmojiMention[] = customEmojis.map(e => ({
+    id: e.id,
+    name: e.name,
+  }));
+
   // Local mention state for DMs
   const [dmMentionState, setDmMentionState] = useState<SimpleMentionState>({
     isOpen: false,
@@ -338,7 +350,7 @@ export default function MessageInput({
     setSending(true);
     try {
       const messageText = text.trim() || "";
-      let spans = parseMessageWithMentions(messageText, userMentions, channelMentions, aliasMentions);
+      let spans = parseMessageWithMentions(messageText, userMentions, channelMentions, aliasMentions, emojiMentions);
 
       if (spans.length === 0) {
         spans = [{ type: SpanType.PLAINTEXT, text: '' }];
@@ -561,6 +573,8 @@ export default function MessageInput({
         anchorEl={emojiAnchorEl}
         onClose={handleEmojiPickerClose}
         onEmojiSelect={handleEmojiSelect}
+        communityId={isChannel ? communityId : undefined}
+        onCustomEmojiSelect={(emoji) => handleEmojiSelect(`:${emoji.name}:`)}
         title="Add Emoji"
       />
     </Box>

--- a/frontend/src/components/Message/MessageReactions.tsx
+++ b/frontend/src/components/Message/MessageReactions.tsx
@@ -4,28 +4,74 @@ import { useTheme, alpha } from '@mui/material/styles';
 import type { Reaction } from '../../types/message.type';
 import { useQuery } from '@tanstack/react-query';
 import { userControllerGetProfileOptions } from '../../api-client/@tanstack/react-query.gen';
+import type { CustomEmojiDto } from '../../api-client/types.gen';
+import { getFileUrl } from '../../utils/fileHelpers';
 import { ReactionTooltip } from './ReactionTooltip';
 
 interface MessageReactionsProps {
   messageId: string;
   reactions: Reaction[];
   onReactionClick: (emoji: string) => void;
+  /** Community custom emojis, keyed by id — resolves `custom:{id}` reactions. */
+  emojiById?: Map<string, CustomEmojiDto>;
 }
+
+/** Sentinel prefix for custom (community) emoji reactions: `custom:{emojiId}`. */
+const CUSTOM_REACTION_PREFIX = 'custom:';
+
+/** Inline image label for a custom-emoji reaction chip, with count. */
+const CustomReactionLabel: React.FC<{
+  emoji: string;
+  count: number;
+  emojiById?: Map<string, CustomEmojiDto>;
+}> = ({ emoji, count, emojiById }) => {
+  const id = emoji.slice(CUSTOM_REACTION_PREFIX.length);
+  const custom = emojiById?.get(id);
+  const src = custom ? getFileUrl(custom.fileId) : null;
+  return (
+    <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
+      {custom && src ? (
+        <img
+          src={src}
+          alt={`:${custom.name}:`}
+          title={`:${custom.name}:`}
+          style={{ height: '1.15em', width: 'auto', verticalAlign: '-0.2em' }}
+        />
+      ) : (
+        // Unknown/deleted custom emoji — neutral placeholder.
+        <span>{custom ? `:${custom.name}:` : '❓'}</span>
+      )}
+      {count}
+    </Box>
+  );
+};
 
 // Component to display user info for a single reaction
 const SingleReactionChip: React.FC<{
   reaction: Reaction;
   userHasReacted: boolean;
-  onReactionClick: (emoji: string) => void
-}> = ({ reaction, userHasReacted, onReactionClick }) => {
+  onReactionClick: (emoji: string) => void;
+  emojiById?: Map<string, CustomEmojiDto>;
+}> = ({ reaction, userHasReacted, onReactionClick, emojiById }) => {
   const theme = useTheme();
   const userIds = reaction.userIds ?? [];
   const count = userIds.length;
+  const isCustom = reaction.emoji.startsWith(CUSTOM_REACTION_PREFIX);
 
   return (
     <ReactionTooltip userIds={userIds}>
       <Chip
-        label={`${reaction.emoji} ${count}`}
+        label={
+          isCustom ? (
+            <CustomReactionLabel
+              emoji={reaction.emoji}
+              count={count}
+              emojiById={emojiById}
+            />
+          ) : (
+            `${reaction.emoji} ${count}`
+          )
+        }
         size="small"
         variant="filled"
         onClick={() => onReactionClick(reaction.emoji)}
@@ -68,9 +114,10 @@ const SingleReactionChip: React.FC<{
   );
 };
 
-export const MessageReactions: React.FC<MessageReactionsProps> = ({ 
-  reactions, 
-  onReactionClick 
+export const MessageReactions: React.FC<MessageReactionsProps> = ({
+  reactions,
+  onReactionClick,
+  emojiById,
 }) => {
   const { data: currentUser } = useQuery(userControllerGetProfileOptions());
 
@@ -87,6 +134,7 @@ export const MessageReactions: React.FC<MessageReactionsProps> = ({
             reaction={reaction}
             userHasReacted={userHasReacted}
             onReactionClick={onReactionClick}
+            emojiById={emojiById}
           />
         );
       })}

--- a/frontend/src/components/Message/MessageSpan.tsx
+++ b/frontend/src/components/Message/MessageSpan.tsx
@@ -5,22 +5,66 @@
  * Supports mentions (user, special, community, alias) and plain text.
  */
 
-import React from "react";
+import React, { useState } from "react";
 import { useTheme } from "@mui/material/styles";
 import { Span, SpanType } from "../../types/message.type";
+import type { CustomEmojiDto } from "../../api-client/types.gen";
+import { getFileUrl } from "../../utils/fileHelpers";
 
 export interface MessageSpanProps {
   span: Span;
   index: number;
+  /** Community custom emojis, keyed by id — resolves EMOJI spans to images. */
+  emojiById?: Map<string, CustomEmojiDto>;
 }
+
+/**
+ * Inline custom-emoji image with graceful fallback: if the emoji is unknown
+ * (e.g. deleted) or the image fails to load, the `:shortcode:` text is shown.
+ */
+const EmojiImage: React.FC<{ emoji: CustomEmojiDto; fallback: string }> = ({
+  emoji,
+  fallback,
+}) => {
+  const [failed, setFailed] = useState(false);
+  const src = getFileUrl(emoji.fileId);
+  if (failed || !src) return <>{fallback}</>;
+  return (
+    <img
+      src={src}
+      alt={`:${emoji.name}:`}
+      title={`:${emoji.name}:`}
+      onError={() => setFailed(true)}
+      style={{
+        height: "1.375em",
+        width: "auto",
+        verticalAlign: "-0.3em",
+        margin: "0 1px",
+        objectFit: "contain",
+      }}
+    />
+  );
+};
 
 /**
  * Render a single message span with type-specific styling
  */
-export const MessageSpan: React.FC<MessageSpanProps> = ({ span, index }) => {
+export const MessageSpan: React.FC<MessageSpanProps> = ({ span, index, emojiById }) => {
   const theme = useTheme();
 
   switch (span.type) {
+    case SpanType.EMOJI: {
+      const emoji = span.emojiId ? emojiById?.get(span.emojiId) : undefined;
+      if (!emoji) {
+        // Unknown/deleted emoji — render the literal shortcode.
+        return <span key={index}>{span.text || ""}</span>;
+      }
+      return (
+        <span key={index}>
+          <EmojiImage emoji={emoji} fallback={span.text || `:${emoji.name}:`} />
+        </span>
+      );
+    }
     case SpanType.USER_MENTION:
       return (
         <span key={index} style={{ color: theme.palette.primary.main, fontWeight: 600 }}>
@@ -123,6 +167,11 @@ export const MessageSpan: React.FC<MessageSpanProps> = ({ span, index }) => {
  * Render an array of message spans
  */
 // eslint-disable-next-line react-refresh/only-export-components
-export const renderMessageSpans = (spans: Span[]): React.ReactNode => {
-  return spans.map((span, idx) => <MessageSpan key={idx} span={span} index={idx} />);
+export const renderMessageSpans = (
+  spans: Span[],
+  emojiById?: Map<string, CustomEmojiDto>,
+): React.ReactNode => {
+  return spans.map((span, idx) => (
+    <MessageSpan key={idx} span={span} index={idx} emojiById={emojiById} />
+  ));
 };

--- a/frontend/src/components/Message/MessageToolbar.tsx
+++ b/frontend/src/components/Message/MessageToolbar.tsx
@@ -52,6 +52,8 @@ export interface MessageToolbarProps {
   onUnpin: () => void;
   onReplyInThread: () => void;
   onQuoteReply?: () => void;
+  /** Community for the custom-emoji reaction section (channels only). */
+  communityId?: string | null;
 }
 
 export const MessageToolbar: React.FC<MessageToolbarProps> = ({
@@ -70,6 +72,7 @@ export const MessageToolbar: React.FC<MessageToolbarProps> = ({
   onUnpin,
   onReplyInThread,
   onQuoteReply,
+  communityId,
 }) => {
   return (
     <MessageTools
@@ -104,7 +107,11 @@ export const MessageToolbar: React.FC<MessageToolbarProps> = ({
         </>
       ) : (
         <>
-          <EmojiPicker onEmojiSelect={onEmojiSelect} />
+          <EmojiPicker
+            onEmojiSelect={onEmojiSelect}
+            communityId={communityId}
+            onCustomEmojiSelect={(emoji) => onEmojiSelect(`custom:${emoji.id}`)}
+          />
           {onQuoteReply && (
             <Tooltip title="Quote reply">
               <IconButton size="small" onClick={onQuoteReply}>

--- a/frontend/src/components/Message/useMessageActions.ts
+++ b/frontend/src/components/Message/useMessageActions.ts
@@ -215,8 +215,23 @@ export function useMessageActions(
           displayName: span.text?.replace('@', '') || 'user',
         }));
 
-      // Parse edited text back to spans, preserving existing mentions
-      let parsedSpans: Span[] = parseMessageWithMentions(editText, mentionedUsers);
+      // Preserve custom emojis already present in the message so editing
+      // doesn't turn their `:shortcode:` back into literal text.
+      const messageEmojis = message.spans
+        .filter(span => span.type === SpanType.EMOJI && span.emojiId)
+        .map(span => ({
+          id: span.emojiId!,
+          name: (span.text || '').replace(/:/g, ''),
+        }));
+
+      // Parse edited text back to spans, preserving existing mentions + emojis
+      let parsedSpans: Span[] = parseMessageWithMentions(
+        editText,
+        mentionedUsers,
+        [],
+        [],
+        messageEmojis,
+      );
 
       // Ensure at least one span exists
       if (parsedSpans.length === 0) {
@@ -235,6 +250,7 @@ export function useMessageActions(
             specialKind: span.specialKind ?? null,
             communityId: span.communityId ?? null,
             aliasId: span.aliasId ?? null,
+            emojiId: span.emojiId ?? null,
           })),
           attachments: editAttachments.map(att => att.id),
         },

--- a/frontend/src/components/Thread/ThreadMessageInput.tsx
+++ b/frontend/src/components/Thread/ThreadMessageInput.tsx
@@ -22,20 +22,31 @@ import { logger } from "../../utils/logger";
 import { EmojiPickerPopover } from "../Message/EmojiPicker";
 import { useResponsive } from "../../hooks/useResponsive";
 import { parseMessageWithMentions } from "../../utils/mentionParser";
+import type { EmojiMention } from "../../utils/mentionParser";
 import { wrapSelection, markerForShortcut } from "../../utils/richTextShortcuts";
+import { useCommunityCustomEmojis } from "../../hooks/useCommunityCustomEmojis";
 
 interface ThreadMessageInputProps {
   parentMessageId: string;
+  /** Community for custom emojis (undefined in DM threads). */
+  communityId?: string;
 }
 
 export const ThreadMessageInput: React.FC<ThreadMessageInputProps> = ({
   parentMessageId,
+  communityId,
 }) => {
   const theme = useTheme();
   const { socket } = useContext(SocketContext);
   const { isTouchDevice } = useResponsive();
   const [content, setContent] = useState("");
   const [isSending, setIsSending] = useState(false);
+
+  const { emojis: customEmojis } = useCommunityCustomEmojis(communityId);
+  const emojiMentions: EmojiMention[] = customEmojis.map(e => ({
+    id: e.id,
+    name: e.name,
+  }));
 
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const [emojiAnchorEl, setEmojiAnchorEl] = useState<HTMLElement | null>(null);
@@ -106,7 +117,7 @@ export const ThreadMessageInput: React.FC<ThreadMessageInputProps> = ({
     // Parse markdown-style rich-text formatting (bold/italic/strike/code).
     // Thread replies have no mention autocomplete context, so mentions are
     // left unresolved (rendered as plaintext), matching prior behaviour.
-    let spans = parseMessageWithMentions(trimmedContent);
+    let spans = parseMessageWithMentions(trimmedContent, [], [], [], emojiMentions);
     if (spans.length === 0) {
       spans = [{ type: SpanType.PLAINTEXT, text: trimmedContent }];
     }
@@ -227,6 +238,8 @@ export const ThreadMessageInput: React.FC<ThreadMessageInputProps> = ({
         anchorEl={emojiAnchorEl}
         onClose={handleEmojiPickerClose}
         onEmojiSelect={handleEmojiSelect}
+        communityId={communityId}
+        onCustomEmojiSelect={(emoji) => handleEmojiSelect(`:${emoji.name}:`)}
         title="Add Emoji"
       />
     </Box>

--- a/frontend/src/components/Thread/ThreadPanel.tsx
+++ b/frontend/src/components/Thread/ThreadPanel.tsx
@@ -236,7 +236,7 @@ export const ThreadPanel: React.FC<ThreadPanelProps> = ({
       </Box>
 
       {/* Message Input */}
-      <ThreadMessageInput parentMessageId={parentMessageId} />
+      <ThreadMessageInput parentMessageId={parentMessageId} communityId={communityId} />
     </Box>
   );
 };

--- a/frontend/src/constants/rbacActions.ts
+++ b/frontend/src/constants/rbacActions.ts
@@ -70,6 +70,9 @@ export const RBAC_ACTIONS = {
   CREATE_ATTACHMENT: 'CREATE_ATTACHMENT',
   DELETE_ATTACHMENT: 'DELETE_ATTACHMENT',
 
+  // Custom Emojis
+  MANAGE_EMOJIS: 'MANAGE_EMOJIS',
+
   // Moderation
   BAN_USER: 'BAN_USER',
   KICK_USER: 'KICK_USER',
@@ -144,6 +147,7 @@ export const PERMISSION_GROUPS = {
     RBAC_ACTIONS.DELETE_REACTION,
     RBAC_ACTIONS.CREATE_ATTACHMENT,
     RBAC_ACTIONS.DELETE_ATTACHMENT,
+    RBAC_ACTIONS.MANAGE_EMOJIS,
   ],
   'Alias Groups': [
     RBAC_ACTIONS.CREATE_ALIAS_GROUP,
@@ -220,6 +224,7 @@ export const ACTION_LABELS: Record<RbacAction, string> = {
   [RBAC_ACTIONS.DELETE_REACTION]: 'Remove reactions',
   [RBAC_ACTIONS.CREATE_ATTACHMENT]: 'Upload files',
   [RBAC_ACTIONS.DELETE_ATTACHMENT]: 'Delete files',
+  [RBAC_ACTIONS.MANAGE_EMOJIS]: 'Manage custom emojis',
 
   // Alias Groups
   [RBAC_ACTIONS.CREATE_ALIAS_GROUP]: 'Create mention groups',

--- a/frontend/src/hooks/useCommunityCustomEmojis.ts
+++ b/frontend/src/hooks/useCommunityCustomEmojis.ts
@@ -1,0 +1,39 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { customEmojiControllerListCommunityEmojisOptions } from "../api-client/@tanstack/react-query.gen";
+import type { CustomEmojiDto } from "../api-client/types.gen";
+
+export interface CommunityCustomEmojis {
+  emojis: CustomEmojiDto[];
+  /** Lookup by emoji id (for rendering spans / reaction sentinels). */
+  byId: Map<string, CustomEmojiDto>;
+  /** Lookup by shortcode name (for parsing `:name:` in the composer). */
+  byName: Map<string, CustomEmojiDto>;
+  isLoading: boolean;
+}
+
+/**
+ * Fetch a community's custom emojis (cached via TanStack Query). Disabled for
+ * DMs / when no community is in context, in which case empty maps are returned.
+ */
+export function useCommunityCustomEmojis(
+  communityId?: string | null,
+): CommunityCustomEmojis {
+  const { data, isLoading } = useQuery({
+    ...customEmojiControllerListCommunityEmojisOptions({
+      path: { communityId: communityId || "" },
+    }),
+    enabled: !!communityId,
+  });
+
+  return useMemo(() => {
+    const emojis = data ?? [];
+    const byId = new Map<string, CustomEmojiDto>();
+    const byName = new Map<string, CustomEmojiDto>();
+    for (const emoji of emojis) {
+      byId.set(emoji.id, emoji);
+      byName.set(emoji.name, emoji);
+    }
+    return { emojis, byId, byName, isLoading };
+  }, [data, isLoading]);
+}

--- a/frontend/src/pages/EditCommunityPage.tsx
+++ b/frontend/src/pages/EditCommunityPage.tsx
@@ -32,6 +32,7 @@ import {
   PrivateChannelMembership,
   RoleManagement,
   AliasGroupManagement,
+  CustomEmojiManagement,
 } from "../components/Community";
 import {
   BanListPanel,
@@ -126,6 +127,12 @@ const EditCommunityPage: React.FC = () => {
     resourceType: "COMMUNITY",
     resourceId: communityId!,
     actions: ["VIEW_BAN_LIST"],
+  });
+
+  const { hasPermissions: canManageEmojis } = useUserPermissions({
+    resourceType: "COMMUNITY",
+    resourceId: communityId!,
+    actions: ["MANAGE_EMOJIS"],
   });
 
   const {
@@ -264,7 +271,8 @@ const EditCommunityPage: React.FC = () => {
             <Tab label="Private Channels" {...a11yProps(3)} disabled={!canManageChannels} />
             <Tab label="Roles" {...a11yProps(4)} />
             <Tab label="Mention Groups" {...a11yProps(5)} />
-            <Tab label="Moderation" {...a11yProps(6)} disabled={!canViewModeration} />
+            <Tab label="Custom Emoji" {...a11yProps(6)} disabled={!canManageEmojis} />
+            <Tab label="Moderation" {...a11yProps(7)} disabled={!canViewModeration} />
           </Tabs>
         </Box>
 
@@ -349,6 +357,16 @@ const EditCommunityPage: React.FC = () => {
         </TabPanel>
 
         <TabPanel value={tabValue} index={6}>
+          {canManageEmojis ? (
+            <CustomEmojiManagement communityId={communityId!} />
+          ) : (
+            <Alert severity="warning">
+              You don't have permission to manage custom emojis.
+            </Alert>
+          )}
+        </TabPanel>
+
+        <TabPanel value={tabValue} index={7}>
           {canViewModeration ? (
             <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
               <Box sx={{ display: "flex", gap: 3, flexWrap: "wrap" }}>

--- a/frontend/src/utils/mentionParser.ts
+++ b/frontend/src/utils/mentionParser.ts
@@ -25,6 +25,14 @@ export interface AliasMention {
   name: string;
 }
 
+export interface EmojiMention {
+  id: string;
+  name: string;
+}
+
+/** Matches a `:shortcode:` custom-emoji token (lowercase, digits, underscore). */
+const EMOJI_TOKEN_REGEX = /:([a-z0-9_]{2,32}):/g;
+
 /**
  * Find regions in text that are inside code blocks or inline code.
  * Returns array of [start, end] ranges that should be excluded from mention parsing.
@@ -116,15 +124,49 @@ function parseMentionRun(
   text: string,
   userMentions: UserMention[],
   channelMentions: ChannelMention[],
-  aliasMentions: AliasMention[]
+  aliasMentions: AliasMention[],
+  emojiMentions: EmojiMention[] = []
 ): MessageSpan[] {
   const spans: MessageSpan[] = [];
-  const mentions = findMentions(text);
+
+  // Collect resolved custom-emoji tokens (unknown shortcodes stay literal) and
+  // interleave them with mentions, ordered by position.
+  const emojiTokens: {
+    type: 'emoji';
+    start: number;
+    end: number;
+    text: string;
+    emoji: EmojiMention;
+  }[] = [];
+  if (emojiMentions.length > 0) {
+    const byName = new Map(emojiMentions.map((e) => [e.name, e]));
+    let m: RegExpExecArray | null;
+    EMOJI_TOKEN_REGEX.lastIndex = 0;
+    while ((m = EMOJI_TOKEN_REGEX.exec(text)) !== null) {
+      const emoji = byName.get(m[1]);
+      if (emoji) {
+        emojiTokens.push({
+          type: 'emoji',
+          start: m.index,
+          end: m.index + m[0].length,
+          text: m[0],
+          emoji,
+        });
+      }
+    }
+  }
+
+  const tokens = [...findMentions(text), ...emojiTokens].sort(
+    (a, b) => a.start - b.start
+  );
 
   let lastIndex = 0;
 
-  for (const mention of mentions) {
-    // Add plaintext before this mention
+  for (const mention of tokens) {
+    // Skip tokens overlapping an already-consumed region.
+    if (mention.start < lastIndex) continue;
+
+    // Add plaintext before this token
     if (mention.start > lastIndex) {
       const plaintext = text.substring(lastIndex, mention.start);
       if (plaintext) {
@@ -132,8 +174,13 @@ function parseMentionRun(
       }
     }
 
-    // Find resolved mention
-    if (mention.type === 'user') {
+    if (mention.type === 'emoji') {
+      spans.push({
+        type: SpanType.EMOJI,
+        text: mention.text, // `:shortcode:` for round-trip + fallback
+        emojiId: mention.emoji.id,
+      });
+    } else if (mention.type === 'user') {
       // First check if this is an alias group mention
       const resolvedAlias = aliasMentions.find(
         alias => alias.name.toLowerCase() === mention.query.toLowerCase()
@@ -269,7 +316,8 @@ function parseInline(
   style: StyleFlags,
   userMentions: UserMention[],
   channelMentions: ChannelMention[],
-  aliasMentions: AliasMention[]
+  aliasMentions: AliasMention[],
+  emojiMentions: EmojiMention[] = []
 ): MessageSpan[] {
   const result: MessageSpan[] = [];
   let buffer = '';
@@ -277,7 +325,13 @@ function parseInline(
 
   const flushBuffer = () => {
     if (!buffer) return;
-    const runSpans = parseMentionRun(buffer, userMentions, channelMentions, aliasMentions);
+    const runSpans = parseMentionRun(
+      buffer,
+      userMentions,
+      channelMentions,
+      aliasMentions,
+      emojiMentions
+    );
     for (const s of runSpans) result.push(withStyle(s, style));
     buffer = '';
   };
@@ -320,7 +374,8 @@ function parseInline(
           { ...style, [flag]: true },
           userMentions,
           channelMentions,
-          aliasMentions
+          aliasMentions,
+          emojiMentions
         )
       );
       i = close + marker.length;
@@ -369,7 +424,8 @@ export function parseMessageWithMentions(
   text: string,
   userMentions: UserMention[] = [],
   channelMentions: ChannelMention[] = [],
-  aliasMentions: AliasMention[] = []
+  aliasMentions: AliasMention[] = [],
+  emojiMentions: EmojiMention[] = []
 ): MessageSpan[] {
   const spans: MessageSpan[] = [];
 
@@ -386,7 +442,8 @@ export function parseMessageWithMentions(
           {},
           userMentions,
           channelMentions,
-          aliasMentions
+          aliasMentions,
+          emojiMentions
         )
       );
     }
@@ -404,7 +461,8 @@ export function parseMessageWithMentions(
         {},
         userMentions,
         channelMentions,
-        aliasMentions
+        aliasMentions,
+        emojiMentions
       )
     );
   }
@@ -425,6 +483,9 @@ export function spansToText(spans: MessageSpan[]): string {
         return span.text || `@${span.specialKind}`;
       case SpanType.COMMUNITY_MENTION:
       case SpanType.ALIAS_MENTION:
+        return span.text || '';
+      case SpanType.EMOJI:
+        // Round-trips to `:shortcode:` (stored on span.text).
         return span.text || '';
       case SpanType.CODE_BLOCK:
         return '```\n' + (span.text || '') + '\n```';

--- a/shared/src/types/message.types.ts
+++ b/shared/src/types/message.types.ts
@@ -7,6 +7,9 @@ export enum SpanType {
   // Multi-line fenced (```) code block. Its `text` is rendered verbatim —
   // no mentions, inline formatting, or auto-linking are parsed inside it.
   CODE_BLOCK = 'CODE_BLOCK',
+  // Community custom emoji (`:shortcode:`). Rendered as an inline image resolved
+  // from `emojiId`; `text` holds the `:shortcode:` for round-trip and fallback.
+  EMOJI = 'EMOJI',
 }
 
 export interface Span {
@@ -16,6 +19,8 @@ export interface Span {
   specialKind?: string;
   communityId?: string;
   aliasId?: string;
+  // For EMOJI spans: id of the community CustomEmoji this shortcode resolved to.
+  emojiId?: string;
   // Composable inline-formatting flags applied to PLAINTEXT spans. They combine
   // freely (a span can be bold AND italic). `code` marks an inline `code` run
   // whose text is rendered verbatim (no formatting/mentions/links inside).


### PR DESCRIPTION
Closes #300.

Community-scoped custom emojis: community managers upload small images as named `:shortcode:` emojis; members use them inline in messages and as reactions, rendered as images. (Stickers were explicitly out of scope.)

## Data model
- **`CustomEmoji`** `{ id, communityId → Community (cascade), name, fileId → File (cascade), createdBy, createdAt, @@unique([communityId, name]) }`.
- **`MessageSpan.emojiId String?`** FK → CustomEmoji, `ON DELETE SET NULL` (a deleted emoji leaves the span's `:shortcode:` text as a graceful fallback). New **`SpanType.EMOJI`**.
- New **`MANAGE_EMOJIS`** RbacAction.
- Migration `20260705082747_custom_emojis` — the spurious `DROP COLUMN "searchVector"` + index drop that `prisma migrate dev` always generates (it can't model the manually-managed tsvector) was **hand-stripped**; the migration contains only the CustomEmoji/emojiId/enum changes.

## RBAC
- `list` (GET) — any community member (`READ_COMMUNITY`).
- `create` (POST) / `delete` (DELETE) — `MANAGE_EMOJIS`, gated with `@RbacResource({ type: COMMUNITY, … })`.
- `MANAGE_EMOJIS` seeded onto the **Community Admin** and **Community Creator** default roles; added to `swagger-enums.ts` and the frontend `rbacActions.ts`.
- Create validates name format `^[a-z0-9_]{2,32}$` and that the referenced file is a `CUSTOM_EMOJI` belonging to the community.

## Reactions
`MessageReaction.emoji` stays a free-form string. Custom reactions use the sentinel **`custom:{emojiId}`**. `reactions.service.addReaction` validates the sentinel (emoji exists, belongs to the message's channel community, reactor is a member); unicode reactions are unchanged. Removal is unrestricted.

## Span approach — emojiId vs fileId (documented choice)
The EMOJI span stores **`emojiId`** (not `fileId`). The renderer and reaction chips resolve `emojiId → fileId` through the cached community-emoji query (`useCommunityCustomEmojis`). This keeps the span minimal and means deleted/renamed emojis don't leave stale denormalized data — they fall back to the `:shortcode:` text stored on the span. The reaction sentinel only carries the id, so a resolver was needed regardless, making this consistent for both spans and reactions.

## Parser / rendering
- `:shortcode:` resolves to EMOJI spans against the community's emoji list (passed in like mentions). Never fires inside inline code or fenced code blocks. Unknown shortcodes stay literal. `spansToText` round-trips EMOJI → `:shortcode:` (the edit flow re-derives the emoji list from the message's own EMOJI spans so editing doesn't drop them).
- `emojiId` passed through both reply-preview span mappers (`messages.service` and `link-previews.service` — the one missed in #405 review) and thread `sanitizeSpans`.
- Renderer: EMOJI span → inline `<img>` (~1.375em, alt/title `:name:`) with image-error + unknown-emoji fallback to the shortcode.
- Picker: "Custom" section (channels only; hidden in DMs) in both composers (`MessageInput`, `ThreadMessageInput`) and the message-hover reaction picker. Composer inserts `:name:`; reaction pickers send `custom:{id}`.
- New **Custom Emoji** management tab in EditCommunityPage (upload + name form, image-preview list, delete), gated on `MANAGE_EMOJIS`.

## Tests
- **Backend** (`@suites/unit`): custom-emoji service (CRUD, name uniqueness/format, non-CUSTOM_EMOJI file + cross-community rejection) and controller specs; reactions.service sentinel validation (valid member, missing emoji, DM rejection, cross-community, non-member). Updated span-mapper expectations for the new `emojiId` field.
- **Frontend** (Vitest + MSW): parser (`:shortcode:` resolution, unknown-literal, inline+fenced code suppression, round-trip, interleaving with mentions), MessageSpan EMOJI render + fallback, MessageReactions custom-sentinel render + click, CustomEmojiManagement (empty/list/permission-denied/validation/upload+create).

Local results: backend build + lint clean, targeted specs green (custom-emoji, reactions, messages, threads, link-previews, notifications, read-receipts, moderation — 470+ tests). Frontend type-check + lint clean (0 errors), affected suites green (93 tests). Full frontend suite not run end-to-end due to the known WSL2 timeout/OOM flakiness baseline.

## Deferred / needs review
- Custom emoji images have no server-side dimension/animation constraints beyond the existing 256KB PNG/GIF/WebP validator.
- Emoji picker "Custom" section lists all community emojis without pagination (fine for expected counts; revisit if communities amass hundreds).
- No websocket push for emoji create/delete — open composers/pickers pick up new emojis on the next query refetch/invalidation rather than instantly.
- Deleting an emoji leaves historical message spans showing the `:shortcode:` text (intended fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDq3CGGinSAbEWtoPrMmDb