### PR TITLE
feat(messages): Tenor GIF picker and backend search proxy

### DIFF
--- a/backend/env.sample
+++ b/backend/env.sample
@@ -50,3 +50,8 @@ VAPID_SUBJECT=mailto:admin@your-instance.com
 # THUMBNAIL_BACKFILL_BATCH_SIZE=25
 # THUMBNAIL_BACKFILL_STARTUP_DELAY_MS=60000
 # THUMBNAIL_BACKFILL_THROTTLE_MS=1000
+
+# GIF Search (Tenor)
+# Get a free API key at https://tenor.com/developer/dashboard
+# Feature is off (GIF picker hidden, /gifs endpoints return 503) when absent.
+TENOR_API_KEY=

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7262,6 +7262,92 @@
           "Soundboard"
         ]
       }
+    },
+    "/api/gifs/search": {
+      "get": {
+        "operationId": "GifsController_search",
+        "parameters": [
+          {
+            "name": "q",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "pos",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GifSearchResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Search Tenor GIFs by query term.",
+        "tags": [
+          "Gifs"
+        ]
+      }
+    },
+    "/api/gifs/featured": {
+      "get": {
+        "operationId": "GifsController_featured",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "pos",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GifSearchResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Fetch Tenor's currently featured/trending GIFs (shown when the search\nbox is empty).",
+        "tags": [
+          "Gifs"
+        ]
+      }
     }
   },
   "info": {
@@ -11964,12 +12050,17 @@
           },
           "maxFileSizeBytes": {
             "type": "number"
+          },
+          "gifSearchEnabled": {
+            "type": "boolean",
+            "description": "Whether the Tenor GIF picker is available (TENOR_API_KEY configured)."
           }
         },
         "required": [
           "name",
           "registrationMode",
-          "maxFileSizeBytes"
+          "maxFileSizeBytes",
+          "gifSearchEnabled"
         ]
       },
       "InstanceSettingsResponseDto": {
@@ -12905,6 +12996,57 @@
         "required": [
           "name",
           "fileId"
+        ]
+      },
+      "GifResultDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "description": "Full-size animated GIF URL (media_formats.gif.url) — sent as message content."
+          },
+          "previewUrl": {
+            "type": "string",
+            "description": "Small animated preview used in the picker grid (media_formats.tinygif.url)."
+          },
+          "width": {
+            "type": "number"
+          },
+          "height": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "url",
+          "previewUrl",
+          "width",
+          "height"
+        ]
+      },
+      "GifSearchResponseDto": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GifResultDto"
+            }
+          },
+          "next": {
+            "type": "string",
+            "description": "Tenor's pagination cursor for the next page; undefined when exhausted."
+          }
+        },
+        "required": [
+          "results"
         ]
       }
     }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -49,6 +49,7 @@ import { StorageQuotaModule } from './storage-quota/storage-quota.module';
 import { AliasGroupsModule } from './alias-groups/alias-groups.module';
 import { CustomEmojiModule } from './custom-emoji/custom-emoji.module';
 import { SoundboardModule } from './soundboard/soundboard.module';
+import { GifsModule } from './gifs/gifs.module';
 import { DebugModule } from './debug/debug.module';
 import { MetricsModule } from './metrics/metrics.module';
 import { JwtAuthGuard } from './auth/jwt-auth.guard';
@@ -122,6 +123,7 @@ import { JwtAuthGuard } from './auth/jwt-auth.guard';
     AliasGroupsModule,
     CustomEmojiModule,
     SoundboardModule,
+    GifsModule,
     ...(process.env.ADMIN_DEBUG_PANEL === 'true' ? [DebugModule] : []),
     // Prometheus metrics (/api/metrics) — opt-in only; when disabled the
     // module isn't imported, so the endpoint does not exist.

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -90,6 +90,12 @@ export class EnvironmentVariables {
   @IsOptional()
   @IsString()
   THUMBNAIL_BACKFILL_THROTTLE_MS?: string;
+
+  // GIF search (Tenor) — feature is disabled when absent, no production
+  // requirement.
+  @IsOptional()
+  @IsString()
+  TENOR_API_KEY?: string;
 }
 
 /**

--- a/backend/src/gifs/dto/gif-response.dto.ts
+++ b/backend/src/gifs/dto/gif-response.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Slim representation of a Tenor GIF result — only the fields the composer
+ * picker and message-send flow need.
+ */
+export class GifResultDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  title: string;
+
+  /** Full-size animated GIF URL (media_formats.gif.url) — sent as message content. */
+  @ApiProperty()
+  url: string;
+
+  /** Small animated preview used in the picker grid (media_formats.tinygif.url). */
+  @ApiProperty()
+  previewUrl: string;
+
+  @ApiProperty()
+  width: number;
+
+  @ApiProperty()
+  height: number;
+}
+
+export class GifSearchResponseDto {
+  @ApiProperty({ type: [GifResultDto] })
+  results: GifResultDto[];
+
+  /** Tenor's pagination cursor for the next page; undefined when exhausted. */
+  @ApiPropertyOptional()
+  next?: string;
+}

--- a/backend/src/gifs/gifs.controller.spec.ts
+++ b/backend/src/gifs/gifs.controller.spec.ts
@@ -1,0 +1,83 @@
+import { TestBed } from '@suites/unit';
+import type { Mocked } from '@suites/doubles.jest';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
+import { GifsController } from './gifs.controller';
+import { GifsService } from './gifs.service';
+
+describe('GifsController', () => {
+  let controller: GifsController;
+  let service: Mocked<GifsService>;
+
+  const mockResponse = {
+    results: [
+      {
+        id: 'gif-1',
+        title: 'Cat',
+        url: 'https://media.tenor.com/1/cat.gif',
+        previewUrl: 'https://media.tenor.com/1/cat-tiny.gif',
+        width: 220,
+        height: 140,
+      },
+    ],
+    next: 'cursor-1',
+  };
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(GifsController).compile();
+
+    controller = unit;
+    service = unitRef.get(GifsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('applies JwtAuthGuard at the controller level', () => {
+    const guards = Reflect.getMetadata(GUARDS_METADATA, GifsController);
+    expect(guards).toContain(JwtAuthGuard);
+  });
+
+  describe('search', () => {
+    it('forwards q, limit, and pos to the service', async () => {
+      service.search.mockResolvedValue(mockResponse);
+
+      const result = await controller.search('cats', 20, 'cursor-0');
+
+      expect(service.search).toHaveBeenCalledWith('cats', 20, 'cursor-0');
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('clamps limit to the maximum of 50', async () => {
+      service.search.mockResolvedValue(mockResponse);
+
+      await controller.search('cats', 500, undefined);
+
+      expect(service.search).toHaveBeenCalledWith('cats', 50, undefined);
+    });
+  });
+
+  describe('featured', () => {
+    it('forwards limit and pos to the service', async () => {
+      service.featured.mockResolvedValue(mockResponse);
+
+      const result = await controller.featured(15, 'cursor-2');
+
+      expect(service.featured).toHaveBeenCalledWith(15, 'cursor-2');
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('clamps limit to the maximum of 50', async () => {
+      service.featured.mockResolvedValue(mockResponse);
+
+      await controller.featured(999, undefined);
+
+      expect(service.featured).toHaveBeenCalledWith(50, undefined);
+    });
+  });
+});

--- a/backend/src/gifs/gifs.controller.ts
+++ b/backend/src/gifs/gifs.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Controller,
+  DefaultValuePipe,
+  Get,
+  ParseIntPipe,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOkResponse, ApiQuery } from '@nestjs/swagger';
+import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
+import { GifsService } from './gifs.service';
+import { GifSearchResponseDto } from './dto/gif-response.dto';
+
+const MAX_LIMIT = 50;
+
+@Controller('gifs')
+@UseGuards(JwtAuthGuard)
+export class GifsController {
+  constructor(private readonly gifsService: GifsService) {}
+
+  /**
+   * Search Tenor GIFs by query term.
+   */
+  @Get('search')
+  @ApiOkResponse({ type: GifSearchResponseDto })
+  @ApiQuery({ name: 'limit', required: false })
+  @ApiQuery({ name: 'pos', required: false })
+  async search(
+    @Query('q') q: string,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+    @Query('pos') pos?: string,
+  ): Promise<GifSearchResponseDto> {
+    return this.gifsService.search(q, Math.min(limit, MAX_LIMIT), pos);
+  }
+
+  /**
+   * Fetch Tenor's currently featured/trending GIFs (shown when the search
+   * box is empty).
+   */
+  @Get('featured')
+  @ApiOkResponse({ type: GifSearchResponseDto })
+  @ApiQuery({ name: 'limit', required: false })
+  @ApiQuery({ name: 'pos', required: false })
+  async featured(
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+    @Query('pos') pos?: string,
+  ): Promise<GifSearchResponseDto> {
+    return this.gifsService.featured(Math.min(limit, MAX_LIMIT), pos);
+  }
+}

--- a/backend/src/gifs/gifs.module.ts
+++ b/backend/src/gifs/gifs.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { GifsController } from './gifs.controller';
+import { GifsService } from './gifs.service';
+
+@Module({
+  controllers: [GifsController],
+  providers: [GifsService],
+})
+export class GifsModule {}

--- a/backend/src/gifs/gifs.service.spec.ts
+++ b/backend/src/gifs/gifs.service.spec.ts
@@ -1,0 +1,236 @@
+import { TestBed } from '@suites/unit';
+import type { Mocked } from '@suites/doubles.jest';
+import { ConfigService } from '@nestjs/config';
+import { ServiceUnavailableException } from '@nestjs/common';
+import { GifsService } from './gifs.service';
+
+describe('GifsService', () => {
+  let service: GifsService;
+  let configService: Mocked<ConfigService>;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(GifsService).compile();
+
+    service = unit;
+    configService = unitRef.get(ConfigService);
+    configService.get.mockReturnValue('test-api-key');
+
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function mockFetchResponse(body: unknown, ok = true, status = 200) {
+    fetchSpy.mockResolvedValue({
+      ok,
+      status,
+      json: () => Promise.resolve(body),
+    } as Response);
+  }
+
+  describe('key-absent path', () => {
+    it('throws ServiceUnavailableException from search when TENOR_API_KEY is not configured', async () => {
+      configService.get.mockReturnValue(undefined);
+
+      await expect(service.search('cats', 20)).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('throws ServiceUnavailableException from featured when TENOR_API_KEY is not configured', async () => {
+      configService.get.mockReturnValue(undefined);
+
+      await expect(service.featured(20)).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('search', () => {
+    it('maps Tenor results to the slim DTO shape', async () => {
+      mockFetchResponse({
+        results: [
+          {
+            id: 'gif-1',
+            title: '',
+            content_description: 'Cat jumping',
+            media_formats: {
+              gif: {
+                url: 'https://media.tenor.com/1/cat.gif',
+                dims: [220, 140],
+              },
+              tinygif: {
+                url: 'https://media.tenor.com/1/cat-tiny.gif',
+                dims: [110, 70],
+              },
+            },
+          },
+        ],
+        next: 'cursor-abc',
+      });
+
+      const result = await service.search('cat', 20);
+
+      expect(result).toEqual({
+        results: [
+          {
+            id: 'gif-1',
+            title: 'Cat jumping',
+            url: 'https://media.tenor.com/1/cat.gif',
+            previewUrl: 'https://media.tenor.com/1/cat-tiny.gif',
+            width: 220,
+            height: 140,
+          },
+        ],
+        next: 'cursor-abc',
+      });
+    });
+
+    it('passes q, limit, pos, key, client_key and media_filter as query params', async () => {
+      mockFetchResponse({ results: [] });
+
+      await service.search('dogs', 15, 'cursor-1');
+
+      const calledUrl = new URL(fetchSpy.mock.calls[0][0] as string);
+      expect(calledUrl.origin + calledUrl.pathname).toBe(
+        'https://tenor.googleapis.com/v2/search',
+      );
+      expect(calledUrl.searchParams.get('q')).toBe('dogs');
+      expect(calledUrl.searchParams.get('limit')).toBe('15');
+      expect(calledUrl.searchParams.get('pos')).toBe('cursor-1');
+      expect(calledUrl.searchParams.get('key')).toBe('test-api-key');
+      expect(calledUrl.searchParams.get('client_key')).toBe('semaphore-chat');
+      expect(calledUrl.searchParams.get('media_filter')).toBe('gif,tinygif');
+    });
+
+    it('falls back to title when content_description is absent', async () => {
+      mockFetchResponse({
+        results: [
+          {
+            id: 'gif-2',
+            title: 'Fallback title',
+            media_formats: {
+              gif: { url: 'https://media.tenor.com/2/dog.gif' },
+            },
+          },
+        ],
+      });
+
+      const result = await service.search('dog', 20);
+
+      expect(result.results[0].title).toBe('Fallback title');
+    });
+
+    it('omits results missing the gif media format', async () => {
+      mockFetchResponse({
+        results: [
+          {
+            id: 'gif-3',
+            media_formats: {
+              tinygif: { url: 'https://media.tenor.com/3/tiny-only.gif' },
+            },
+          },
+          {
+            id: 'gif-4',
+            media_formats: {
+              gif: {
+                url: 'https://media.tenor.com/4/full.gif',
+                dims: [100, 100],
+              },
+            },
+          },
+        ],
+      });
+
+      const result = await service.search('missing', 20);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].id).toBe('gif-4');
+    });
+
+    it('falls back to the full gif url as previewUrl when tinygif is missing', async () => {
+      mockFetchResponse({
+        results: [
+          {
+            id: 'gif-5',
+            media_formats: {
+              gif: {
+                url: 'https://media.tenor.com/5/full.gif',
+                dims: [50, 60],
+              },
+            },
+          },
+        ],
+      });
+
+      const result = await service.search('no-tiny', 20);
+
+      expect(result.results[0].previewUrl).toBe(
+        'https://media.tenor.com/5/full.gif',
+      );
+    });
+
+    it('defaults width/height to 0 when dims are missing', async () => {
+      mockFetchResponse({
+        results: [
+          {
+            id: 'gif-6',
+            media_formats: {
+              gif: { url: 'https://media.tenor.com/6/full.gif' },
+            },
+          },
+        ],
+      });
+
+      const result = await service.search('no-dims', 20);
+
+      expect(result.results[0].width).toBe(0);
+      expect(result.results[0].height).toBe(0);
+    });
+
+    it('returns an empty results array and no cursor when Tenor returns no results field', async () => {
+      mockFetchResponse({});
+
+      const result = await service.search('nothing', 20);
+
+      expect(result).toEqual({ results: [], next: undefined });
+    });
+
+    it('throws ServiceUnavailableException when Tenor responds with a non-OK status', async () => {
+      mockFetchResponse({}, false, 502);
+
+      await expect(service.search('cat', 20)).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+    });
+
+    it('throws ServiceUnavailableException when the fetch itself rejects (network/timeout)', async () => {
+      fetchSpy.mockRejectedValue(new Error('timed out'));
+
+      await expect(service.search('cat', 20)).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+    });
+  });
+
+  describe('featured', () => {
+    it('passes the cursor through and hits the featured endpoint without q', async () => {
+      mockFetchResponse({ results: [], next: 'cursor-2' });
+
+      const result = await service.featured(10, 'cursor-1');
+
+      const calledUrl = new URL(fetchSpy.mock.calls[0][0] as string);
+      expect(calledUrl.origin + calledUrl.pathname).toBe(
+        'https://tenor.googleapis.com/v2/featured',
+      );
+      expect(calledUrl.searchParams.has('q')).toBe(false);
+      expect(calledUrl.searchParams.get('pos')).toBe('cursor-1');
+      expect(result.next).toBe('cursor-2');
+    });
+  });
+});

--- a/backend/src/gifs/gifs.service.ts
+++ b/backend/src/gifs/gifs.service.ts
@@ -1,0 +1,126 @@
+import {
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GifResultDto, GifSearchResponseDto } from './dto/gif-response.dto';
+
+const TENOR_BASE_URL = 'https://tenor.googleapis.com/v2';
+const TENOR_CLIENT_KEY = 'semaphore-chat';
+const MEDIA_FILTER = 'gif,tinygif';
+const FETCH_TIMEOUT_MS = 5000;
+
+interface TenorMediaFormat {
+  url: string;
+  dims?: [number, number];
+}
+
+interface TenorResult {
+  id: string;
+  title?: string;
+  content_description?: string;
+  media_formats?: {
+    gif?: TenorMediaFormat;
+    tinygif?: TenorMediaFormat;
+  };
+}
+
+interface TenorApiResponse {
+  results?: TenorResult[];
+  next?: string;
+}
+
+/**
+ * Proxies Tenor's v2 search/featured endpoints so the API key stays
+ * server-side (Tenor doesn't support browser CORS for these endpoints).
+ */
+@Injectable()
+export class GifsService {
+  private readonly logger = new Logger(GifsService.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async search(
+    q: string,
+    limit: number,
+    pos?: string,
+  ): Promise<GifSearchResponseDto> {
+    return this.fetchTenor('search', { q, limit, pos });
+  }
+
+  async featured(limit: number, pos?: string): Promise<GifSearchResponseDto> {
+    return this.fetchTenor('featured', { limit, pos });
+  }
+
+  private async fetchTenor(
+    endpoint: 'search' | 'featured',
+    params: { q?: string; limit: number; pos?: string },
+  ): Promise<GifSearchResponseDto> {
+    const apiKey = this.configService.get<string>('TENOR_API_KEY');
+    if (!apiKey) {
+      throw new ServiceUnavailableException(
+        'GIF search is not configured on this instance. Set TENOR_API_KEY in .env',
+      );
+    }
+
+    const url = new URL(`${TENOR_BASE_URL}/${endpoint}`);
+    url.searchParams.set('key', apiKey);
+    url.searchParams.set('client_key', TENOR_CLIENT_KEY);
+    url.searchParams.set('media_filter', MEDIA_FILTER);
+    url.searchParams.set('limit', String(params.limit));
+    if (params.q) url.searchParams.set('q', params.q);
+    if (params.pos) url.searchParams.set('pos', params.pos);
+
+    let response: Response;
+    try {
+      response = await fetch(url.toString(), {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+    } catch (error) {
+      this.logger.warn(
+        `Tenor ${endpoint} request failed: ${(error as Error).message}`,
+      );
+      throw new ServiceUnavailableException(
+        'Failed to reach the Tenor GIF service',
+      );
+    }
+
+    if (!response.ok) {
+      this.logger.warn(`Tenor ${endpoint} returned HTTP ${response.status}`);
+      throw new ServiceUnavailableException(
+        'Failed to reach the Tenor GIF service',
+      );
+    }
+
+    const data = (await response.json()) as TenorApiResponse;
+
+    const results = (data.results ?? [])
+      .map((result) => this.mapResult(result))
+      .filter((result): result is GifResultDto => result !== null);
+
+    return { results, next: data.next };
+  }
+
+  /**
+   * Maps a raw Tenor result to our slim DTO. Returns null (and is filtered
+   * out) when the `gif` media format is missing, since we have no URL to
+   * render. Falls back to the full-size gif URL for `previewUrl` when
+   * `tinygif` specifically is missing.
+   */
+  private mapResult(result: TenorResult): GifResultDto | null {
+    const gif = result.media_formats?.gif;
+    if (!gif?.url) return null;
+
+    const tinygif = result.media_formats?.tinygif;
+
+    return {
+      id: result.id,
+      title: result.content_description || result.title || '',
+      url: gif.url,
+      previewUrl: tinygif?.url || gif.url,
+      width: gif.dims?.[0] ?? 0,
+      height: gif.dims?.[1] ?? 0,
+    };
+  }
+}

--- a/backend/src/instance/dto/instance-response.dto.ts
+++ b/backend/src/instance/dto/instance-response.dto.ts
@@ -10,6 +10,10 @@ export class PublicSettingsResponseDto {
 
   @ApiProperty()
   maxFileSizeBytes: number;
+
+  /** Whether the Tenor GIF picker is available (TENOR_API_KEY configured). */
+  @ApiProperty()
+  gifSearchEnabled: boolean;
 }
 
 export class InstanceStatsResponseDto {

--- a/backend/src/instance/instance.controller.spec.ts
+++ b/backend/src/instance/instance.controller.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@suites/unit';
 import type { Mocked } from '@suites/doubles.jest';
+import { ConfigService } from '@nestjs/config';
 import { InstanceController } from './instance.controller';
 import { InstanceService } from './instance.service';
 import { RegistrationMode } from '@prisma/client';
@@ -7,6 +8,7 @@ import { RegistrationMode } from '@prisma/client';
 describe('InstanceController', () => {
   let controller: InstanceController;
   let service: Mocked<InstanceService>;
+  let configService: Mocked<ConfigService>;
 
   beforeEach(async () => {
     const { unit, unitRef } =
@@ -14,6 +16,8 @@ describe('InstanceController', () => {
 
     controller = unit;
     service = unitRef.get(InstanceService);
+    configService = unitRef.get(ConfigService);
+    configService.get.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -45,6 +49,7 @@ describe('InstanceController', () => {
         name: 'Test Instance',
         registrationMode: RegistrationMode.OPEN,
         maxFileSizeBytes: 524288000,
+        gifSearchEnabled: false,
       });
     });
 
@@ -66,6 +71,46 @@ describe('InstanceController', () => {
 
       expect(typeof result.maxFileSizeBytes).toBe('number');
       expect(result.maxFileSizeBytes).toBe(1073741824);
+    });
+
+    it('should set gifSearchEnabled to false when TENOR_API_KEY is not configured', async () => {
+      const mockSettings = {
+        id: 'settings-1',
+        name: 'Test Instance',
+        description: null,
+        registrationMode: RegistrationMode.INVITE_ONLY,
+        maxFileSizeBytes: BigInt(524288000),
+        defaultStorageQuotaBytes: BigInt(53687091200),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      service.getSettings.mockResolvedValue(mockSettings as any);
+      configService.get.mockReturnValue(undefined);
+
+      const result = await controller.getPublicSettings();
+
+      expect(result.gifSearchEnabled).toBe(false);
+    });
+
+    it('should set gifSearchEnabled to true when TENOR_API_KEY is configured', async () => {
+      const mockSettings = {
+        id: 'settings-1',
+        name: 'Test Instance',
+        description: null,
+        registrationMode: RegistrationMode.INVITE_ONLY,
+        maxFileSizeBytes: BigInt(524288000),
+        defaultStorageQuotaBytes: BigInt(53687091200),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      service.getSettings.mockResolvedValue(mockSettings as any);
+      configService.get.mockImplementation((key: string) =>
+        key === 'TENOR_API_KEY' ? 'tenor-key-123' : undefined,
+      );
+
+      const result = await controller.getPublicSettings();
+
+      expect(result.gifSearchEnabled).toBe(true);
     });
   });
 });

--- a/backend/src/instance/instance.controller.ts
+++ b/backend/src/instance/instance.controller.ts
@@ -8,6 +8,7 @@ import {
   ClassSerializerInterceptor,
 } from '@nestjs/common';
 import { ApiOkResponse } from '@nestjs/swagger';
+import { ConfigService } from '@nestjs/config';
 import { InstanceService } from './instance.service';
 import { RbacActions } from '@prisma/client';
 import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
@@ -25,7 +26,10 @@ import {
 @Controller('instance')
 @UseInterceptors(ClassSerializerInterceptor)
 export class InstanceController {
-  constructor(private readonly instanceService: InstanceService) {}
+  constructor(
+    private readonly instanceService: InstanceService,
+    private readonly configService: ConfigService,
+  ) {}
 
   /**
    * Get instance settings (public - needed for registration mode)
@@ -39,6 +43,7 @@ export class InstanceController {
       name: settings.name,
       registrationMode: settings.registrationMode,
       maxFileSizeBytes: Number(settings.maxFileSizeBytes),
+      gifSearchEnabled: Boolean(this.configService.get('TENOR_API_KEY')),
     };
   }
 

--- a/frontend/src/__tests__/components/GifPicker.test.tsx
+++ b/frontend/src/__tests__/components/GifPicker.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../msw/server';
+import { renderWithProviders } from '../test-utils';
+import { GifPickerPopover } from '../../components/Message/GifPicker';
+import type { GifResultDto, GifSearchResponseDto } from '../../api-client/types.gen';
+
+// vi.mock factories are hoisted above the rest of the module, so this must
+// not reference the BASE_URL const declared below (TDZ) — inline the literal.
+vi.mock('../../api-client/client.gen', async (importOriginal) => {
+  const { createClient, createConfig } = await import('../../api-client/client');
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    client: createClient(createConfig({ baseUrl: 'http://localhost:3000' })),
+  };
+});
+
+const BASE_URL = 'http://localhost:3000';
+
+// Default: desktop (non-touch) so the picker renders as a Popover.
+vi.mock('../../hooks/useResponsive', () => ({
+  useResponsive: () => ({
+    isTouchDevice: false,
+    shouldUseTouchUI: false,
+    isMobile: false,
+    isTablet: false,
+    isDesktop: true,
+    deviceType: 'desktop',
+  }),
+}));
+
+function makeGif(overrides: Partial<GifResultDto> = {}): GifResultDto {
+  return {
+    id: 'gif-1',
+    title: 'Cat jumping',
+    url: 'https://media.tenor.com/1/cat.gif',
+    previewUrl: 'https://media.tenor.com/1/cat-tiny.gif',
+    width: 220,
+    height: 140,
+    ...overrides,
+  };
+}
+
+const featuredResponse: GifSearchResponseDto = {
+  results: [makeGif({ id: 'featured-1', title: 'Featured GIF' })],
+  next: undefined,
+};
+
+const searchResponse: GifSearchResponseDto = {
+  results: [makeGif({ id: 'search-1', title: 'Search result GIF' })],
+  next: undefined,
+};
+
+describe('GifPickerPopover', () => {
+  let searchRequests: URLSearchParams[];
+  let featuredCalled: boolean;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchRequests = [];
+    featuredCalled = false;
+
+    server.use(
+      http.get(`${BASE_URL}/api/gifs/featured`, () => {
+        featuredCalled = true;
+        return HttpResponse.json(featuredResponse);
+      }),
+      http.get(`${BASE_URL}/api/gifs/search`, ({ request }) => {
+        const url = new URL(request.url);
+        searchRequests.push(url.searchParams);
+        return HttpResponse.json(searchResponse);
+      }),
+    );
+  });
+
+  function setup(onSelect = vi.fn()) {
+    // MUI's Popover warns if anchorEl isn't laid out in the document, so use
+    // a real attached element rather than document.body.
+    const anchorEl = document.createElement('div');
+    document.body.appendChild(anchorEl);
+
+    const utils = renderWithProviders(
+      <GifPickerPopover
+        open
+        anchorEl={anchorEl}
+        onClose={vi.fn()}
+        onSelect={onSelect}
+      />,
+    );
+    return { ...utils, onSelect };
+  }
+
+  it('loads featured GIFs when opened with an empty search box', async () => {
+    setup();
+
+    expect(await screen.findByRole('button', { name: 'Featured GIF' })).toBeInTheDocument();
+    expect(featuredCalled).toBe(true);
+    expect(searchRequests).toHaveLength(0);
+  });
+
+  it('does not render anything when closed', () => {
+    renderWithProviders(
+      <GifPickerPopover open={false} anchorEl={null} onClose={vi.fn()} onSelect={vi.fn()} />,
+    );
+
+    expect(screen.queryByPlaceholderText('Search GIFs...')).not.toBeInTheDocument();
+  });
+
+  it('triggers a search request once the user types a query', async () => {
+    const { user } = setup();
+
+    // Wait for the initial featured load so we don't race it.
+    await screen.findByRole('button', { name: 'Featured GIF' });
+
+    await user.type(screen.getByPlaceholderText('Search GIFs...'), 'cat');
+
+    await waitFor(() => {
+      expect(searchRequests.length).toBeGreaterThan(0);
+    });
+
+    const lastRequest = searchRequests[searchRequests.length - 1];
+    expect(lastRequest.get('q')).toBe('cat');
+
+    expect(
+      await screen.findByRole('button', { name: 'Search result GIF' }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onSelect with the clicked gif', async () => {
+    const { user, onSelect } = setup();
+
+    const gifButton = await screen.findByRole('button', { name: 'Featured GIF' });
+    await user.click(gifButton);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'featured-1', title: 'Featured GIF' }),
+    );
+  });
+});

--- a/frontend/src/__tests__/components/MessageInput.test.tsx
+++ b/frontend/src/__tests__/components/MessageInput.test.tsx
@@ -34,6 +34,56 @@ vi.mock('../../components/Message/EmojiPicker', () => ({
     ) : null,
 }));
 
+// Mock the GIF picker so we can trigger a selection deterministically.
+vi.mock('../../components/Message/GifPicker', () => ({
+  GifPickerPopover: ({
+    open,
+    onSelect,
+  }: {
+    open: boolean;
+    onSelect: (gif: { id: string; url: string; previewUrl: string; title: string; width: number; height: number }) => void;
+  }) =>
+    open ? (
+      <button
+        type="button"
+        data-testid="mock-gif-pick"
+        onClick={() =>
+          onSelect({
+            id: 'gif-1',
+            url: 'https://media.tenor.com/1/cat.gif',
+            previewUrl: 'https://media.tenor.com/1/cat-tiny.gif',
+            title: 'Cat',
+            width: 220,
+            height: 140,
+          })
+        }
+      >
+        pick gif
+      </button>
+    ) : null,
+}));
+
+// Controls the public-settings `gifSearchEnabled` flag consumed by MessageInput.
+// Reset to false in beforeEach; individual tests flip it on.
+let mockGifSearchEnabled = false;
+
+vi.mock('../../api-client/@tanstack/react-query.gen', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    instanceControllerGetPublicSettingsOptions: () => ({
+      queryKey: ['instanceControllerGetPublicSettings'],
+      queryFn: () =>
+        Promise.resolve({
+          name: 'Test Instance',
+          registrationMode: 'OPEN',
+          maxFileSizeBytes: 500 * 1024 * 1024,
+          gifSearchEnabled: mockGifSearchEnabled,
+        }),
+    }),
+  };
+});
+
 // Default: desktop (non-touch). Individual tests override isTouchDevice.
 const mockResponsive = vi.fn(() => ({
   isTouchDevice: false,
@@ -75,6 +125,7 @@ describe('MessageInput', () => {
       isDesktop: true,
       deviceType: 'desktop',
     });
+    mockGifSearchEnabled = false;
   });
 
   describe('emoji insertion', () => {
@@ -144,6 +195,44 @@ describe('MessageInput', () => {
 
       expect(onSendMessage).not.toHaveBeenCalled();
       expect(input.value).toBe('hi\n');
+    });
+  });
+
+  describe('GIF picker', () => {
+    it('hides the GIF button when gifSearchEnabled is false', async () => {
+      mockGifSearchEnabled = false;
+      setup();
+
+      await waitFor(() => {
+        expect(screen.queryByLabelText('add gif')).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows the GIF button when gifSearchEnabled is true', async () => {
+      mockGifSearchEnabled = true;
+      setup();
+
+      expect(await screen.findByLabelText('add gif')).toBeInTheDocument();
+    });
+
+    it('sends the GIF url immediately on selection, leaving composer text untouched', async () => {
+      mockGifSearchEnabled = true;
+      const { user, input, onSendMessage } = setup();
+
+      await user.type(input, 'still typing');
+      await user.click(await screen.findByLabelText('add gif'));
+      await user.click(screen.getByTestId('mock-gif-pick'));
+
+      await waitFor(() => {
+        expect(onSendMessage).toHaveBeenCalledTimes(1);
+      });
+      expect(onSendMessage).toHaveBeenCalledWith(
+        'https://media.tenor.com/1/cat.gif',
+        expect.any(Array),
+        [],
+      );
+      // The composer's own draft text is untouched by the GIF send.
+      expect(input.value).toBe('still typing');
     });
   });
 });

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -1,6 +1,15 @@
 import '@testing-library/jest-dom/vitest';
+import { configure } from '@testing-library/react';
 import { beforeAll, afterEach, afterAll } from 'vitest';
 import { server } from './msw/server';
+
+// RTL's default findBy*/waitFor timeout (1000ms) assumes a lightly-loaded
+// machine. Under v8 coverage instrumentation + constrained CI parallelism,
+// real timers (debounce, MSW round-trips) can occasionally take longer to
+// fire even though nothing is actually stuck — bumping this gives assertions
+// realistic headroom instead of trading it for a global vitest testTimeout
+// bump alone.
+configure({ asyncUtilTimeout: 5000 });
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
 afterEach(() => server.resetHandlers());

--- a/frontend/src/__tests__/utils/messageUtils.test.ts
+++ b/frontend/src/__tests__/utils/messageUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isUserMentioned } from '../../components/Message/messageUtils';
+import { isUserMentioned, isSoleTenorGifLink } from '../../components/Message/messageUtils';
 import { SpanType } from '../../types/message.type';
 import { createMessage } from '../test-utils/factories';
 
@@ -58,5 +58,79 @@ describe('isUserMentioned', () => {
       spans: [{ type: SpanType.USER_MENTION, text: '@alice', userId: 'user-42' }],
     });
     expect(isUserMentioned(message, 'user-99')).toBe(false);
+  });
+});
+
+describe('isSoleTenorGifLink', () => {
+  const tenorUrl = 'https://media.tenor.com/abc123/cat.gif';
+
+  it('returns true for a sole media.tenor.com URL with a matching image preview', () => {
+    const message = createMessage({
+      spans: [{ type: SpanType.PLAINTEXT, text: tenorUrl }],
+      linkPreviews: [{ url: tenorUrl, imageUrl: tenorUrl, siteName: 'media.tenor.com' }],
+    });
+    expect(isSoleTenorGifLink(message)).toBe(true);
+  });
+
+  it('returns false when there is no link preview', () => {
+    const message = createMessage({
+      spans: [{ type: SpanType.PLAINTEXT, text: tenorUrl }],
+    });
+    expect(isSoleTenorGifLink(message)).toBe(false);
+  });
+
+  it('returns false when the link preview has no imageUrl', () => {
+    const message = createMessage({
+      spans: [{ type: SpanType.PLAINTEXT, text: tenorUrl }],
+      linkPreviews: [{ url: tenorUrl, siteName: 'media.tenor.com' }],
+    });
+    expect(isSoleTenorGifLink(message)).toBe(false);
+  });
+
+  it('returns false for a non-Tenor URL', () => {
+    const otherUrl = 'https://example.com/image.gif';
+    const message = createMessage({
+      spans: [{ type: SpanType.PLAINTEXT, text: otherUrl }],
+      linkPreviews: [{ url: otherUrl, imageUrl: otherUrl }],
+    });
+    expect(isSoleTenorGifLink(message)).toBe(false);
+  });
+
+  it('returns false when there is more than one span', () => {
+    const message = createMessage({
+      spans: [
+        { type: SpanType.PLAINTEXT, text: 'check this out ' },
+        { type: SpanType.PLAINTEXT, text: tenorUrl },
+      ],
+      linkPreviews: [{ url: tenorUrl, imageUrl: tenorUrl }],
+    });
+    expect(isSoleTenorGifLink(message)).toBe(false);
+  });
+
+  it('returns false when the span has surrounding text besides the URL', () => {
+    const message = createMessage({
+      spans: [{ type: SpanType.PLAINTEXT, text: `look at this ${tenorUrl}` }],
+      linkPreviews: [{ url: tenorUrl, imageUrl: tenorUrl }],
+    });
+    expect(isSoleTenorGifLink(message)).toBe(false);
+  });
+
+  it('returns false when the message has attachments', () => {
+    const message = createMessage({
+      spans: [{ type: SpanType.PLAINTEXT, text: tenorUrl }],
+      linkPreviews: [{ url: tenorUrl, imageUrl: tenorUrl }],
+      attachments: [
+        { id: 'file-1', filename: 'a.png', mimeType: 'image/png', fileType: 'IMAGE', size: 10 },
+      ],
+    });
+    expect(isSoleTenorGifLink(message)).toBe(false);
+  });
+
+  it('returns false for a non-PLAINTEXT sole span', () => {
+    const message = createMessage({
+      spans: [{ type: SpanType.USER_MENTION, text: tenorUrl, userId: 'user-1' }],
+      linkPreviews: [{ url: tenorUrl, imageUrl: tenorUrl }],
+    });
+    expect(isSoleTenorGifLink(message)).toBe(false);
   });
 });

--- a/frontend/src/__tests__/utils/messageUtils.test.ts
+++ b/frontend/src/__tests__/utils/messageUtils.test.ts
@@ -133,4 +133,20 @@ describe('isSoleTenorGifLink', () => {
     });
     expect(isSoleTenorGifLink(message)).toBe(false);
   });
+
+  it('returns false when the sole span is an inline-code span', () => {
+    const message = createMessage({
+      spans: [{ type: SpanType.PLAINTEXT, text: tenorUrl, code: true }],
+      linkPreviews: [{ url: tenorUrl, imageUrl: tenorUrl }],
+    });
+    expect(isSoleTenorGifLink(message)).toBe(false);
+  });
+
+  it('returns true when the sole span has other formatting flags (bold)', () => {
+    const message = createMessage({
+      spans: [{ type: SpanType.PLAINTEXT, text: tenorUrl, bold: true }],
+      linkPreviews: [{ url: tenorUrl, imageUrl: tenorUrl }],
+    });
+    expect(isSoleTenorGifLink(message)).toBe(true);
+  });
 });

--- a/frontend/src/components/Message/GifPicker.tsx
+++ b/frontend/src/components/Message/GifPicker.tsx
@@ -1,0 +1,293 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Popover,
+  TextField,
+  InputAdornment,
+  IconButton,
+  CircularProgress,
+  Typography,
+} from "@mui/material";
+import { Search as SearchIcon, Clear as ClearIcon } from "@mui/icons-material";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useResponsive } from "../../hooks/useResponsive";
+import { useDebounce } from "../../hooks/useDebounce";
+import { MobileSheet } from "../Mobile/common/MobileSheet";
+import {
+  gifsControllerSearch,
+  gifsControllerFeatured,
+} from "../../api-client/sdk.gen";
+import type { GifResultDto } from "../../api-client/types.gen";
+
+const GIF_PAGE_LIMIT = 20;
+const SEARCH_DEBOUNCE_MS = 300;
+/** Start loading the next page once the user scrolls within this many px of the bottom. */
+const SCROLL_LOAD_THRESHOLD_PX = 80;
+
+/**
+ * Shared search field + infinite-scrolling GIF grid, used by GifPickerPopover.
+ * Shows Tenor's featured/trending GIFs when the search box is empty.
+ */
+const GifPickerContent: React.FC<{
+  onGifClick: (gif: GifResultDto) => void;
+  /** Touch variant: full-width, taller (for MobileSheet). */
+  touch?: boolean;
+}> = ({ onGifClick, touch = false }) => {
+  const [searchQuery, setSearchQuery] = useState("");
+  const debouncedQuery = useDebounce(searchQuery.trim(), SEARCH_DEBOUNCE_MS);
+
+  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
+    useInfiniteQuery({
+      queryKey: debouncedQuery
+        ? (["gifs", "search", debouncedQuery] as const)
+        : (["gifs", "featured"] as const),
+      queryFn: async ({ pageParam, signal }) => {
+        if (debouncedQuery) {
+          const { data } = await gifsControllerSearch({
+            query: {
+              q: debouncedQuery,
+              limit: GIF_PAGE_LIMIT,
+              pos: pageParam || undefined,
+            },
+            throwOnError: true,
+            signal,
+          });
+          return data;
+        }
+        const { data } = await gifsControllerFeatured({
+          query: { limit: GIF_PAGE_LIMIT, pos: pageParam || undefined },
+          throwOnError: true,
+          signal,
+        });
+        return data;
+      },
+      initialPageParam: "",
+      getNextPageParam: (lastPage) => lastPage.next || undefined,
+    });
+
+  const gifs = data?.pages.flatMap((page) => page.results) ?? [];
+
+  const handleScroll = (event: React.UIEvent<HTMLDivElement>) => {
+    const el = event.currentTarget;
+    const nearBottom =
+      el.scrollHeight - el.scrollTop - el.clientHeight <
+      SCROLL_LOAD_THRESHOLD_PX;
+    if (nearBottom && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        width: touch ? "100%" : "320px",
+        height: touch ? "60vh" : "420px",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* Header with Search */}
+      <Box
+        sx={{
+          p: 1.5,
+          pb: 1,
+          borderBottom: "1px solid",
+          borderColor: "divider",
+          flexShrink: 0,
+        }}
+      >
+        <TextField
+          size="small"
+          placeholder="Search GIFs..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          autoFocus
+          fullWidth
+          sx={{
+            "& .MuiOutlinedInput-root": {
+              fontSize: "0.85rem",
+              borderRadius: "8px",
+              backgroundColor: "action.hover",
+              "& fieldset": {
+                border: "none",
+              },
+              "&:hover fieldset": {
+                border: "none",
+              },
+              "&.Mui-focused fieldset": {
+                border: "1px solid",
+                borderColor: "primary.main",
+              },
+            },
+            "& .MuiOutlinedInput-input": {
+              padding: "8px 12px",
+            },
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon sx={{ fontSize: "1rem", color: "text.disabled" }} />
+              </InputAdornment>
+            ),
+            endAdornment: searchQuery && (
+              <InputAdornment position="end">
+                <IconButton
+                  size="small"
+                  onClick={() => setSearchQuery("")}
+                  sx={{ p: 0.5 }}
+                >
+                  <ClearIcon sx={{ fontSize: "0.9rem" }} />
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Box>
+
+      {/* Scrollable GIF grid */}
+      <Box
+        onScroll={handleScroll}
+        sx={{
+          flex: 1,
+          overflowY: "auto",
+          overflowX: "hidden",
+          p: 1,
+          "&::-webkit-scrollbar": {
+            width: "6px",
+          },
+          "&::-webkit-scrollbar-track": {
+            backgroundColor: "transparent",
+          },
+          "&::-webkit-scrollbar-thumb": {
+            backgroundColor: "rgba(255, 255, 255, 0.2)",
+            borderRadius: "3px",
+            "&:hover": {
+              backgroundColor: "rgba(255, 255, 255, 0.3)",
+            },
+          },
+        }}
+      >
+        {isLoading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+            <CircularProgress size={28} />
+          </Box>
+        ) : gifs.length === 0 ? (
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              py: 4,
+              color: "text.disabled",
+            }}
+          >
+            <Typography variant="body2">No GIFs found</Typography>
+          </Box>
+        ) : (
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(2, 1fr)",
+              gap: "4px",
+            }}
+          >
+            {gifs.map((gif) => (
+              <Box
+                key={gif.id}
+                component="button"
+                type="button"
+                onClick={() => onGifClick(gif)}
+                aria-label={gif.title || "GIF"}
+                sx={{
+                  border: "none",
+                  borderRadius: "6px",
+                  overflow: "hidden",
+                  cursor: "pointer",
+                  p: 0,
+                  backgroundColor: "action.hover",
+                  aspectRatio: `${gif.width || 1} / ${gif.height || 1}`,
+                  transition: "opacity 0.12s ease",
+                  "&:hover": {
+                    opacity: 0.85,
+                  },
+                }}
+              >
+                <img
+                  src={gif.previewUrl}
+                  alt={gif.title || ""}
+                  loading="lazy"
+                  style={{
+                    width: "100%",
+                    height: "100%",
+                    objectFit: "cover",
+                    display: "block",
+                  }}
+                />
+              </Box>
+            ))}
+          </Box>
+        )}
+        {isFetchingNextPage && (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 1 }}>
+            <CircularProgress size={20} />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export interface GifPickerPopoverProps {
+  open: boolean;
+  /** Element anchor (used by the composer GIF button); opens above the anchor. */
+  anchorEl?: HTMLElement | null;
+  onClose: () => void;
+  onSelect: (gif: GifResultDto) => void;
+  /** Sheet title on touch devices. */
+  title?: string;
+}
+
+/**
+ * Controlled GIF picker popover. Mirrors EmojiPickerPopover's structure:
+ * anchors to an element and opens above it on desktop, renders as a
+ * full-width bottom sheet on touch devices.
+ */
+export const GifPickerPopover: React.FC<GifPickerPopoverProps> = ({
+  open,
+  anchorEl,
+  onClose,
+  onSelect,
+  title = "GIFs",
+}) => {
+  const { shouldUseTouchUI } = useResponsive();
+
+  if (shouldUseTouchUI) {
+    return (
+      <MobileSheet open={open} onClose={onClose} title={title} maxHeight="70vh">
+        <GifPickerContent onGifClick={onSelect} touch />
+      </MobileSheet>
+    );
+  }
+
+  return (
+    <Popover
+      open={open}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      // Without this, the Modal's focus trap re-focuses the GIF BUTTON when
+      // the exit transition finishes — clobbering the composer's focus.
+      disableRestoreFocus
+      anchorOrigin={{
+        vertical: "top",
+        horizontal: "left",
+      }}
+      transformOrigin={{
+        vertical: "bottom",
+        horizontal: "left",
+      }}
+    >
+      <GifPickerContent onGifClick={onSelect} />
+    </Popover>
+  );
+};

--- a/frontend/src/components/Message/MessageComponent.tsx
+++ b/frontend/src/components/Message/MessageComponent.tsx
@@ -21,7 +21,7 @@ import { MessageToolbar } from "./MessageToolbar";
 import { renderMessageSpans } from "./MessageSpan";
 import { Container } from "./MessageComponentStyles";
 import { useMessageActions } from "./useMessageActions";
-import { isUserMentioned } from "./messageUtils";
+import { isUserMentioned, isSoleTenorGifLink } from "./messageUtils";
 import UserAvatar from "../Common/UserAvatar";
 import ConfirmDialog from "../Common/ConfirmDialog";
 import { ThreadReplyBadge } from "../Thread/ThreadReplyBadge";
@@ -267,9 +267,11 @@ function MessageComponentInner({
           />
         ) : (
           <>
-            <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word', wordBreak: 'break-word' }}>
-              {renderMessageSpans(message.spans, emojiById)}
-            </Typography>
+            {!isSoleTenorGifLink(message) && (
+              <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word', wordBreak: 'break-word' }}>
+                {renderMessageSpans(message.spans, emojiById)}
+              </Typography>
+            )}
             <MessageAttachments attachments={message.attachments} />
             <MessageLinkPreviews linkPreviews={message.linkPreviews} />
             <MessageReactions

--- a/frontend/src/components/Message/MessageInput.tsx
+++ b/frontend/src/components/Message/MessageInput.tsx
@@ -6,13 +6,17 @@
  * and simple local filtering for DMs.
  */
 
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { Box, IconButton, CircularProgress } from "@mui/material";
 import SendIcon from "@mui/icons-material/Send";
 import AttachFileIcon from "@mui/icons-material/AttachFile";
 import EmojiEmotionsOutlinedIcon from "@mui/icons-material/EmojiEmotionsOutlined";
 import { StyledPaper, StyledTextField } from "./MessageInputStyles";
 import { EmojiPickerPopover } from "./EmojiPicker";
+import { GifPickerPopover } from "./GifPicker";
+import type { GifResultDto } from "../../api-client/types.gen";
+import { instanceControllerGetPublicSettingsOptions } from "../../api-client/@tanstack/react-query.gen";
+import GifBoxOutlinedIcon from "@mui/icons-material/GifBoxOutlined";
 import { useResponsive } from "../../hooks/useResponsive";
 import { FilePreview } from "./FilePreview";
 import { MentionDropdown } from "./MentionDropdown";
@@ -88,6 +92,14 @@ export default function MessageInput({
     start: 0,
     end: 0,
   });
+
+  // GIF picker state
+  const [gifAnchorEl, setGifAnchorEl] = useState<HTMLElement | null>(null);
+  const gifPickerOpen = Boolean(gifAnchorEl);
+  const { data: publicSettings } = useQuery(
+    instanceControllerGetPublicSettingsOptions(),
+  );
+  const gifSearchEnabled = Boolean(publicSettings?.gifSearchEnabled);
 
   const captureSelection = useCallback(() => {
     const el = inputRef.current;
@@ -189,19 +201,23 @@ export default function MessageInput({
     enabled: isChannel,
   });
 
-  const aliasMentions: AliasMention[] = isChannel
-    ? aliasGroups.map(group => ({ id: group.id, name: group.name }))
-    : [];
+  const aliasMentions: AliasMention[] = useMemo(
+    () =>
+      isChannel
+        ? aliasGroups.map(group => ({ id: group.id, name: group.name }))
+        : [],
+    [isChannel, aliasGroups],
+  );
 
   // Custom emojis (channel only) — used to resolve `:shortcode:` at send time
   // and to power the picker's Custom section.
   const { emojis: customEmojis } = useCommunityCustomEmojis(
     isChannel ? communityId : undefined,
   );
-  const emojiMentions: EmojiMention[] = customEmojis.map(e => ({
-    id: e.id,
-    name: e.name,
-  }));
+  const emojiMentions: EmojiMention[] = useMemo(
+    () => customEmojis.map(e => ({ id: e.id, name: e.name })),
+    [customEmojis],
+  );
 
   // Local mention state for DMs
   const [dmMentionState, setDmMentionState] = useState<SimpleMentionState>({
@@ -342,41 +358,56 @@ export default function MessageInput({
     }
   };
 
-  // --- Send handler ---
-  const handleSend = async () => {
-    if ((!text || !text.trim()) && selectedFiles.length === 0) return;
-    if (sending) return;
+  // --- Send (core) ---
+  // Shared by the composer's send button/Enter key and the GIF picker, so
+  // there is exactly one place that builds spans and calls onSendMessage.
+  // Returns whether the message was actually sent (false = no-op or error).
+  const sendMessageContent = useCallback(
+    async (rawText: string, files: File[]): Promise<boolean> => {
+      if ((!rawText || !rawText.trim()) && files.length === 0) return false;
+      if (sending) return false;
 
-    setSending(true);
-    try {
-      const messageText = text.trim() || "";
-      let spans = parseMessageWithMentions(messageText, userMentions, channelMentions, aliasMentions, emojiMentions);
+      setSending(true);
+      try {
+        const messageText = rawText.trim() || "";
+        let spans = parseMessageWithMentions(messageText, userMentions, channelMentions, aliasMentions, emojiMentions);
 
-      if (spans.length === 0) {
-        spans = [{ type: SpanType.PLAINTEXT, text: '' }];
-      }
-
-      await onSendMessage(messageText, spans, selectedFiles);
-      sendTypingStop();
-      setText("");
-      clearFiles();
-      if (isChannel) {
-        mentionHook.close();
-      } else {
-        closeDmMentions();
-      }
-
-      requestAnimationFrame(() => {
-        if (inputRef.current) {
-          inputRef.current.focus();
+        if (spans.length === 0) {
+          spans = [{ type: SpanType.PLAINTEXT, text: '' }];
         }
-      });
-    } catch (error) {
-      logger.error("Failed to send message:", error);
-      showNotification("Failed to send message. Please try again.", "error");
-    } finally {
-      setSending(false);
+
+        await onSendMessage(messageText, spans, files);
+        sendTypingStop();
+        return true;
+      } catch (error) {
+        logger.error("Failed to send message:", error);
+        showNotification("Failed to send message. Please try again.", "error");
+        return false;
+      } finally {
+        setSending(false);
+      }
+    },
+    [sending, userMentions, channelMentions, aliasMentions, emojiMentions, onSendMessage, sendTypingStop, showNotification],
+  );
+
+  // --- Send handler (composer) ---
+  const handleSend = async () => {
+    const sent = await sendMessageContent(text, selectedFiles);
+    if (!sent) return;
+
+    setText("");
+    clearFiles();
+    if (isChannel) {
+      mentionHook.close();
+    } else {
+      closeDmMentions();
     }
+
+    requestAnimationFrame(() => {
+      if (inputRef.current) {
+        inputRef.current.focus();
+      }
+    });
   };
 
   // --- Emoji picker handlers ---
@@ -390,6 +421,25 @@ export default function MessageInput({
   const handleEmojiPickerClose = () => {
     setEmojiAnchorEl(null);
   };
+
+  // --- GIF picker handlers ---
+  const handleGifButtonClick = (event: React.MouseEvent<HTMLElement>) => {
+    setGifAnchorEl(event.currentTarget);
+  };
+
+  const handleGifPickerClose = () => {
+    setGifAnchorEl(null);
+  };
+
+  // Selecting a GIF sends it immediately as its own message (Discord
+  // behavior) — the composer's text/files are left untouched.
+  const handleGifSelect = useCallback(
+    (gif: GifResultDto) => {
+      setGifAnchorEl(null);
+      void sendMessageContent(gif.url, []);
+    },
+    [sendMessageContent],
+  );
 
   const handleEmojiSelect = useCallback(
     (emoji: string) => {
@@ -550,6 +600,15 @@ export default function MessageInput({
           >
             <EmojiEmotionsOutlinedIcon />
           </IconButton>
+          {gifSearchEnabled && (
+            <IconButton
+              onClick={handleGifButtonClick}
+              disabled={sending}
+              aria-label="add gif"
+            >
+              <GifBoxOutlinedIcon />
+            </IconButton>
+          )}
           <IconButton
             onClick={handleFileButtonClick}
             disabled={sending}
@@ -577,6 +636,16 @@ export default function MessageInput({
         onCustomEmojiSelect={(emoji) => handleEmojiSelect(`:${emoji.name}:`)}
         title="Add Emoji"
       />
+
+      {gifSearchEnabled && (
+        <GifPickerPopover
+          open={gifPickerOpen}
+          anchorEl={gifAnchorEl}
+          onClose={handleGifPickerClose}
+          onSelect={handleGifSelect}
+          title="GIFs"
+        />
+      )}
     </Box>
   );
 }

--- a/frontend/src/components/Message/messageUtils.ts
+++ b/frontend/src/components/Message/messageUtils.ts
@@ -58,6 +58,8 @@ export function isSoleTenorGifLink(message: MessageType): boolean {
 
   const [span] = message.spans;
   if (span.type !== SpanType.PLAINTEXT) return false;
+  // Inline code was an intentional choice to show the raw URL, not hide it.
+  if (span.code === true) return false;
 
   const text = span.text?.trim();
   if (!text) return false;

--- a/frontend/src/components/Message/messageUtils.ts
+++ b/frontend/src/components/Message/messageUtils.ts
@@ -45,3 +45,32 @@ export function isUserMentioned(
     return false;
   });
 }
+
+/**
+ * True when a message's entire content is a single `media.tenor.com` URL
+ * (i.e. sent via the GIF picker) AND there's a matching link preview with an
+ * image. Callers can use this to hide the redundant raw URL text and show
+ * only the rendered preview image — Discord-style GIF messages.
+ */
+export function isSoleTenorGifLink(message: MessageType): boolean {
+  if (message.attachments.length > 0) return false;
+  if (message.spans.length !== 1) return false;
+
+  const [span] = message.spans;
+  if (span.type !== SpanType.PLAINTEXT) return false;
+
+  const text = span.text?.trim();
+  if (!text) return false;
+
+  let url: URL;
+  try {
+    url = new URL(text);
+  } catch {
+    return false;
+  }
+  if (url.hostname !== "media.tenor.com") return false;
+
+  return !!message.linkPreviews?.some(
+    (preview) => preview.url === text && !!preview.imageUrl,
+  );
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/__tests__/setup.ts'],
     include: ['src/__tests__/**/*.test.{ts,tsx}'],
+    // Coverage instrumentation (v8) plus CI worker contention can slow real
+    // (non-fake) timers/network round-trips enough to blow past the 5s
+    // default, even when the underlying assertion is not actually stuck —
+    // see GifPicker/MessageInput flake investigation. Give tests headroom
+    // rather than papering over it per-test.
+    testTimeout: 15000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary'],


### PR DESCRIPTION
Fixes #301

## Summary
- New `gifs` backend module proxying Tenor v2 (`GET /gifs/search`, `GET /gifs/featured`), JWT-authenticated, returning a slim DTO (`id, title, url, previewUrl, width, height`) plus Tenor's `next` cursor; 503 when `TENOR_API_KEY` is not configured
- `gifSearchEnabled` flag added to public instance settings so the frontend hides the feature when no key is set
- `GifPickerPopover` in the composer (mirrors the emoji picker): featured on open, debounced search, 2-column grid, infinite scroll via the `pos` cursor
- Selecting a GIF sends immediately through the existing send path with the media URL as sole content; rendering rides the existing link-preview pipeline (no new render pipeline, no schema changes). Messages that are a single Tenor link hide the raw URL and show only the GIF

## Config
- `TENOR_API_KEY` (optional) — feature is fully hidden/disabled when absent

## Testing
- Backend: gifs service/controller specs (mapping, missing media formats, key-absent 503, cursor passthrough), instance settings flag specs
- Frontend: GifPicker (featured/search/select) and MessageInput button visibility per flag (Vitest + MSW)
- Full backend and frontend suites green at pre-existing baselines; lint clean; OpenAPI spec regenerated

Note for smoke testing: set `TENOR_API_KEY` in backend env, reload — GIF button appears next to the emoji picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)