### PR TITLE
feat(webhooks): per-webhook-id rate limit on execute endpoint

### DIFF
--- a/backend/src/webhooks/webhook-throttler.guard.spec.ts
+++ b/backend/src/webhooks/webhook-throttler.guard.spec.ts
@@ -1,0 +1,129 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import {
+  ThrottlerException,
+  ThrottlerModuleOptions,
+  ThrottlerStorage,
+} from '@nestjs/throttler';
+import { WebhookThrottlerGuard } from './webhook-throttler.guard';
+
+describe('WebhookThrottlerGuard', () => {
+  let guard: WebhookThrottlerGuard;
+  let storage: jest.Mocked<ThrottlerStorage>;
+  const originalEnv = process.env.NODE_ENV;
+
+  /**
+   * Fake storage that mirrors the real ThrottlerStorage contract closely
+   * enough for these tests: increments a per-key counter and reports
+   * isBlocked once the caller-supplied limit is exceeded for that key.
+   * Different keys (e.g. different webhook ids, or different throttler
+   * names) never share a counter, since the guard's generateKey() folds
+   * the throttler name, tracker, controller, and handler into the key.
+   */
+  function createFakeStorage(): jest.Mocked<ThrottlerStorage> {
+    const counts = new Map<string, number>();
+    const increment = jest.fn((key: string, ttl: number, limit: number) => {
+      const totalHits = (counts.get(key) ?? 0) + 1;
+      counts.set(key, totalHits);
+      const isBlocked = totalHits > limit;
+      return {
+        totalHits,
+        timeToExpire: ttl,
+        isBlocked,
+        timeToBlockExpire: isBlocked ? ttl : 0,
+      };
+    });
+    // Cast rather than declaring the unused (blockDuration, throttlerName)
+    // params: the real ThrottlerStorage#increment signature has 5 params,
+    // but this fake only needs the first 3.
+    return { increment } as unknown as jest.Mocked<ThrottlerStorage>;
+  }
+
+  function createContext(webhookId: string): ExecutionContext {
+    const req: Record<string, any> = { params: { id: webhookId }, headers: {} };
+    const res = { header: jest.fn() };
+    return {
+      switchToHttp: () => ({
+        getRequest: () => req,
+        getResponse: () => res,
+      }),
+      getClass: () => ({ name: 'WebhookExecutionController' }),
+      getHandler: () => ({ name: 'execute' }),
+    } as unknown as ExecutionContext;
+  }
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'development';
+    storage = createFakeStorage();
+    const options: ThrottlerModuleOptions = { throttlers: [] };
+    guard = new WebhookThrottlerGuard(options, storage, new Reflector());
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  describe('getTracker', () => {
+    it('returns webhook:<id> from the request params', async () => {
+      const req = { params: { id: 'wh-123' } };
+
+      const tracker = await (guard as any).getTracker(req);
+
+      expect(tracker).toBe('webhook:wh-123');
+    });
+  });
+
+  describe('test-mode skip', () => {
+    it('allows the request without touching storage when NODE_ENV=test', async () => {
+      process.env.NODE_ENV = 'test';
+      const context = createContext('wh-1');
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(storage.increment).not.toHaveBeenCalled();
+    });
+
+    it('enforces the limit when NODE_ENV is not test', async () => {
+      const context = createContext('wh-1');
+
+      await guard.canActivate(context);
+
+      expect(storage.increment).toHaveBeenCalled();
+    });
+  });
+
+  describe('per-webhook limit enforcement', () => {
+    it('allows requests up to the per-webhook limit and rejects beyond it', async () => {
+      const context = createContext('wh-1');
+
+      // webhookShort tier allows 10 requests per 10s.
+      for (let i = 0; i < 10; i++) {
+        await expect(guard.canActivate(context)).resolves.toBe(true);
+      }
+
+      await expect(guard.canActivate(context)).rejects.toBeInstanceOf(
+        ThrottlerException,
+      );
+    });
+  });
+
+  describe('key-space isolation between webhook ids', () => {
+    it('does not share counters across different webhook ids', async () => {
+      const contextA = createContext('wh-a');
+      const contextB = createContext('wh-b');
+
+      // Exhaust the limit for webhook A.
+      for (let i = 0; i < 10; i++) {
+        await guard.canActivate(contextA);
+      }
+      await expect(guard.canActivate(contextA)).rejects.toBeInstanceOf(
+        ThrottlerException,
+      );
+
+      // Webhook B has an independent counter and is unaffected.
+      await expect(guard.canActivate(contextB)).resolves.toBe(true);
+    });
+  });
+});

--- a/backend/src/webhooks/webhook-throttler.guard.ts
+++ b/backend/src/webhooks/webhook-throttler.guard.ts
@@ -1,0 +1,121 @@
+import { Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import {
+  InjectThrottlerOptions,
+  InjectThrottlerStorage,
+  ThrottlerGuard,
+  ThrottlerModuleOptions,
+  ThrottlerOptions,
+  ThrottlerStorage,
+} from '@nestjs/throttler';
+
+/**
+ * Per-webhook-identity rate limit for the public webhook execute endpoint
+ * (`POST /webhooks/:id/:token` — see WebhookExecutionController#execute).
+ *
+ * This composes with, rather than replaces, the route's existing per-IP
+ * `@Throttle({ short, long })` tiers. Those are enforced by the global
+ * `APP_GUARD` ThrottlerGuard (see app.module.ts) using the library's
+ * default tracker (`req.ip`). A leaked webhook token can still flood a
+ * channel by rotating source IPs (botnet / cloud IP churn), so this guard
+ * additionally keys on the webhook id itself, independent of source IP.
+ * Both guards run on the route and must both pass.
+ *
+ * ## Key-space separation from the IP-based tiers
+ *
+ * `ThrottlerGuard#generateKey` (inherited unchanged here) hashes
+ * `sha256(`${controllerName}-${handlerName}-${throttlerName}-${tracker}`)`.
+ * Two things independently guarantee this guard's Redis keys never collide
+ * with the global guard's IP-keyed entries for the same route:
+ *   1. Distinct throttler names: this guard uses `webhookShort` /
+ *      `webhookLong`, never `short` / `medium` / `long` (the app-wide,
+ *      IP-based tier names). The hash input differs on `throttlerName`
+ *      alone, before the tracker is even considered.
+ *   2. Distinct tracker values: this guard's tracker is `webhook:<id>`,
+ *      the global guard's is the request IP — never equal in practice.
+ *
+ * Distinct names also matter for a second reason: `@Throttle()` metadata
+ * (`THROTTLER_LIMIT:<name>` / `THROTTLER_TTL:<name>` etc., set via
+ * `Reflect.defineMetadata` on the handler) is read by *any* ThrottlerGuard
+ * instance checking that handler, keyed only by throttler name — not by
+ * guard identity. Reusing `short`/`long` here would let the existing
+ * `@Throttle({ short: {...}, long: {...} })` decorator on the execute
+ * route silently override this guard's limits too. Using guard-private
+ * names (`webhookShort`/`webhookLong`) makes that impossible: neither
+ * guard's metadata can affect the other's tiers.
+ *
+ * ## Where the limits come from
+ *
+ * The 10-per-10s / 60-per-60s webhook tiers are hardcoded in
+ * `configureWebhookThrottlers()` below rather than sourced from
+ * `@Throttle()` route metadata or the global `ThrottlerModuleOptions`
+ * ('short'/'medium'/'long' are reserved for app-wide IP-based limiting).
+ * Storage is still the shared, injected `ThrottlerStorage` — the
+ * Redis-backed, fail-open `FailOpenThrottlerStorage` configured in
+ * app.module.ts — so these limits hold across replicas and fail open on a
+ * Redis outage exactly like every other tier.
+ *
+ * ## Test-mode behavior
+ *
+ * The global `APP_GUARD` ThrottlerGuard is omitted entirely under
+ * `NODE_ENV=test` (see app.module.ts). This guard is instead bound
+ * directly to the route via `@UseGuards`, so it isn't skipped by that
+ * omission — it must skip itself, mirroring the same convention.
+ */
+@Injectable()
+export class WebhookThrottlerGuard extends ThrottlerGuard {
+  constructor(
+    @InjectThrottlerOptions() options: ThrottlerModuleOptions,
+    @InjectThrottlerStorage() storageService: ThrottlerStorage,
+    reflector: Reflector,
+  ) {
+    super(options, storageService, reflector);
+    this.configureWebhookThrottlers();
+  }
+
+  /**
+   * The base class's onModuleInit() derives `this.throttlers` from the
+   * injected global ThrottlerModuleOptions (the IP-based 'short'/'medium'/
+   * 'long' tiers), which would clobber the fixed webhook tiers set in the
+   * constructor if Nest invokes this lifecycle hook for us. Re-applying the
+   * same fixed config here keeps behavior correct whether or not Nest calls
+   * onModuleInit for a guard resolved via `@UseGuards()` (as opposed to a
+   * module `providers` entry).
+   */
+  onModuleInit(): Promise<void> {
+    this.configureWebhookThrottlers();
+    return Promise.resolve();
+  }
+
+  protected shouldSkip(): Promise<boolean> {
+    return Promise.resolve(process.env.NODE_ENV === 'test');
+  }
+
+  protected getTracker(req: Record<string, any>): Promise<string> {
+    const params = req.params as Record<string, string> | undefined;
+    return Promise.resolve(`webhook:${params?.id}`);
+  }
+
+  private configureWebhookThrottlers(): void {
+    const throttlers: ThrottlerOptions[] = [
+      { name: 'webhookShort', ttl: 10_000, limit: 10 },
+      { name: 'webhookLong', ttl: 60_000, limit: 60 },
+    ];
+    // Arrow functions (rather than `this.getTracker.bind(this)`) avoid the
+    // `any`-typed return of Function.prototype.bind's lib.es5 overloads,
+    // while still capturing `this` lexically.
+    const getTracker: ThrottlerOptions['getTracker'] = (
+      req: Record<string, any>,
+    ) => this.getTracker(req);
+    const generateKey: ThrottlerOptions['generateKey'] = (
+      context,
+      suffix,
+      name,
+    ) => this.generateKey(context, suffix, name);
+    this.throttlers = throttlers;
+    this.commonOptions = {
+      getTracker,
+      generateKey,
+    };
+  }
+}

--- a/backend/src/webhooks/webhooks.controller.ts
+++ b/backend/src/webhooks/webhooks.controller.ts
@@ -23,6 +23,7 @@ import {
 } from '@/auth/rbac-resource.decorator';
 import { AuthenticatedRequest } from '@/types';
 import { WebhooksService } from './webhooks.service';
+import { WebhookThrottlerGuard } from './webhook-throttler.guard';
 import { CreateWebhookDto } from './dto/create-webhook.dto';
 import { ExecuteWebhookDto } from './dto/execute-webhook.dto';
 import {
@@ -99,6 +100,9 @@ export class WebhookExecutionController {
   @HttpCode(201)
   @Public()
   @Throttle({ short: { limit: 4, ttl: 1000 }, long: { limit: 30, ttl: 60000 } })
+  // Per-webhook-identity limit, independent of the per-IP tiers above — see
+  // WebhookThrottlerGuard for how the two dimensions stay isolated.
+  @UseGuards(WebhookThrottlerGuard)
   @ApiCreatedResponse({ type: ExecuteWebhookResponseDto })
   execute(
     @Param('id') id: string,


### PR DESCRIPTION
## Summary
- The webhook execute endpoint's existing throttle keys per-IP, so a leaked token could flood a channel from distributed IPs.
- Adds `WebhookThrottlerGuard` (extends ThrottlerGuard) keying on `webhook:<id>` from the route param: **10/10s and 60/min per webhook**, enforced independently alongside the unchanged per-IP tiers.
- Storage is the app's existing Redis-backed fail-open ThrottlerStorage (global module) — limits hold across replicas; key-space separation from the IP guard verified against @nestjs/throttler key derivation (distinct throttler names + tracker).
- Skips under NODE_ENV=test, matching the app's global-guard convention.

## Test plan
- 5 guard unit tests (tracker, per-id isolation, breach → 429, test-mode skip) against a real counter-backed fake storage; full backend suite 142 suites / 2359 tests, lint, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sAJfCfBfMm8chbZMsh5Y5