### PR TITLE
fix(files): batch and defer thumbnail backfill to avoid startup OOM

### DIFF
--- a/backend/env.sample
+++ b/backend/env.sample
@@ -41,3 +41,12 @@ VAPID_SUBJECT=mailto:admin@your-instance.com
 # Prometheus metrics at /api/metrics (unauthenticated — restrict at the
 # reverse proxy if your deployment is public)
 # METRICS_ENABLED=true
+
+# Thumbnail backfill (retries missing video thumbnails on startup)
+# Deferred and batched to avoid startup memory spikes: at most one ffmpeg
+# frame-extraction child runs at a time (30s max), and the DB working set
+# per batch is THUMBNAIL_BACKFILL_BATCH_SIZE rows of just { id, storagePath }.
+# THUMBNAIL_BACKFILL_ENABLED=true
+# THUMBNAIL_BACKFILL_BATCH_SIZE=25
+# THUMBNAIL_BACKFILL_STARTUP_DELAY_MS=60000
+# THUMBNAIL_BACKFILL_THROTTLE_MS=1000

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -72,6 +72,24 @@ export class EnvironmentVariables {
   @IsOptional()
   @IsString()
   VAPID_PRIVATE_KEY?: string;
+
+  // Thumbnail backfill (issue #409) ---------------------------------------
+
+  @IsOptional()
+  @IsString()
+  THUMBNAIL_BACKFILL_ENABLED?: string;
+
+  @IsOptional()
+  @IsString()
+  THUMBNAIL_BACKFILL_BATCH_SIZE?: string;
+
+  @IsOptional()
+  @IsString()
+  THUMBNAIL_BACKFILL_STARTUP_DELAY_MS?: string;
+
+  @IsOptional()
+  @IsString()
+  THUMBNAIL_BACKFILL_THROTTLE_MS?: string;
 }
 
 /**

--- a/backend/src/file/thumbnail-backfill.service.spec.ts
+++ b/backend/src/file/thumbnail-backfill.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@suites/unit';
 import type { Mocked } from '@suites/doubles.jest';
+import { ConfigService } from '@nestjs/config';
 import { ThumbnailBackfillService } from './thumbnail-backfill.service';
 import { DatabaseService } from '@/database/database.service';
 import { StorageService } from '@/storage/storage.service';
@@ -11,6 +12,7 @@ describe('ThumbnailBackfillService', () => {
   let databaseService: Mocked<DatabaseService>;
   let storageService: Mocked<StorageService>;
   let thumbnailService: Mocked<ThumbnailService>;
+  let configService: Mocked<ConfigService>;
 
   beforeEach(async () => {
     const { unit, unitRef } = await TestBed.solitary(
@@ -21,119 +23,286 @@ describe('ThumbnailBackfillService', () => {
     databaseService = unitRef.get(DatabaseService);
     storageService = unitRef.get(StorageService);
     thumbnailService = unitRef.get(ThumbnailService);
+    configService = unitRef.get(ConfigService);
 
     jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    // Default: no env vars set, so the service falls back to its defaults
+    // (enabled, batch size 25, 60s startup delay, 1s throttle).
+    configService.get.mockReturnValue(undefined);
   });
 
-  it('should query only non-deleted video files without a thumbnail', async () => {
-    databaseService.file.findMany.mockResolvedValue([]);
+  afterEach(() => {
+    jest.useRealTimers();
+  });
 
-    await service.backfill();
+  describe('onApplicationBootstrap', () => {
+    it('should log and never call backfill when disabled via THUMBNAIL_BACKFILL_ENABLED', async () => {
+      configService.get.mockImplementation((key: string) =>
+        key === 'THUMBNAIL_BACKFILL_ENABLED' ? 'false' : undefined,
+      );
+      const logSpy = jest
+        .spyOn(
+          (service as unknown as { logger: { log: (msg: string) => void } })
+            .logger,
+          'log',
+        )
+        .mockImplementation(() => undefined);
 
-    expect(databaseService.file.findMany).toHaveBeenCalledWith({
-      where: {
-        fileType: FileType.VIDEO,
-        thumbnailPath: null,
-        deletedAt: null,
-      },
-      select: { id: true, storagePath: true },
+      service.onApplicationBootstrap();
+      await jest.runAllTimersAsync();
+
+      expect(logSpy).toHaveBeenCalledWith(
+        'Thumbnail backfill disabled via THUMBNAIL_BACKFILL_ENABLED',
+      );
+      expect(databaseService.file.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should defer backfill behind THUMBNAIL_BACKFILL_STARTUP_DELAY_MS', async () => {
+      configService.get.mockImplementation((key: string) =>
+        key === 'THUMBNAIL_BACKFILL_STARTUP_DELAY_MS' ? '5000' : undefined,
+      );
+      databaseService.file.findMany.mockResolvedValue([]);
+
+      service.onApplicationBootstrap();
+      expect(databaseService.file.findMany).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(4999);
+      expect(databaseService.file.findMany).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(1);
+      expect(databaseService.file.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('should clear the pending startup timer on onModuleDestroy', async () => {
+      databaseService.file.findMany.mockResolvedValue([]);
+
+      service.onApplicationBootstrap();
+      service.onModuleDestroy();
+
+      await jest.advanceTimersByTimeAsync(60_000);
+
+      expect(databaseService.file.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should not reject when the deferred backfill fails', async () => {
+      databaseService.file.findMany.mockRejectedValue(new Error('db down'));
+
+      expect(() => service.onApplicationBootstrap()).not.toThrow();
+      await jest.advanceTimersByTimeAsync(60_000);
     });
   });
 
-  it('should do nothing when no files need backfill', async () => {
-    databaseService.file.findMany.mockResolvedValue([]);
+  describe('backfill', () => {
+    it('should query only non-deleted video files without a thumbnail, cursored on id', async () => {
+      databaseService.file.findMany.mockResolvedValue([]);
 
-    const result = await service.backfill();
+      await service.backfill();
 
-    expect(result).toEqual({ generated: 0, skipped: 0 });
-    expect(thumbnailService.generateVideoThumbnail).not.toHaveBeenCalled();
-  });
-
-  it('should generate thumbnails and persist paths for backfillable files', async () => {
-    databaseService.file.findMany.mockResolvedValue([
-      { id: 'file-1', storagePath: '/clips/a.mp4' },
-      { id: 'file-2', storagePath: '/clips/b.mp4' },
-    ] as any);
-    storageService.fileExists.mockResolvedValue(true);
-    thumbnailService.generateVideoThumbnail
-      .mockResolvedValueOnce('uploads/thumbnails/file-1.jpg')
-      .mockResolvedValueOnce('uploads/thumbnails/file-2.jpg');
-    databaseService.file.update.mockResolvedValue({} as any);
-
-    const result = await service.backfill();
-
-    expect(result).toEqual({ generated: 2, skipped: 0 });
-    expect(databaseService.file.update).toHaveBeenCalledWith({
-      where: { id: 'file-1' },
-      data: { thumbnailPath: 'uploads/thumbnails/file-1.jpg' },
+      expect(databaseService.file.findMany).toHaveBeenCalledWith({
+        where: {
+          fileType: FileType.VIDEO,
+          thumbnailPath: null,
+          deletedAt: null,
+        },
+        orderBy: { id: 'asc' },
+        take: 25,
+        select: { id: true, storagePath: true },
+      });
     });
-    expect(databaseService.file.update).toHaveBeenCalledWith({
-      where: { id: 'file-2' },
-      data: { thumbnailPath: 'uploads/thumbnails/file-2.jpg' },
+
+    it('should do nothing when no files need backfill', async () => {
+      databaseService.file.findMany.mockResolvedValue([]);
+
+      const result = await service.backfill();
+
+      expect(result).toEqual({ generated: 0, skipped: 0 });
+      expect(thumbnailService.generateVideoThumbnail).not.toHaveBeenCalled();
     });
-  });
 
-  it('should skip files whose source no longer exists on disk', async () => {
-    databaseService.file.findMany.mockResolvedValue([
-      { id: 'file-gone', storagePath: '/clips/gone.mp4' },
-    ] as any);
-    storageService.fileExists.mockResolvedValue(false);
+    it('should page through candidates with an id cursor until a short batch is returned', async () => {
+      configService.get.mockImplementation((key: string) =>
+        key === 'THUMBNAIL_BACKFILL_BATCH_SIZE' ? '2' : undefined,
+      );
+      databaseService.file.findMany
+        .mockResolvedValueOnce([
+          { id: 'file-a', storagePath: '/clips/a.mp4' },
+          { id: 'file-b', storagePath: '/clips/b.mp4' },
+        ] as any)
+        .mockResolvedValueOnce([
+          { id: 'file-c', storagePath: '/clips/c.mp4' },
+        ] as any);
+      storageService.fileExists.mockResolvedValue(true);
+      thumbnailService.generateVideoThumbnail
+        .mockResolvedValueOnce('thumb-a.jpg')
+        .mockResolvedValueOnce('thumb-b.jpg')
+        .mockResolvedValueOnce('thumb-c.jpg');
+      databaseService.file.update.mockResolvedValue({} as any);
 
-    const result = await service.backfill();
+      const resultPromise = service.backfill();
+      await jest.runAllTimersAsync();
+      const result = await resultPromise;
 
-    expect(result).toEqual({ generated: 0, skipped: 1 });
-    expect(thumbnailService.generateVideoThumbnail).not.toHaveBeenCalled();
-    expect(databaseService.file.update).not.toHaveBeenCalled();
-  });
-
-  it('should skip files whose generation fails and continue with the rest', async () => {
-    databaseService.file.findMany.mockResolvedValue([
-      { id: 'file-bad', storagePath: '/clips/bad.mp4' },
-      { id: 'file-good', storagePath: '/clips/good.mp4' },
-    ] as any);
-    storageService.fileExists.mockResolvedValue(true);
-    thumbnailService.generateVideoThumbnail
-      .mockResolvedValueOnce(null) // generateVideoThumbnail returns null on failure
-      .mockResolvedValueOnce('uploads/thumbnails/file-good.jpg');
-    databaseService.file.update.mockResolvedValue({} as any);
-
-    const result = await service.backfill();
-
-    expect(result).toEqual({ generated: 1, skipped: 1 });
-    expect(databaseService.file.update).toHaveBeenCalledTimes(1);
-    expect(databaseService.file.update).toHaveBeenCalledWith({
-      where: { id: 'file-good' },
-      data: { thumbnailPath: 'uploads/thumbnails/file-good.jpg' },
+      expect(result).toEqual({ generated: 3, skipped: 0 });
+      expect(databaseService.file.findMany).toHaveBeenCalledTimes(2);
+      expect(databaseService.file.findMany).toHaveBeenNthCalledWith(1, {
+        where: {
+          fileType: FileType.VIDEO,
+          thumbnailPath: null,
+          deletedAt: null,
+        },
+        orderBy: { id: 'asc' },
+        take: 2,
+        select: { id: true, storagePath: true },
+      });
+      expect(databaseService.file.findMany).toHaveBeenNthCalledWith(2, {
+        where: {
+          fileType: FileType.VIDEO,
+          thumbnailPath: null,
+          deletedAt: null,
+          id: { gt: 'file-b' },
+        },
+        orderBy: { id: 'asc' },
+        take: 2,
+        select: { id: true, storagePath: true },
+      });
+      expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledTimes(3);
     });
-  });
 
-  it('should continue with remaining files when one file errors mid-processing', async () => {
-    databaseService.file.findMany.mockResolvedValue([
-      { id: 'file-db-err', storagePath: '/clips/a.mp4' },
-      { id: 'file-ok', storagePath: '/clips/b.mp4' },
-    ] as any);
-    storageService.fileExists.mockResolvedValue(true);
-    thumbnailService.generateVideoThumbnail
-      .mockResolvedValueOnce('uploads/thumbnails/file-db-err.jpg')
-      .mockResolvedValueOnce('uploads/thumbnails/file-ok.jpg');
-    databaseService.file.update
-      .mockRejectedValueOnce(new Error('transient db error'))
-      .mockResolvedValueOnce({} as any);
+    it('should sleep THUMBNAIL_BACKFILL_THROTTLE_MS between files', async () => {
+      configService.get.mockImplementation((key: string) =>
+        key === 'THUMBNAIL_BACKFILL_THROTTLE_MS' ? '1000' : undefined,
+      );
+      databaseService.file.findMany
+        .mockResolvedValueOnce([
+          { id: 'file-1', storagePath: '/clips/a.mp4' },
+          { id: 'file-2', storagePath: '/clips/b.mp4' },
+        ] as any)
+        .mockResolvedValueOnce([]);
+      storageService.fileExists.mockResolvedValue(true);
+      thumbnailService.generateVideoThumbnail
+        .mockResolvedValueOnce('thumb-1.jpg')
+        .mockResolvedValueOnce('thumb-2.jpg');
+      databaseService.file.update.mockResolvedValue({} as any);
 
-    const result = await service.backfill();
+      const resultPromise = service.backfill();
 
-    expect(result).toEqual({ generated: 1, skipped: 1 });
-    expect(databaseService.file.update).toHaveBeenCalledWith({
-      where: { id: 'file-ok' },
-      data: { thumbnailPath: 'uploads/thumbnails/file-ok.jpg' },
+      // Let the first file's async work settle before the throttle sleep gates
+      // the second one.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(999);
+      expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(1);
+      expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledTimes(2);
+
+      // Flush the trailing throttle sleep after the last file so the
+      // backfill promise settles.
+      await jest.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result).toEqual({ generated: 2, skipped: 0 });
     });
-  });
 
-  it('should not reject from onApplicationBootstrap when backfill fails', async () => {
-    databaseService.file.findMany.mockRejectedValue(new Error('db down'));
+    it('should generate thumbnails and persist paths for backfillable files', async () => {
+      databaseService.file.findMany
+        .mockResolvedValueOnce([
+          { id: 'file-1', storagePath: '/clips/a.mp4' },
+          { id: 'file-2', storagePath: '/clips/b.mp4' },
+        ] as any)
+        .mockResolvedValueOnce([]);
+      storageService.fileExists.mockResolvedValue(true);
+      thumbnailService.generateVideoThumbnail
+        .mockResolvedValueOnce('uploads/thumbnails/file-1.jpg')
+        .mockResolvedValueOnce('uploads/thumbnails/file-2.jpg');
+      databaseService.file.update.mockResolvedValue({} as any);
 
-    expect(() => service.onApplicationBootstrap()).not.toThrow();
-    // Allow the fire-and-forget promise to settle (error is logged, not thrown)
-    await new Promise((r) => setImmediate(r));
+      const resultPromise = service.backfill();
+      await jest.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result).toEqual({ generated: 2, skipped: 0 });
+      expect(databaseService.file.update).toHaveBeenCalledWith({
+        where: { id: 'file-1' },
+        data: { thumbnailPath: 'uploads/thumbnails/file-1.jpg' },
+      });
+      expect(databaseService.file.update).toHaveBeenCalledWith({
+        where: { id: 'file-2' },
+        data: { thumbnailPath: 'uploads/thumbnails/file-2.jpg' },
+      });
+    });
+
+    it('should skip files whose source no longer exists on disk', async () => {
+      databaseService.file.findMany
+        .mockResolvedValueOnce([
+          { id: 'file-gone', storagePath: '/clips/gone.mp4' },
+        ] as any)
+        .mockResolvedValueOnce([]);
+      storageService.fileExists.mockResolvedValue(false);
+
+      const resultPromise = service.backfill();
+      await jest.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result).toEqual({ generated: 0, skipped: 1 });
+      expect(thumbnailService.generateVideoThumbnail).not.toHaveBeenCalled();
+      expect(databaseService.file.update).not.toHaveBeenCalled();
+    });
+
+    it('should skip files whose generation fails and continue with the rest', async () => {
+      databaseService.file.findMany
+        .mockResolvedValueOnce([
+          { id: 'file-bad', storagePath: '/clips/bad.mp4' },
+          { id: 'file-good', storagePath: '/clips/good.mp4' },
+        ] as any)
+        .mockResolvedValueOnce([]);
+      storageService.fileExists.mockResolvedValue(true);
+      thumbnailService.generateVideoThumbnail
+        .mockResolvedValueOnce(null) // generateVideoThumbnail returns null on failure
+        .mockResolvedValueOnce('uploads/thumbnails/file-good.jpg');
+      databaseService.file.update.mockResolvedValue({} as any);
+
+      const resultPromise = service.backfill();
+      await jest.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result).toEqual({ generated: 1, skipped: 1 });
+      expect(databaseService.file.update).toHaveBeenCalledTimes(1);
+      expect(databaseService.file.update).toHaveBeenCalledWith({
+        where: { id: 'file-good' },
+        data: { thumbnailPath: 'uploads/thumbnails/file-good.jpg' },
+      });
+    });
+
+    it('should continue with remaining files when one file errors mid-processing', async () => {
+      databaseService.file.findMany
+        .mockResolvedValueOnce([
+          { id: 'file-db-err', storagePath: '/clips/a.mp4' },
+          { id: 'file-ok', storagePath: '/clips/b.mp4' },
+        ] as any)
+        .mockResolvedValueOnce([]);
+      storageService.fileExists.mockResolvedValue(true);
+      thumbnailService.generateVideoThumbnail
+        .mockResolvedValueOnce('uploads/thumbnails/file-db-err.jpg')
+        .mockResolvedValueOnce('uploads/thumbnails/file-ok.jpg');
+      databaseService.file.update
+        .mockRejectedValueOnce(new Error('transient db error'))
+        .mockResolvedValueOnce({} as any);
+
+      const resultPromise = service.backfill();
+      await jest.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result).toEqual({ generated: 1, skipped: 1 });
+      expect(databaseService.file.update).toHaveBeenCalledWith({
+        where: { id: 'file-ok' },
+        data: { thumbnailPath: 'uploads/thumbnails/file-ok.jpg' },
+      });
+    });
   });
 });

--- a/backend/src/file/thumbnail-backfill.service.spec.ts
+++ b/backend/src/file/thumbnail-backfill.service.spec.ts
@@ -92,6 +92,42 @@ describe('ThumbnailBackfillService', () => {
       expect(() => service.onApplicationBootstrap()).not.toThrow();
       await jest.advanceTimersByTimeAsync(60_000);
     });
+
+    it.each(['FALSE', '0', 'off', 'OFF', '  false  '])(
+      'should treat THUMBNAIL_BACKFILL_ENABLED=%s as disabled (case-insensitive, trimmed)',
+      async (value) => {
+        configService.get.mockImplementation((key: string) =>
+          key === 'THUMBNAIL_BACKFILL_ENABLED' ? value : undefined,
+        );
+        const logSpy = jest
+          .spyOn(
+            (service as unknown as { logger: { log: (msg: string) => void } })
+              .logger,
+            'log',
+          )
+          .mockImplementation(() => undefined);
+
+        service.onApplicationBootstrap();
+        await jest.runAllTimersAsync();
+
+        expect(logSpy).toHaveBeenCalledWith(
+          'Thumbnail backfill disabled via THUMBNAIL_BACKFILL_ENABLED',
+        );
+        expect(databaseService.file.findMany).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should treat unrecognized THUMBNAIL_BACKFILL_ENABLED values as enabled', async () => {
+      configService.get.mockImplementation((key: string) =>
+        key === 'THUMBNAIL_BACKFILL_ENABLED' ? 'yes' : undefined,
+      );
+      databaseService.file.findMany.mockResolvedValue([]);
+
+      service.onApplicationBootstrap();
+      await jest.runAllTimersAsync();
+
+      expect(databaseService.file.findMany).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('backfill', () => {
@@ -168,6 +204,124 @@ describe('ThumbnailBackfillService', () => {
         select: { id: true, storagePath: true },
       });
       expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledTimes(3);
+    });
+
+    it.each([
+      ['THUMBNAIL_BACKFILL_BATCH_SIZE', 'not-a-number', 25],
+      ['THUMBNAIL_BACKFILL_BATCH_SIZE', '0', 25],
+      ['THUMBNAIL_BACKFILL_BATCH_SIZE', '-5', 25],
+    ])(
+      'should fall back to the default batch size and warn when %s=%s is invalid',
+      async (key, value, expectedDefault) => {
+        configService.get.mockImplementation((k: string) =>
+          k === key ? value : undefined,
+        );
+        const warnSpy = jest
+          .spyOn(
+            (
+              service as unknown as {
+                logger: { warn: (msg: string) => void };
+              }
+            ).logger,
+            'warn',
+          )
+          .mockImplementation(() => undefined);
+        databaseService.file.findMany.mockResolvedValue([]);
+
+        await service.backfill();
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `Invalid ${key} value "${value}"; falling back to default ${expectedDefault}`,
+          ),
+        );
+        expect(databaseService.file.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({ take: expectedDefault }),
+        );
+      },
+    );
+
+    it.each([
+      ['THUMBNAIL_BACKFILL_THROTTLE_MS', 'not-a-number'],
+      ['THUMBNAIL_BACKFILL_THROTTLE_MS', '-1'],
+    ])('should fall back to the default for %s=%s', async (key, value) => {
+      configService.get.mockImplementation((k: string) =>
+        k === key ? value : undefined,
+      );
+      const warnSpy = jest
+        .spyOn(
+          (
+            service as unknown as {
+              logger: { warn: (msg: string) => void };
+            }
+          ).logger,
+          'warn',
+        )
+        .mockImplementation(() => undefined);
+      databaseService.file.findMany.mockResolvedValue([]);
+
+      await service.backfill();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`Invalid ${key} value "${value}"`),
+      );
+    });
+
+    it.each([
+      ['THUMBNAIL_BACKFILL_STARTUP_DELAY_MS', 'not-a-number'],
+      ['THUMBNAIL_BACKFILL_STARTUP_DELAY_MS', '-1'],
+    ])(
+      'should fall back to the default startup delay (60s) and warn for %s=%s',
+      async (key, value) => {
+        configService.get.mockImplementation((k: string) =>
+          k === key ? value : undefined,
+        );
+        const warnSpy = jest
+          .spyOn(
+            (
+              service as unknown as {
+                logger: { warn: (msg: string) => void };
+              }
+            ).logger,
+            'warn',
+          )
+          .mockImplementation(() => undefined);
+        databaseService.file.findMany.mockResolvedValue([]);
+
+        service.onApplicationBootstrap();
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(`Invalid ${key} value "${value}"`),
+        );
+        expect(databaseService.file.findMany).not.toHaveBeenCalled();
+
+        await jest.advanceTimersByTimeAsync(60_000);
+        expect(databaseService.file.findMany).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    it('should skip the throttle sleep entirely when THUMBNAIL_BACKFILL_THROTTLE_MS is 0', async () => {
+      configService.get.mockImplementation((key: string) =>
+        key === 'THUMBNAIL_BACKFILL_THROTTLE_MS' ? '0' : undefined,
+      );
+      databaseService.file.findMany
+        .mockResolvedValueOnce([
+          { id: 'file-1', storagePath: '/clips/a.mp4' },
+          { id: 'file-2', storagePath: '/clips/b.mp4' },
+        ] as any)
+        .mockResolvedValueOnce([]);
+      storageService.fileExists.mockResolvedValue(true);
+      thumbnailService.generateVideoThumbnail
+        .mockResolvedValueOnce('thumb-1.jpg')
+        .mockResolvedValueOnce('thumb-2.jpg');
+      databaseService.file.update.mockResolvedValue({} as any);
+
+      // No fake-timer advancement needed: with throttle 0 there is no
+      // setTimeout gating between files, so the promise settles on its own.
+      const result = await service.backfill();
+
+      expect(result).toEqual({ generated: 2, skipped: 0 });
+      expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledTimes(2);
     });
 
     it('should sleep THUMBNAIL_BACKFILL_THROTTLE_MS between files', async () => {

--- a/backend/src/file/thumbnail-backfill.service.ts
+++ b/backend/src/file/thumbnail-backfill.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  OnApplicationBootstrap,
+  OnModuleDestroy,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { FileType } from '@prisma/client';
 import { DatabaseService } from '@/database/database.service';
 import { StorageService } from '@/storage/storage.service';
@@ -14,87 +20,166 @@ import { ThumbnailService } from './thumbnail.service';
  * retroactively. Files whose source is gone or whose generation keeps
  * failing are skipped (and retried on the next boot, which is cheap:
  * one ffmpeg frame-extraction per file, run sequentially).
+ *
+ * Startup is deferred (THUMBNAIL_BACKFILL_STARTUP_DELAY_MS) and candidates
+ * are fetched in batches via an id cursor (THUMBNAIL_BACKFILL_BATCH_SIZE)
+ * rather than all at once, so a large backlog can't spike memory or
+ * saturate the DB working set at boot. See GitHub issue #409.
  */
 @Injectable()
-export class ThumbnailBackfillService implements OnApplicationBootstrap {
+export class ThumbnailBackfillService
+  implements OnApplicationBootstrap, OnModuleDestroy
+{
   private readonly logger = new Logger(ThumbnailBackfillService.name);
+  private startupTimer?: ReturnType<typeof setTimeout>;
 
   constructor(
     private readonly databaseService: DatabaseService,
     private readonly storageService: StorageService,
     private readonly thumbnailService: ThumbnailService,
+    private readonly configService: ConfigService,
   ) {}
 
+  private isEnabled(): boolean {
+    return (
+      this.configService.get<string>('THUMBNAIL_BACKFILL_ENABLED') !== 'false'
+    );
+  }
+
+  private getBatchSize(): number {
+    return parseInt(
+      this.configService.get<string>('THUMBNAIL_BACKFILL_BATCH_SIZE') || '25',
+      10,
+    );
+  }
+
+  private getStartupDelayMs(): number {
+    return parseInt(
+      this.configService.get<string>('THUMBNAIL_BACKFILL_STARTUP_DELAY_MS') ||
+        '60000',
+      10,
+    );
+  }
+
+  private getThrottleMs(): number {
+    return parseInt(
+      this.configService.get<string>('THUMBNAIL_BACKFILL_THROTTLE_MS') ||
+        '1000',
+      10,
+    );
+  }
+
   onApplicationBootstrap(): void {
-    // Fire-and-forget: never block application startup
-    void this.backfill().catch((error) => {
-      this.logger.error(
-        `Thumbnail backfill failed: ${error instanceof Error ? error.message : String(error)}`,
+    if (!this.isEnabled()) {
+      this.logger.log(
+        'Thumbnail backfill disabled via THUMBNAIL_BACKFILL_ENABLED',
       );
-    });
+      return;
+    }
+
+    // Defer past peak startup memory, then fire-and-forget so we never
+    // block application startup.
+    this.startupTimer = setTimeout(() => {
+      void this.backfill().catch((error) => {
+        this.logger.error(
+          `Thumbnail backfill failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+    }, this.getStartupDelayMs());
+  }
+
+  onModuleDestroy(): void {
+    if (this.startupTimer) {
+      clearTimeout(this.startupTimer);
+      this.startupTimer = undefined;
+    }
   }
 
   async backfill(): Promise<{ generated: number; skipped: number }> {
-    const candidates = await this.databaseService.file.findMany({
-      where: {
-        fileType: FileType.VIDEO,
-        thumbnailPath: null,
-        deletedAt: null,
-      },
-      select: { id: true, storagePath: true },
-    });
-
-    if (candidates.length === 0) {
-      return { generated: 0, skipped: 0 };
-    }
-
-    this.logger.log(
-      `Backfilling thumbnails for ${candidates.length} video file(s) without one`,
-    );
+    const batchSize = this.getBatchSize();
+    const throttleMs = this.getThrottleMs();
 
     let generated = 0;
     let skipped = 0;
+    let processed = 0;
+    let lastId: string | undefined;
 
-    // Sequential on purpose: avoids spawning concurrent ffmpeg processes.
-    // Best-effort per file: one failure must not abort the remaining candidates.
-    for (const file of candidates) {
-      try {
-        if (!(await this.storageService.fileExists(file.storagePath))) {
-          this.logger.warn(
-            `Skipping thumbnail backfill for file ${file.id}: source ${file.storagePath} not found`,
-          );
-          skipped++;
-          continue;
-        }
+    for (;;) {
+      const batch = await this.databaseService.file.findMany({
+        where: {
+          fileType: FileType.VIDEO,
+          thumbnailPath: null,
+          deletedAt: null,
+          ...(lastId ? { id: { gt: lastId } } : {}),
+        },
+        orderBy: { id: 'asc' },
+        take: batchSize,
+        select: { id: true, storagePath: true },
+      });
 
-        // generateVideoThumbnail logs and returns null on failure
-        const thumbnailPath =
-          await this.thumbnailService.generateVideoThumbnail(
-            file.storagePath,
-            file.id,
-          );
+      if (batch.length === 0) {
+        break;
+      }
 
-        if (!thumbnailPath) {
-          skipped++;
-          continue;
-        }
-
-        await this.databaseService.file.update({
-          where: { id: file.id },
-          data: { thumbnailPath },
-        });
-        generated++;
-      } catch (error) {
-        this.logger.warn(
-          `Skipping thumbnail backfill for file ${file.id}: ${error instanceof Error ? error.message : String(error)}`,
+      if (processed === 0) {
+        this.logger.log(
+          `Backfilling thumbnails for video files without one (batch size ${batchSize})`,
         );
-        skipped++;
+      }
+
+      // Sequential on purpose: avoids spawning concurrent ffmpeg processes.
+      // Best-effort per file: one failure must not abort the remaining candidates.
+      for (const file of batch) {
+        try {
+          if (!(await this.storageService.fileExists(file.storagePath))) {
+            this.logger.warn(
+              `Skipping thumbnail backfill for file ${file.id}: source ${file.storagePath} not found`,
+            );
+            skipped++;
+            continue;
+          }
+
+          // generateVideoThumbnail logs and returns null on failure
+          const thumbnailPath =
+            await this.thumbnailService.generateVideoThumbnail(
+              file.storagePath,
+              file.id,
+            );
+
+          if (!thumbnailPath) {
+            skipped++;
+            continue;
+          }
+
+          await this.databaseService.file.update({
+            where: { id: file.id },
+            data: { thumbnailPath },
+          });
+          generated++;
+        } catch (error) {
+          this.logger.warn(
+            `Skipping thumbnail backfill for file ${file.id}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          skipped++;
+        } finally {
+          processed++;
+          lastId = file.id;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, throttleMs));
+      }
+
+      if (batch.length < batchSize) {
+        break;
       }
     }
 
-    this.logger.log(
-      `Thumbnail backfill complete: ${generated} generated, ${skipped} skipped`,
-    );
+    if (processed > 0) {
+      this.logger.log(
+        `Thumbnail backfill complete: ${generated} generated, ${skipped} skipped`,
+      );
+    }
+
     return { generated, skipped };
   }
 }

--- a/backend/src/file/thumbnail-backfill.service.ts
+++ b/backend/src/file/thumbnail-backfill.service.ts
@@ -41,32 +41,58 @@ export class ThumbnailBackfillService
   ) {}
 
   private isEnabled(): boolean {
-    return (
-      this.configService.get<string>('THUMBNAIL_BACKFILL_ENABLED') !== 'false'
-    );
+    const raw = this.configService.get<string>('THUMBNAIL_BACKFILL_ENABLED');
+    if (raw === undefined) {
+      return true;
+    }
+    const normalized = raw.trim().toLowerCase();
+    return !['false', '0', 'off'].includes(normalized);
+  }
+
+  /**
+   * Parses a non-negative integer env var, warning and falling back to
+   * `defaultValue` when the value is missing, not a number, or (per
+   * `allowZero`) not strictly positive.
+   */
+  private parseIntEnv(
+    key: string,
+    defaultValue: number,
+    { allowZero }: { allowZero: boolean },
+  ): number {
+    const raw = this.configService.get<string>(key);
+    if (raw === undefined) {
+      return defaultValue;
+    }
+
+    const parsed = parseInt(raw, 10);
+    const isValid = allowZero ? parsed >= 0 : parsed > 0;
+
+    if (Number.isNaN(parsed) || !isValid) {
+      this.logger.warn(
+        `Invalid ${key} value "${raw}"; falling back to default ${defaultValue}`,
+      );
+      return defaultValue;
+    }
+
+    return parsed;
   }
 
   private getBatchSize(): number {
-    return parseInt(
-      this.configService.get<string>('THUMBNAIL_BACKFILL_BATCH_SIZE') || '25',
-      10,
-    );
+    return this.parseIntEnv('THUMBNAIL_BACKFILL_BATCH_SIZE', 25, {
+      allowZero: false,
+    });
   }
 
   private getStartupDelayMs(): number {
-    return parseInt(
-      this.configService.get<string>('THUMBNAIL_BACKFILL_STARTUP_DELAY_MS') ||
-        '60000',
-      10,
-    );
+    return this.parseIntEnv('THUMBNAIL_BACKFILL_STARTUP_DELAY_MS', 60000, {
+      allowZero: true,
+    });
   }
 
   private getThrottleMs(): number {
-    return parseInt(
-      this.configService.get<string>('THUMBNAIL_BACKFILL_THROTTLE_MS') ||
-        '1000',
-      10,
-    );
+    return this.parseIntEnv('THUMBNAIL_BACKFILL_THROTTLE_MS', 1000, {
+      allowZero: true,
+    });
   }
 
   onApplicationBootstrap(): void {
@@ -80,12 +106,14 @@ export class ThumbnailBackfillService
     // Defer past peak startup memory, then fire-and-forget so we never
     // block application startup.
     this.startupTimer = setTimeout(() => {
+      this.startupTimer = undefined;
       void this.backfill().catch((error) => {
         this.logger.error(
           `Thumbnail backfill failed: ${error instanceof Error ? error.message : String(error)}`,
         );
       });
     }, this.getStartupDelayMs());
+    this.startupTimer.unref();
   }
 
   onModuleDestroy(): void {
@@ -166,7 +194,12 @@ export class ThumbnailBackfillService
           lastId = file.id;
         }
 
-        await new Promise((resolve) => setTimeout(resolve, throttleMs));
+        if (throttleMs > 0) {
+          await new Promise((resolve) => {
+            const timer = setTimeout(resolve, throttleMs);
+            timer.unref();
+          });
+        }
       }
 
       if (batch.length < batchSize) {

--- a/docs-site/docs/installation/configuration.md
+++ b/docs-site/docs/installation/configuration.md
@@ -88,6 +88,17 @@ Generate VAPID keys:
 docker compose run --rm backend npx web-push generate-vapid-keys
 ```
 
+### Thumbnail backfill
+
+On startup, Semaphore Chat retries thumbnail generation for video files that don't have one yet (e.g. uploaded before thumbnail support existed, or whose generation failed). This is deferred and batched so it can't spike memory at boot: at most one ffmpeg frame-extraction child process runs at a time (capped at 30s), and the database working set per batch is just `THUMBNAIL_BACKFILL_BATCH_SIZE` rows of `{ id, storagePath }`.
+
+| Variable | Description | Default |
+|----------|------------|---------|
+| `THUMBNAIL_BACKFILL_ENABLED` | Set to `false` to disable the backfill entirely | `true` |
+| `THUMBNAIL_BACKFILL_BATCH_SIZE` | Rows fetched per batch (id-cursor pagination) | `25` |
+| `THUMBNAIL_BACKFILL_STARTUP_DELAY_MS` | Delay before starting, so it runs after peak startup memory has settled | `60000` |
+| `THUMBNAIL_BACKFILL_THROTTLE_MS` | Delay between files, to spread out ffmpeg/DB load | `1000` |
+
 ## Frontend environment variables
 
 Copy `frontend/.env.sample` to `frontend/.env`. The defaults work for local Docker development.


### PR DESCRIPTION
Fixes #409

## Summary
- Replaces the unbounded `findMany` in `ThumbnailBackfillService` with an id-cursor batch loop (default 25 rows/batch) so the candidate list no longer scales memory with backlog size
- Defers the backfill behind a configurable startup delay (default 60s) so ffmpeg work no longer competes with peak startup memory; timer cleared on shutdown
- Adds a per-file throttle (default 1s) and an enable flag; concurrency stays at 1

## New env vars (all optional)
- `THUMBNAIL_BACKFILL_ENABLED` (default `true`)
- `THUMBNAIL_BACKFILL_BATCH_SIZE` (default `25`)
- `THUMBNAIL_BACKFILL_STARTUP_DELAY_MS` (default `60000`)
- `THUMBNAIL_BACKFILL_THROTTLE_MS` (default `1000`)

Cursor pagination (`id > lastId`) rather than skip/take is deliberate: failed files keep `thumbnailPath: null` and would otherwise be re-fetched forever.

## Testing
- Extended `thumbnail-backfill.service.spec.ts`: disabled flag, startup-delay deferral + timer cleanup (fake timers), cursored batching until short batch, throttle between files, per-file failure isolation
- Full backend suite green (one pre-existing unrelated metrics failure on missing `prom-client`); lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)