### PR TITLE
fix(e2e): run e2e stack under dedicated compose project name

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -6,7 +6,7 @@ services:
   postgres-test:
     image: postgres:17
     ports:
-      - "5433:5432"  # Different port to avoid conflicts
+      - "${E2E_POSTGRES_PORT:-5433}:5432"  # Different port to avoid conflicts; override if 5433 is taken
     environment:
       POSTGRES_USER: semaphore
       POSTGRES_PASSWORD: semaphore

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -130,6 +130,13 @@ See `.github/workflows/e2e-tests.yml` for configuration.
 docker compose -p kraken-e2e -f docker-compose.e2e.yml build --no-cache
 ```
 
+If the e2e Postgres port (5433) collides with something already running on your
+host, override it:
+
+```bash
+E2E_POSTGRES_PORT=5533 ./scripts/run-e2e.sh
+```
+
 ### Database seed fails
 
 ```bash

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -127,14 +127,14 @@ See `.github/workflows/e2e-tests.yml` for configuration.
 ```bash
 # Clean up and rebuild
 ./scripts/run-e2e.sh --clean
-docker-compose -f docker-compose.e2e.yml build --no-cache
+docker compose -p kraken-e2e -f docker-compose.e2e.yml build --no-cache
 ```
 
 ### Database seed fails
 
 ```bash
 # Check backend logs
-docker-compose -f docker-compose.e2e.yml logs backend-test
+docker compose -p kraken-e2e -f docker-compose.e2e.yml logs backend-test
 ```
 
 ### Browser not installed

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -24,6 +24,10 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+# Dedicated compose project name so cleanup (down -v --remove-orphans) can never
+# touch the dev stack, which runs under the default project name (see #403).
+COMPOSE="docker compose -p kraken-e2e -f docker-compose.e2e.yml"
+
 # Parse arguments
 ALL_BROWSERS=false
 UI_MODE=false
@@ -73,7 +77,7 @@ echo ""
 cleanup() {
   echo -e "\n${YELLOW}🧹 Cleaning up Docker containers...${NC}"
   cd "$PROJECT_ROOT"
-  docker-compose -f docker-compose.e2e.yml down -v --remove-orphans 2>/dev/null || true
+  $COMPOSE down -v --remove-orphans 2>/dev/null || true
   echo -e "${GREEN}✓ Cleanup complete${NC}"
 }
 
@@ -89,13 +93,13 @@ trap cleanup EXIT
 # Step 1: Start E2E containers
 echo -e "${BLUE}📦 Starting E2E Docker containers...${NC}"
 cd "$PROJECT_ROOT"
-docker-compose -f docker-compose.e2e.yml down -v --remove-orphans 2>/dev/null || true
-docker-compose -f docker-compose.e2e.yml up -d postgres-test redis-test
+$COMPOSE down -v --remove-orphans 2>/dev/null || true
+$COMPOSE up -d postgres-test redis-test
 
 # Wait for PostgreSQL to be ready
 echo -e "${YELLOW}⏳ Waiting for PostgreSQL...${NC}"
 for i in {1..30}; do
-  if docker-compose -f docker-compose.e2e.yml exec -T postgres-test pg_isready -U semaphore > /dev/null 2>&1; then
+  if $COMPOSE exec -T postgres-test pg_isready -U semaphore > /dev/null 2>&1; then
     echo -e "${GREEN}✓ PostgreSQL is ready${NC}"
     break
   fi
@@ -109,7 +113,7 @@ done
 # Wait for Redis to be ready
 echo -e "${YELLOW}⏳ Waiting for Redis...${NC}"
 for i in {1..30}; do
-  if docker-compose -f docker-compose.e2e.yml exec -T redis-test redis-cli ping > /dev/null 2>&1; then
+  if $COMPOSE exec -T redis-test redis-cli ping > /dev/null 2>&1; then
     echo -e "${GREEN}✓ Redis is ready${NC}"
     break
   fi
@@ -122,7 +126,7 @@ done
 
 # Start backend
 echo -e "${BLUE}🚀 Starting backend service...${NC}"
-docker-compose -f docker-compose.e2e.yml up -d backend-test
+$COMPOSE up -d backend-test
 
 # Wait for backend
 echo -e "${YELLOW}⏳ Waiting for backend...${NC}"
@@ -134,7 +138,7 @@ for i in {1..60}; do
   sleep 2
   if [ $i -eq 60 ]; then
     echo -e "${RED}✗ Backend failed to start. Logs:${NC}"
-    docker-compose -f docker-compose.e2e.yml logs backend-test --tail=50
+    $COMPOSE logs backend-test --tail=50
     exit 1
   fi
 done
@@ -142,10 +146,10 @@ done
 # Step 2: Migrate + seed the database (volumes are fresh after `down -v`,
 # so the schema must be applied before seeding — same order as CI)
 echo -e "${BLUE}🗄️  Running database migrations...${NC}"
-docker-compose -f docker-compose.e2e.yml exec -T backend-test pnpm run prisma:migrate
+$COMPOSE exec -T backend-test pnpm run prisma:migrate
 
 echo -e "${BLUE}🌱 Seeding test database...${NC}"
-docker-compose -f docker-compose.e2e.yml exec -T backend-test npx ts-node prisma/seed-e2e.ts || {
+$COMPOSE exec -T backend-test npx ts-node prisma/seed-e2e.ts || {
   echo -e "${YELLOW}⚠️  Seed script not found, creating test user via API...${NC}"
 
   # Fallback: create users via API
@@ -161,7 +165,7 @@ echo -e "${GREEN}✓ Database seeded${NC}"
 
 # Start frontend
 echo -e "${BLUE}🌐 Starting frontend service...${NC}"
-docker-compose -f docker-compose.e2e.yml up -d frontend-test
+$COMPOSE up -d frontend-test
 
 # Wait for frontend
 echo -e "${YELLOW}⏳ Waiting for frontend...${NC}"
@@ -173,7 +177,7 @@ for i in {1..60}; do
   sleep 2
   if [ $i -eq 60 ]; then
     echo -e "${RED}✗ Frontend failed to start. Logs:${NC}"
-    docker-compose -f docker-compose.e2e.yml logs frontend-test --tail=50
+    $COMPOSE logs frontend-test --tail=50
     exit 1
   fi
 done

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -25,7 +25,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 # Dedicated compose project name so cleanup (down -v --remove-orphans) can never
-# touch the dev stack, which runs under the default project name (see #403).
+# touch the dev stack, which runs without -p and therefore under the
+# directory-derived default project name (see #403).
 COMPOSE="docker compose -p kraken-e2e -f docker-compose.e2e.yml"
 
 # Parse arguments

--- a/scripts/run-voice-e2e.sh
+++ b/scripts/run-voice-e2e.sh
@@ -26,7 +26,9 @@ set -uo pipefail
 GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
 cd "$(dirname "$0")/.."
 
-COMPOSE="docker compose -f docker-compose.e2e.yml -f docker-compose.voice-e2e.yml -f docker-compose.voice-e2e.host.yml"
+# -p kraken-e2e: dedicated project name so `down -v` can never touch the dev
+# stack, which runs under the default project name (see #403).
+COMPOSE="docker compose -p kraken-e2e -f docker-compose.e2e.yml -f docker-compose.voice-e2e.yml -f docker-compose.voice-e2e.host.yml"
 CLEAN=false
 HEADED=""
 SPEC=""

--- a/scripts/run-voice-e2e.sh
+++ b/scripts/run-voice-e2e.sh
@@ -27,7 +27,8 @@ GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
 cd "$(dirname "$0")/.."
 
 # -p kraken-e2e: dedicated project name so `down -v` can never touch the dev
-# stack, which runs under the default project name (see #403).
+# stack, which runs without -p and therefore under the directory-derived
+# default project name (see #403).
 COMPOSE="docker compose -p kraken-e2e -f docker-compose.e2e.yml -f docker-compose.voice-e2e.yml -f docker-compose.voice-e2e.host.yml"
 CLEAN=false
 HEADED=""


### PR DESCRIPTION
## Summary

The e2e scripts ran `docker compose -f docker-compose.e2e.yml` under the same default project name (`kraken`) as the dev stack. Their cleanup (`down -v --remove-orphans`) therefore treated the dev stack's containers as orphans and removed them — a footgun that destroyed a running dev environment twice in one day (see #403).

- **`scripts/run-e2e.sh`**: all compose invocations centralized into a `COMPOSE` variable with `-p kraken-e2e`. Also moves from legacy `docker-compose` (v1, no longer installed on dev machines) to `docker compose` v2, matching `run-voice-e2e.sh` and CI.
- **`scripts/run-voice-e2e.sh`**: same `-p kraken-e2e` added to its existing `COMPOSE` var (it shares `docker-compose.e2e.yml` and runs `down -v` on `--clean`).
- **`docker-compose.e2e.yml`**: e2e postgres host port is now `${E2E_POSTGRES_PORT:-5433}` so collisions with parked stacks can be resolved without editing the file.
- **`frontend/e2e/README.md`**: troubleshooting commands updated to include the project flag.

CI (`.github/workflows/e2e-tests.yml`) is unchanged — runners are isolated, so no project-name collision exists there.

## Verification

With the dev stack running:
- `./scripts/run-e2e.sh --clean` → dev containers untouched (previously this removed them as orphans)
- `docker compose -p kraken-e2e -f docker-compose.e2e.yml up -d postgres-test redis-test` → containers created as `kraken-e2e-*`, `docker compose ls` shows `kraken` and `kraken-e2e` as separate projects; `down -v` removed only e2e resources
- `bash -n` on both scripts; `docker compose -p kraken-e2e -f docker-compose.e2e.yml config --quiet` passes

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sAJfCfBfMm8chbZMsh5Y5