### PR TITLE
feat(frontend): app-level and route-level error boundaries

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,9 @@ import { hasServers } from "./utils/serverStorage";
 import { isElectron } from "./utils/platform";
 import { AuthGate } from "./components/AuthGate";
 import { PublicRoute } from "./components/PublicRoute";
+import { ErrorBoundary } from "./components/ErrorBoundary";
+import { AppErrorFallback } from "./components/AppErrorFallback";
+import { RouteErrorBoundary } from "./components/RouteErrorBoundary";
 
 // Eager imports - first-paint routes
 import LoginPage from "./pages/LoginPage";
@@ -93,61 +96,75 @@ function App() {
       <PWAInstallPrompt />
       <UpdateToast />
       <OfflineBanner />
-      <Suspense fallback={
-        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 'var(--full-dvh)' }}>
-          <CircularProgress />
-        </Box>
-      }>
-        <Routes>
-          {/* Public routes */}
-          <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
-          <Route path="/register" element={<PublicRoute><RegisterPage /></PublicRoute>} />
-          <Route path="/forgot-password" element={<PublicRoute><ForgotPasswordPage /></PublicRoute>} />
-          <Route path="/reset-password" element={<PublicRoute><ResetPasswordPage /></PublicRoute>} />
-          <Route path="/onboarding" element={<OnboardingPage />} />
-          <Route path="/join/:inviteCode" element={<JoinInvitePage />} />
+      {/*
+        App-level boundary: the outermost safety net for render crashes that
+        escape every closer boundary (e.g. RouteErrorBoundary below). It sits
+        inside ThemeProvider so the fallback is themed, and above the routes
+        so it only catches what a route-level boundary didn't. QueryClient
+        (main.tsx) and the auth/socket/notification providers mounted by
+        AuthGate/Layout live below RouteErrorBoundary's panel-level seams, so
+        ordinary page crashes never reach this far and never unmount them —
+        this boundary firing means a full reload is the safest recovery.
+      */}
+      <ErrorBoundary fallback={(error) => <AppErrorFallback error={error} />}>
+        <Suspense fallback={
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 'var(--full-dvh)' }}>
+            <CircularProgress />
+          </Box>
+        }>
+          <RouteErrorBoundary>
+            <Routes>
+              {/* Public routes */}
+              <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
+              <Route path="/register" element={<PublicRoute><RegisterPage /></PublicRoute>} />
+              <Route path="/forgot-password" element={<PublicRoute><ForgotPasswordPage /></PublicRoute>} />
+              <Route path="/reset-password" element={<PublicRoute><ResetPasswordPage /></PublicRoute>} />
+              <Route path="/onboarding" element={<OnboardingPage />} />
+              <Route path="/join/:inviteCode" element={<JoinInvitePage />} />
 
-          {/* Authenticated routes — AuthGate validates token + mounts providers */}
-          <Route element={<AuthGate />}>
-            {/* Debug routes — outside Layout so they render on mobile too */}
-            <Route path="debug/pwa" element={<PWADebugPage />} />
+              {/* Authenticated routes — AuthGate validates token + mounts providers */}
+              <Route element={<AuthGate />}>
+                {/* Debug routes — outside Layout so they render on mobile too */}
+                <Route path="debug/pwa" element={<PWADebugPage />} />
 
-            <Route path="/" element={<Layout />}>
-              <Route index element={<HomePage />} />
-              <Route path="direct-messages" element={<DirectMessagesPage />} />
-              <Route path="direct-messages/:dmGroupId" element={<DirectMessagesPage />} />
-              <Route path="notifications" element={<NotificationsPage />} />
-              <Route path="friends" element={<FriendsPage />} />
-              <Route path="settings" element={<SettingsPage />} />
+                <Route path="/" element={<Layout />}>
+                  <Route index element={<HomePage />} />
+                  <Route path="direct-messages" element={<DirectMessagesPage />} />
+                  <Route path="direct-messages/:dmGroupId" element={<DirectMessagesPage />} />
+                  <Route path="notifications" element={<NotificationsPage />} />
+                  <Route path="friends" element={<FriendsPage />} />
+                  <Route path="settings" element={<SettingsPage />} />
 
-              {/* Admin routes with dedicated layout */}
-              <Route path="admin" element={<AdminLayout />}>
-                <Route index element={<AdminDashboard />} />
-                <Route path="users" element={<AdminUsersPage />} />
-                <Route path="communities" element={<AdminCommunitiesPage />} />
-                <Route path="invites" element={<AdminInvitePage />} />
-                <Route path="roles" element={<AdminRolesPage />} />
-                <Route path="storage" element={<AdminStoragePage />} />
-                <Route path="settings" element={<AdminSettingsPage />} />
-                <Route path="debug" element={<AdminDebugPage />} />
+                  {/* Admin routes with dedicated layout */}
+                  <Route path="admin" element={<AdminLayout />}>
+                    <Route index element={<AdminDashboard />} />
+                    <Route path="users" element={<AdminUsersPage />} />
+                    <Route path="communities" element={<AdminCommunitiesPage />} />
+                    <Route path="invites" element={<AdminInvitePage />} />
+                    <Route path="roles" element={<AdminRolesPage />} />
+                    <Route path="storage" element={<AdminStoragePage />} />
+                    <Route path="settings" element={<AdminSettingsPage />} />
+                    <Route path="debug" element={<AdminDebugPage />} />
+                  </Route>
+
+                  {/* Debug routes (admin only - access check in component) */}
+                  <Route path="debug/notifications" element={<NotificationDebugPage />} />
+                  <Route path="profile" element={<ProfileRedirect />} />
+                  <Route path="profile/edit" element={<ProfileEditPage />} />
+                  <Route path="profile/:userId" element={<ProfilePage />} />
+                  <Route path="community/create" element={<CreateCommunityPage />} />
+                  <Route path="community/:communityId">
+                    <Route index element={<CommunityPage />} />
+                    <Route path="edit" element={<EditCommunityPage />} />
+                    <Route path="channel/:channelId" element={<CommunityPage />} />
+                  </Route>
+                  <Route path="*" element={<NotFoundPage />} />
+                </Route>
               </Route>
-
-              {/* Debug routes (admin only - access check in component) */}
-              <Route path="debug/notifications" element={<NotificationDebugPage />} />
-              <Route path="profile" element={<ProfileRedirect />} />
-              <Route path="profile/edit" element={<ProfileEditPage />} />
-              <Route path="profile/:userId" element={<ProfilePage />} />
-              <Route path="community/create" element={<CreateCommunityPage />} />
-              <Route path="community/:communityId">
-                <Route index element={<CommunityPage />} />
-                <Route path="edit" element={<EditCommunityPage />} />
-                <Route path="channel/:channelId" element={<CommunityPage />} />
-              </Route>
-              <Route path="*" element={<NotFoundPage />} />
-            </Route>
-          </Route>
-        </Routes>
-      </Suspense>
+            </Routes>
+          </RouteErrorBoundary>
+        </Suspense>
+      </ErrorBoundary>
     </ThemeProvider>
   );
 }

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -38,6 +38,7 @@ import { disconnectSocket } from "./utils/socketSingleton";
 import { clearSavedConnection } from "./features/voice/voiceActions";
 import { clearTokens, getElectronRefreshToken } from "./utils/tokenService";
 import { isElectron } from "./utils/platform";
+import { RouteErrorBoundary } from "./components/RouteErrorBoundary";
 
 const settings = ["My Profile", "Settings", "Logout"];
 
@@ -64,7 +65,17 @@ const LayoutContentArea: React.FC<{ voiceConnected: boolean; isMenuExpanded: boo
       }}
     >
       <Box sx={{ flex: 1, minHeight: "100%" }}>
-        <Outlet />
+        {/*
+          Panel-level seam: wraps only the routed page content so a crash in
+          any single page/panel leaves the AppBar, community sidebar, and
+          voice bottom bar (siblings of LayoutContentArea, rendered below)
+          mounted and functional. This is the boundary that keeps the desktop
+          shell alive — see App.tsx for the outer RouteErrorBoundary that
+          covers everything else (including Layout itself).
+        */}
+        <RouteErrorBoundary>
+          <Outlet />
+        </RouteErrorBoundary>
       </Box>
     </Box>
   );

--- a/frontend/src/__tests__/components/AppErrorFallback.test.tsx
+++ b/frontend/src/__tests__/components/AppErrorFallback.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import { ErrorBoundary } from '../../components/ErrorBoundary';
+import { AppErrorFallback } from '../../components/AppErrorFallback';
+
+function Bomb(): never {
+  throw new Error('Catastrophic failure');
+}
+
+describe('AppErrorFallback (app-level ErrorBoundary usage)', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the full-page fallback with the error message and a Reload button when a child throws', () => {
+    // Mirrors how App.tsx wires the app-level boundary:
+    // <ErrorBoundary fallback={(error) => <AppErrorFallback error={error} />}>
+    renderWithProviders(
+      <ErrorBoundary fallback={(error) => <AppErrorFallback error={error} />}>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByText('Catastrophic failure')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload/i })).toBeInTheDocument();
+  });
+
+  it('calls window.location.reload when the Reload button is clicked', async () => {
+    const reloadSpy = vi.fn();
+    const originalLocation = window.location;
+    // jsdom's window.location.reload is not implemented; stub it out.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadSpy },
+    });
+
+    const { user } = renderWithProviders(
+      <ErrorBoundary fallback={(error) => <AppErrorFallback error={error} />}>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /reload/i }));
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+});

--- a/frontend/src/__tests__/components/RouteErrorBoundary.test.tsx
+++ b/frontend/src/__tests__/components/RouteErrorBoundary.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { Link, Outlet, Route, Routes } from 'react-router-dom';
+import { renderWithProviders } from '../test-utils';
+import { RouteErrorBoundary } from '../../components/RouteErrorBoundary';
+
+/** Throws during render while `bomb.shouldThrow` is true. Reset it between
+ * tests/renders to simulate fixing the underlying issue. */
+const bomb = { shouldThrow: true };
+
+function Bomb() {
+  if (bomb.shouldThrow) {
+    throw new Error('Boom');
+  }
+  return <div data-testid="safe-content">Safe content</div>;
+}
+
+/** Mimics the real usage: one RouteErrorBoundary wraps an <Outlet />, and
+ * different route content renders inside it as the pathname changes. */
+function Shell() {
+  return (
+    <RouteErrorBoundary>
+      <Outlet />
+    </RouteErrorBoundary>
+  );
+}
+
+describe('RouteErrorBoundary', () => {
+  beforeEach(() => {
+    bomb.shouldThrow = true;
+    // React logs a console.error for the caught render error (and our
+    // ErrorBoundary logs via logger.error, which also calls console.error).
+    // This is expected noise for these tests — silence it.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the fallback when a child throws during render', () => {
+    renderWithProviders(
+      <RouteErrorBoundary>
+        <Bomb />
+      </RouteErrorBoundary>,
+    );
+
+    expect(screen.getByText(/something went wrong loading this page/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('safe-content')).not.toBeInTheDocument();
+  });
+
+  it('re-renders children when "Try again" is clicked after the throw condition is fixed', async () => {
+    const { user } = renderWithProviders(
+      <RouteErrorBoundary>
+        <Bomb />
+      </RouteErrorBoundary>,
+    );
+
+    expect(screen.getByText(/something went wrong loading this page/i)).toBeInTheDocument();
+
+    // Fix the underlying issue, then retry.
+    bomb.shouldThrow = false;
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+
+    expect(await screen.findByTestId('safe-content')).toBeInTheDocument();
+    expect(screen.queryByText(/something went wrong loading this page/i)).not.toBeInTheDocument();
+  });
+
+  it('resets automatically when navigating to a different pathname', async () => {
+    const { user } = renderWithProviders(
+      <>
+        <Link to="/safe" data-testid="go-safe">
+          Go safe
+        </Link>
+        <Routes>
+          <Route element={<Shell />}>
+            <Route path="/crash" element={<Bomb />} />
+            <Route path="/safe" element={<div data-testid="safe-route">Safe route</div>} />
+          </Route>
+        </Routes>
+      </>,
+      { routerProps: { initialEntries: ['/crash'] } },
+    );
+
+    expect(screen.getByText(/something went wrong loading this page/i)).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('go-safe'));
+
+    expect(await screen.findByTestId('safe-route')).toBeInTheDocument();
+    expect(screen.queryByText(/something went wrong loading this page/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/RouteErrorBoundary.test.tsx
+++ b/frontend/src/__tests__/components/RouteErrorBoundary.test.tsx
@@ -1,3 +1,4 @@
+import { ReactNode, useEffect } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { Link, Outlet, Route, Routes } from 'react-router-dom';
@@ -25,9 +26,56 @@ function Shell() {
   );
 }
 
+/** Module-level mount counter for the provider-persistence tests below. */
+let providerMountCount = 0;
+
+/**
+ * Mirrors a real provider (SocketProvider/VoiceProvider/etc.) mounted as an
+ * ANCESTOR of RouteErrorBoundary — exactly like Layout.tsx mounts
+ * SocketHubProvider/ReplayBufferProvider/etc. above the panel-level
+ * RouteErrorBoundary that wraps just `<Outlet />`. Deliberately does NOT
+ * render an <Outlet /> itself and is NOT part of the route tree beneath the
+ * boundary — it's a plain wrapper, so it can never be part of the subtree
+ * that a nested ErrorBoundary swaps out for its fallback. This is the
+ * property that matters: components above the boundary must survive both
+ * ordinary navigation and a crash-then-recover cycle inside it.
+ */
+function TrackingProvider({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    providerMountCount += 1;
+  }, []);
+  return <>{children}</>;
+}
+
+/** Composition mirroring the App.tsx / Layout.tsx nesting: a provider sits
+ * above RouteErrorBoundary, which wraps <Routes>. */
+function AppLikeShell() {
+  return (
+    <TrackingProvider>
+      <Link to="/a" data-testid="go-a">
+        Go A
+      </Link>
+      <Link to="/b" data-testid="go-b">
+        Go B
+      </Link>
+      <Link to="/crash" data-testid="go-crash">
+        Go crash
+      </Link>
+      <RouteErrorBoundary>
+        <Routes>
+          <Route path="/a" element={<div data-testid="route-a">Route A</div>} />
+          <Route path="/b" element={<div data-testid="route-b">Route B</div>} />
+          <Route path="/crash" element={<Bomb />} />
+        </Routes>
+      </RouteErrorBoundary>
+    </TrackingProvider>
+  );
+}
+
 describe('RouteErrorBoundary', () => {
   beforeEach(() => {
     bomb.shouldThrow = true;
+    providerMountCount = 0;
     // React logs a console.error for the caught render error (and our
     // ErrorBoundary logs via logger.error, which also calls console.error).
     // This is expected noise for these tests — silence it.
@@ -88,5 +136,49 @@ describe('RouteErrorBoundary', () => {
 
     expect(await screen.findByTestId('safe-route')).toBeInTheDocument();
     expect(screen.queryByText(/something went wrong loading this page/i)).not.toBeInTheDocument();
+  });
+
+  it('does not remount providers above RouteErrorBoundary when navigating between healthy routes', async () => {
+    const { user } = renderWithProviders(<AppLikeShell />, {
+      routerProps: { initialEntries: ['/a'] },
+    });
+
+    expect(screen.getByTestId('route-a')).toBeInTheDocument();
+    expect(providerMountCount).toBe(1);
+
+    await user.click(screen.getByTestId('go-b'));
+
+    expect(await screen.findByTestId('route-b')).toBeInTheDocument();
+    // Critical regression check: a pathname-keyed boundary would unmount and
+    // remount everything beneath it (including RouteErrorBoundary's own
+    // children, and — with the old top-level placement wrapping all of
+    // <Routes> in App.tsx — every provider mounted inside the route tree) on
+    // every single navigation. With no location-derived key, healthy
+    // navigation must never touch this provider at all.
+    expect(providerMountCount).toBe(1);
+  });
+
+  it('recovers from a crashed route via navigation without remounting providers above RouteErrorBoundary', async () => {
+    const { user } = renderWithProviders(<AppLikeShell />, {
+      routerProps: { initialEntries: ['/a'] },
+    });
+
+    expect(screen.getByTestId('route-a')).toBeInTheDocument();
+    expect(providerMountCount).toBe(1);
+
+    await user.click(screen.getByTestId('go-crash'));
+
+    expect(await screen.findByText(/something went wrong loading this page/i)).toBeInTheDocument();
+    // The crash is caught entirely inside RouteErrorBoundary; the provider
+    // above it is an already-committed ancestor and is untouched by it.
+    expect(providerMountCount).toBe(1);
+
+    await user.click(screen.getByTestId('go-b'));
+
+    expect(await screen.findByTestId('route-b')).toBeInTheDocument();
+    expect(screen.queryByText(/something went wrong loading this page/i)).not.toBeInTheDocument();
+    // The provider must have survived both the crash and the
+    // navigation-triggered reset — it should never have been remounted.
+    expect(providerMountCount).toBe(1);
   });
 });

--- a/frontend/src/__tests__/components/RouteErrorBoundary.test.tsx
+++ b/frontend/src/__tests__/components/RouteErrorBoundary.test.tsx
@@ -39,12 +39,43 @@ let providerMountCount = 0;
  * that a nested ErrorBoundary swaps out for its fallback. This is the
  * property that matters: components above the boundary must survive both
  * ordinary navigation and a crash-then-recover cycle inside it.
+ *
+ * NOTE: because TrackingProvider sits ABOVE RouteErrorBoundary, it can never
+ * detect a `key={location.pathname}`-style bug on the `<ErrorBoundary>`
+ * RouteErrorBoundary renders internally — a React `key` only affects the
+ * element it's applied to and that element's descendants, never its
+ * ancestors. So tests 4 and 5 below (which use TrackingProvider) verify a
+ * real and useful property — ancestor providers survive healthy navigation
+ * and crash+recovery — but they are NOT a regression guard against the old,
+ * reverted location-keyed-remount bug. See TrackingLayout / test 6 below for
+ * the test that actually discriminates that bug.
  */
 function TrackingProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     providerMountCount += 1;
   }, []);
   return <>{children}</>;
+}
+
+/** Module-level mount counter for the route-level layout test below. */
+let layoutMountCount = 0;
+
+/**
+ * Mirrors a route-level layout rendered INSIDE the `<Routes>` that
+ * RouteErrorBoundary wraps (its own `<Outlet />` renders the matched child
+ * route), as opposed to TrackingProvider above, which sits outside
+ * RouteErrorBoundary entirely. This placement is what lets TrackingLayout
+ * actually detect the old, reverted `key={location.pathname}` bug: that key
+ * was applied to the `<ErrorBoundary>` INSIDE RouteErrorBoundary, so it
+ * unmounted/remounted everything ErrorBoundary rendered as `children` —
+ * including `<Routes>` and everything inside it, including this layout — on
+ * every navigation, not just after a crash.
+ */
+function TrackingLayout() {
+  useEffect(() => {
+    layoutMountCount += 1;
+  }, []);
+  return <Outlet />;
 }
 
 /** Composition mirroring the App.tsx / Layout.tsx nesting: a provider sits
@@ -76,6 +107,7 @@ describe('RouteErrorBoundary', () => {
   beforeEach(() => {
     bomb.shouldThrow = true;
     providerMountCount = 0;
+    layoutMountCount = 0;
     // React logs a console.error for the caught render error (and our
     // ErrorBoundary logs via logger.error, which also calls console.error).
     // This is expected noise for these tests — silence it.
@@ -149,12 +181,12 @@ describe('RouteErrorBoundary', () => {
     await user.click(screen.getByTestId('go-b'));
 
     expect(await screen.findByTestId('route-b')).toBeInTheDocument();
-    // Critical regression check: a pathname-keyed boundary would unmount and
-    // remount everything beneath it (including RouteErrorBoundary's own
-    // children, and — with the old top-level placement wrapping all of
-    // <Routes> in App.tsx — every provider mounted inside the route tree) on
-    // every single navigation. With no location-derived key, healthy
-    // navigation must never touch this provider at all.
+    // Verifies ancestor providers survive healthy navigation. Note this does
+    // NOT exercise the old location-keyed-remount bug: TrackingProvider sits
+    // above RouteErrorBoundary, and a key applied to the ErrorBoundary
+    // RouteErrorBoundary renders internally can never reach its ancestors —
+    // only its own descendants. See the TrackingLayout test below for the
+    // one that actually discriminates that bug.
     expect(providerMountCount).toBe(1);
   });
 
@@ -180,5 +212,44 @@ describe('RouteErrorBoundary', () => {
     // The provider must have survived both the crash and the
     // navigation-triggered reset — it should never have been remounted.
     expect(providerMountCount).toBe(1);
+  });
+
+  it('does not remount a route-level layout inside RouteErrorBoundary when navigating between healthy routes', async () => {
+    const { user } = renderWithProviders(
+      <>
+        <Link to="/layout-a" data-testid="layout-go-a">
+          Go layout A
+        </Link>
+        <Link to="/layout-b" data-testid="layout-go-b">
+          Go layout B
+        </Link>
+        <RouteErrorBoundary>
+          <Routes>
+            <Route element={<TrackingLayout />}>
+              <Route path="/layout-a" element={<div data-testid="layout-route-a">Layout Route A</div>} />
+              <Route path="/layout-b" element={<div data-testid="layout-route-b">Layout Route B</div>} />
+            </Route>
+          </Routes>
+        </RouteErrorBoundary>
+      </>,
+      { routerProps: { initialEntries: ['/layout-a'] } },
+    );
+
+    expect(screen.getByTestId('layout-route-a')).toBeInTheDocument();
+    expect(layoutMountCount).toBe(1);
+
+    await user.click(screen.getByTestId('layout-go-b'));
+
+    expect(await screen.findByTestId('layout-route-b')).toBeInTheDocument();
+    // This is the discriminator: TrackingLayout is a route element rendered
+    // INSIDE the <Routes> that RouteErrorBoundary wraps. Under the old,
+    // reverted `key={location.pathname}` bug, the key was applied to the
+    // ErrorBoundary RouteErrorBoundary renders internally, which unmounted
+    // and remounted everything it rendered as children — including
+    // <Routes> and TrackingLayout inside it — on every navigation, so this
+    // count would become 2. Under the current, fixed implementation there
+    // is no key at all, so healthy navigation never remounts anything
+    // beneath RouteErrorBoundary and the count stays at 1.
+    expect(layoutMountCount).toBe(1);
   });
 });

--- a/frontend/src/components/AppErrorFallback.tsx
+++ b/frontend/src/components/AppErrorFallback.tsx
@@ -1,0 +1,48 @@
+import { Box, Typography, Button } from '@mui/material';
+import { Error as ErrorIcon } from '@mui/icons-material';
+
+interface AppErrorFallbackProps {
+  error?: Error;
+}
+
+/**
+ * Full-page fallback for the app-level ErrorBoundary in App.tsx.
+ *
+ * This is the outermost safety net — it only renders when a render error
+ * escaped every closer boundary (e.g. RouteErrorBoundary), which means we
+ * can't be confident about the state of anything below it (auth, sockets,
+ * voice connection, etc). Recovery is a full reload rather than an in-place
+ * reset.
+ */
+export const AppErrorFallback: React.FC<AppErrorFallbackProps> = ({ error }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: 'var(--full-dvh, 100vh)',
+      width: '100%',
+      p: 3,
+      textAlign: 'center',
+      bgcolor: 'background.default',
+    }}
+  >
+    <ErrorIcon sx={{ fontSize: 64, color: 'error.main', mb: 2 }} />
+    <Typography variant="h5" gutterBottom color="text.primary">
+      Something went wrong
+    </Typography>
+    <Typography variant="body2" color="text.secondary" sx={{ mb: 3, maxWidth: 480 }}>
+      {error?.message || 'An unexpected error occurred and the app needs to reload.'}
+    </Typography>
+    <Button
+      variant="contained"
+      color="primary"
+      onClick={() => window.location.reload()}
+    >
+      Reload
+    </Button>
+  </Box>
+);
+
+export default AppErrorFallback;

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -5,7 +5,12 @@ import { logger } from '../utils/logger';
 
 interface Props {
   children: ReactNode;
-  fallback?: ReactNode;
+  /**
+   * Static fallback node, or a render function that receives the caught
+   * error and a reset callback (useful when the fallback needs to show the
+   * error message and/or trigger recovery itself).
+   */
+  fallback?: ReactNode | ((error: Error | undefined, reset: () => void) => ReactNode);
   onReset?: () => void;
 }
 
@@ -48,6 +53,9 @@ export class ErrorBoundary extends Component<Props, State> {
     if (this.state.hasError) {
       // Custom fallback UI if provided
       if (this.props.fallback) {
+        if (typeof this.props.fallback === 'function') {
+          return this.props.fallback(this.state.error, this.handleReset);
+        }
         return this.props.fallback;
       }
 

--- a/frontend/src/components/RouteErrorBoundary.tsx
+++ b/frontend/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,59 @@
+import { ReactNode, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { Box, Typography, Button } from '@mui/material';
+import { ErrorBoundary } from './ErrorBoundary';
+
+interface RouteErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface RouteErrorFallbackProps {
+  onRetry: () => void;
+}
+
+const RouteErrorFallback: React.FC<RouteErrorFallbackProps> = ({ onRetry }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '50vh',
+      width: '100%',
+      p: 3,
+      textAlign: 'center',
+    }}
+  >
+    <Typography variant="body1" color="text.primary" gutterBottom>
+      Something went wrong loading this page
+    </Typography>
+    <Button variant="outlined" color="primary" onClick={onRetry} sx={{ mt: 1 }}>
+      Try again
+    </Button>
+  </Box>
+);
+
+/**
+ * Wraps route content in an ErrorBoundary that:
+ * - Automatically resets when the URL pathname changes, so navigating away
+ *   from a crashed route recovers without a full page reload.
+ * - Offers a "Try again" button to reset without navigating.
+ *
+ * Both cases are implemented by remounting the inner ErrorBoundary (and its
+ * children) via a `key` that changes on pathname change or manual retry.
+ */
+export const RouteErrorBoundary: React.FC<RouteErrorBoundaryProps> = ({ children }) => {
+  const location = useLocation();
+  const [retryCount, setRetryCount] = useState(0);
+
+  return (
+    <ErrorBoundary
+      key={`${location.pathname}:${retryCount}`}
+      fallback={<RouteErrorFallback onRetry={() => setRetryCount((count) => count + 1)} />}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+};
+
+export default RouteErrorBoundary;

--- a/frontend/src/components/RouteErrorBoundary.tsx
+++ b/frontend/src/components/RouteErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Box, Typography, Button } from '@mui/material';
 import { ErrorBoundary } from './ErrorBoundary';
@@ -8,49 +8,70 @@ interface RouteErrorBoundaryProps {
 }
 
 interface RouteErrorFallbackProps {
-  onRetry: () => void;
+  reset: () => void;
 }
 
-const RouteErrorFallback: React.FC<RouteErrorFallbackProps> = ({ onRetry }) => (
-  <Box
-    sx={{
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-      minHeight: '50vh',
-      width: '100%',
-      p: 3,
-      textAlign: 'center',
-    }}
-  >
-    <Typography variant="body1" color="text.primary" gutterBottom>
-      Something went wrong loading this page
-    </Typography>
-    <Button variant="outlined" color="primary" onClick={onRetry} sx={{ mt: 1 }}>
-      Try again
-    </Button>
-  </Box>
-);
+/**
+ * Rendered ONLY while the boundary is in the errored state (it's the
+ * `fallback` render-prop output, not a sibling of the healthy children). It
+ * captures the pathname that was active when it mounted — i.e. the crashed
+ * route's pathname — and watches for navigation away from it, calling
+ * `reset()` automatically. Because this component only exists during the
+ * errored state, none of this navigation-watching logic runs during normal
+ * (healthy) operation: navigating between healthy routes never mounts this
+ * component and never touches `useLocation` here at all.
+ */
+const RouteErrorFallback: React.FC<RouteErrorFallbackProps> = ({ reset }) => {
+  const location = useLocation();
+  const crashedPathnameRef = useRef(location.pathname);
+
+  useEffect(() => {
+    if (location.pathname !== crashedPathnameRef.current) {
+      reset();
+    }
+  }, [location.pathname, reset]);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100%',
+        width: '100%',
+        p: 3,
+        textAlign: 'center',
+      }}
+    >
+      <Typography variant="body1" color="text.primary" gutterBottom>
+        Something went wrong loading this page
+      </Typography>
+      <Button variant="outlined" color="primary" onClick={reset} sx={{ mt: 1 }}>
+        Try again
+      </Button>
+    </Box>
+  );
+};
 
 /**
  * Wraps route content in an ErrorBoundary that:
- * - Automatically resets when the URL pathname changes, so navigating away
- *   from a crashed route recovers without a full page reload.
+ * - Automatically resets when the URL pathname changes away from the
+ *   pathname that was active at crash time, so navigating away from a
+ *   crashed route recovers without a full page reload.
  * - Offers a "Try again" button to reset without navigating.
  *
- * Both cases are implemented by remounting the inner ErrorBoundary (and its
- * children) via a `key` that changes on pathname change or manual retry.
+ * Deliberately does NOT key the inner ErrorBoundary (or its children) by
+ * `location.pathname`. During healthy operation this component renders
+ * `children` completely unmodified — no keying, no location-derived remount
+ * — so ordinary navigation never unmounts/remounts anything beneath it
+ * (providers, sockets, voice connections, etc. all survive route changes).
+ * Reset-on-navigation only happens while errored, via the `RouteErrorFallback`
+ * above, which is the only place that reads `location`.
  */
 export const RouteErrorBoundary: React.FC<RouteErrorBoundaryProps> = ({ children }) => {
-  const location = useLocation();
-  const [retryCount, setRetryCount] = useState(0);
-
   return (
-    <ErrorBoundary
-      key={`${location.pathname}:${retryCount}`}
-      fallback={<RouteErrorFallback onRetry={() => setRetryCount((count) => count + 1)} />}
-    >
+    <ErrorBoundary fallback={(_error, reset) => <RouteErrorFallback reset={reset} />}>
       {children}
     </ErrorBoundary>
   );


### PR DESCRIPTION
## Summary
- The app previously had exactly one error boundary (buried in MobileChatPanel) — any render throw white-screened the whole app.
- Adds an app-level boundary (inside ThemeProvider, providers stay mounted above it) with a themed full-page fallback + Reload.
- Adds `RouteErrorBoundary` around the route tree and the desktop layout's `<Outlet/>` so a crashing page leaves the nav shell and voice bar alive. Recovery: "Try again" resets in place; navigating away auto-resets.
- Design note: during healthy operation the boundary has **zero** location coupling (no pathname keys) — reset-on-navigation lives inside the errored-state fallback only, so sockets/voice/providers never remount on ordinary navigation. A mount-tracking regression test guards this (proven RED against the keyed anti-pattern).

## Test plan
- 6 boundary tests incl. the no-remount regression guard; full suite 164 files / 1707 tests, type-check, lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sAJfCfBfMm8chbZMsh5Y5