### PR TITLE
fix(messages): detect virtua prepend at MESSAGE_MAX_PAGES cap

### DIFF
--- a/frontend/src/__tests__/components/VirtualMessageList.test.tsx
+++ b/frontend/src/__tests__/components/VirtualMessageList.test.tsx
@@ -286,6 +286,38 @@ describe('VirtualMessageList', () => {
     expect(capturedProps.shift).toBe(false);
   });
 
+  it('sets shift=true when an older page prepends at the cap and evicts the newest page (length unchanged)', () => {
+    const initial = messages(5);
+    const { rerender } = render(
+      <VirtualMessageList {...baseProps} orderedMessages={initial} />,
+    );
+    // Pin to the bottom, as the reader typically is when a background
+    // older-page load evicts the newest page.
+    act(() => capturedProps.onScroll?.(600));
+    fakeHandle.scrollToIndex.mockClear();
+
+    // At MESSAGE_MAX_PAGES, an older-page prepend evicts the newest page:
+    // same length (5), new oldest id, and the newest id also changes.
+    const older = createMessage({ id: 'at-cap-older' });
+    const atCap = [older, ...initial.slice(0, 4)]; // drop msg-4 (newest)
+    rerender(<VirtualMessageList {...baseProps} orderedMessages={atCap} />);
+
+    expect(capturedProps.shift).toBe(true);
+    // Stick-to-bottom must be suppressed even though the newest id changed.
+    expect(fakeHandle.scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it('does not set shift when only the oldest message is dropped (length shrinks)', () => {
+    const initial = messages(5);
+    const { rerender } = render(
+      <VirtualMessageList {...baseProps} orderedMessages={initial} />,
+    );
+    const shrunk = initial.slice(1); // drop msg-0 (oldest), no prepend
+    rerender(<VirtualMessageList {...baseProps} orderedMessages={shrunk} />);
+
+    expect(capturedProps.shift).toBe(false);
+  });
+
   it('sticks to the bottom when a newer message arrives while pinned', () => {
     const initial = messages(5);
     const { rerender } = render(

--- a/frontend/src/components/Message/VirtualMessageList.tsx
+++ b/frontend/src/components/Message/VirtualMessageList.tsx
@@ -121,10 +121,15 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
     const newestId = orderedMessages[len - 1]?.id;
 
     // True on the render immediately after an older page prepended at the start.
+    // At the MESSAGE_MAX_PAGES cap, a prepend adds an older page but evicts the
+    // newest page, so `len` stays unchanged — we can't require `len > prevLen`.
+    // Instead require `len >= prevLen` (deleting only the oldest message shrinks
+    // `len` and is correctly excluded) alongside a defined previous oldest id
+    // (guards the context-switch reset, where it's `undefined`) that changed.
     const isPrepend =
-      prevLenRef.current > 0 &&
-      len > prevLenRef.current &&
-      oldestId !== prevOldestIdRef.current;
+      prevOldestIdRef.current !== undefined &&
+      oldestId !== prevOldestIdRef.current &&
+      len >= prevLenRef.current;
 
     const scrollToBottom = useCallback(() => {
       const handle = vlistRef.current;


### PR DESCRIPTION
## Summary

Fixes the concrete bug from #404: `VirtualMessageList`'s prepend detection required the message array to grow (`len > prevLen`). At the `MESSAGE_MAX_PAGES` cap (40 pages ≈ 1000 messages), TanStack Query evicts the **newest** page when an older page loads, so a prepend leaves the array length unchanged — `shift` was never passed to virtua's `<VList>`, and the viewport jumped on every older-page load in at-cap channels.

**Fix** (`frontend/src/components/Message/VirtualMessageList.tsx`): detect a prepend as

```ts
const isPrepend =
  prevOldestIdRef.current !== undefined &&   // guards the context-switch reset
  oldestId !== prevOldestIdRef.current &&
  len >= prevLenRef.current;                 // deleting only the oldest message shrinks len → excluded
```

This mirrors the guard style of the legacy `useBidirectionalScroll` path (which keys on oldest-id change + scrollHeight, and is immune). At the cap the newest id also changes; `isPrepend` being true now correctly keeps the stick-to-bottom effect suppressed via its existing `!isPrepend` guard.

**Regression tests** (`frontend/src/__tests__/components/VirtualMessageList.test.tsx`):
- constant-length prepend (older message in, newest evicted) → `shift === true` and no scroll-to-bottom
- dropping only the oldest message (length shrinks) → `shift === false`

The cap test was verified to **fail against the old condition** (`expected false to be true` on `shift`) and pass with the fix.

## Scope

This closes only the concrete shift-detection bug from #404. The issue's broader at-cap audit (WS appends targeting evicted pages, jump-to-present semantics when the true newest message is outside the window) remains open — leaving #404 open for that.

## Verification

- Full frontend suite: 160 files / 1678 tests passing (`docker compose run --rm frontend pnpm run test`)
- Lint: 0 errors
- New test fails on old code, passes on new (checked by temporary revert)

Refs #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sAJfCfBfMm8chbZMsh5Y5