### PR TITLE
fix(helm): call prisma binary directly in migrate job (npx removed from prod image)

### DIFF
--- a/helm/semaphore-chat/templates/backend/migration-job.yaml
+++ b/helm/semaphore-chat/templates/backend/migration-job.yaml
@@ -28,7 +28,7 @@ spec:
             {{- toYaml .Values.backend.securityContext | nindent 12 }}
           image: {{ include "semaphore-chat.backend.image" . }}
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
-          command: ["npx", "prisma", "migrate", "deploy", "--schema=prisma/schema.prisma"]
+          command: ["/app/node_modules/.bin/prisma", "migrate", "deploy", "--schema=prisma/schema.prisma"]
           env:
             - name: SKIP_PRISMA_MIGRATE
               value: "true"


### PR DESCRIPTION
## Root cause

`backend/Dockerfile.prod` intentionally strips npm/npx from the production image to clear base-image CVEs:

```
RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
```

`helm/semaphore-chat/templates/backend/migration-job.yaml` was never updated to match, and still invoked prisma via `npx`:

```
command: ["npx", "prisma", "migrate", "deploy", "--schema=prisma/schema.prisma"]
```

This crashes the migration Job on start with:

```
exec: "npx": executable file not found in $PATH
```

ArgoCD sync fails (SyncError), the pre-install/pre-upgrade Job never completes, and live pods stay pinned to the last good image — the rollout is stuck.

`backend/docker-entrypoint.sh` (the runtime entrypoint) was already fixed to call the prisma binary directly instead of going through npx, but the Helm migration job was missed when npx was removed.

## Fix

Mirror the entrypoint's direct-binary invocation in the migration job:

```diff
-          command: ["npx", "prisma", "migrate", "deploy", "--schema=prisma/schema.prisma"]
+          command: ["/app/node_modules/.bin/prisma", "migrate", "deploy", "--schema=prisma/schema.prisma"]
```

`SKIP_PRISMA_MIGRATE=true` and everything else in the file is unchanged.

## Validation

- `helm lint helm/semaphore-chat` — passes (only a pre-existing unrelated warning about missing `postgresql`/`redis` subchart dependencies).
- `helm template helm/semaphore-chat --show-only templates/backend/migration-job.yaml` — rendered Job command is confirmed as `["/app/node_modules/.bin/prisma", "migrate", "deploy", "--schema=prisma/schema.prisma"]`, no `npx`.
- `grep -rn npx helm/` — no other occurrences; this was the only place npx was referenced in the Helm chart.

This unblocks the stuck ArgoCD rollout — the migration Job will run successfully and new builds can deploy again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDq3CGGinSAbEWtoPrMmDb