### PR TITLE
feat(electron): explicit sandbox, origin-checked permissions, secure-storage transparency

### DIFF
--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -14,6 +14,7 @@ import { autoUpdater, UpdateInfo, ProgressInfo } from 'electron-updater';
 import { initMain } from 'electron-audio-loopback';
 import * as path from 'path';
 import * as fs from 'fs';
+import type { SecureStorageAvailability, SecureStorageStoreResult } from './secure-storage.types';
 
 // ─── App Settings (single JSON file in userData) ────────────────────────────
 
@@ -81,6 +82,30 @@ function isWayland(): boolean {
     !!process.env.WAYLAND_DISPLAY ||
     process.env.XDG_SESSION_TYPE === 'wayland'
   );
+}
+
+/**
+ * Determine whether a URL (or origin) belongs to the app itself, as opposed
+ * to a remote page loaded via window-open/will-navigate. Used to gate
+ * media/display-capture/fullscreen permission grants so an unexpected
+ * remote origin can never silently acquire camera/mic/screen access.
+ *
+ * Matches exactly how the app loads in each mode:
+ * - Packaged production: `mainWindow.loadFile(...)` → `file://` origin.
+ * - Development: `mainWindow.loadURL('http://localhost:5173/')`.
+ */
+function isAppOrigin(urlOrOrigin: string): boolean {
+  if (!urlOrOrigin) return false;
+  try {
+    const parsed = new URL(urlOrOrigin);
+    if (parsed.protocol === 'file:') return true;
+    if (parsed.protocol === 'http:' && parsed.hostname === 'localhost' && parsed.port === '5173') {
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -569,21 +594,32 @@ function setupIpcHandlers() {
   // Secure storage handlers — encrypt refresh token via OS keychain
   const secureStoragePath = path.join(app.getPath('userData'), 'secure-tokens');
 
-  ipcMain.handle('secure-storage:store', async (_event, key: string, value: string) => {
+  // Lets the renderer proactively check encryption availability (e.g. to
+  // surface a warning) without performing a store/read operation.
+  ipcMain.handle('secure-storage:availability', (): SecureStorageAvailability => {
+    return safeStorage.isEncryptionAvailable() ? 'available' : 'unavailable';
+  });
+
+  ipcMain.handle('secure-storage:store', async (_event, key: string, value: string): Promise<SecureStorageStoreResult> => {
+    const availability: SecureStorageAvailability = safeStorage.isEncryptionAvailable()
+      ? 'available'
+      : 'unavailable';
+
+    if (availability === 'unavailable') {
+      console.warn('safeStorage encryption not available, falling back to renderer localStorage');
+      return { stored: false, availability };
+    }
+
     try {
-      if (!safeStorage.isEncryptionAvailable()) {
-        console.warn('safeStorage encryption not available, falling back to renderer localStorage');
-        return null;
-      }
       const encrypted = safeStorage.encryptString(value);
       if (!fs.existsSync(secureStoragePath)) {
         fs.mkdirSync(secureStoragePath, { recursive: true });
       }
       fs.writeFileSync(path.join(secureStoragePath, key), encrypted);
-      return true;
+      return { stored: true, availability };
     } catch (error) {
       console.error('Failed to store secure token:', error);
-      return null;
+      return { stored: false, availability };
     }
   });
 
@@ -661,6 +697,13 @@ function createWindow() {
       nodeIntegration: false,
       // Security: enable context isolation
       contextIsolation: true,
+      // Security: explicitly enable the OS-level renderer sandbox (Chromium's
+      // process sandbox). Electron defaults to sandbox: true already when
+      // nodeIntegration is false, but pin it explicitly so this doesn't
+      // silently change if Electron's defaults ever do. The preload script
+      // only uses contextBridge/ipcRenderer plus the polyfilled `process`
+      // global (platform/env), all of which remain available under sandbox.
+      sandbox: true,
       // Enable preload script
       preload: path.join(__dirname, 'preload.cjs'),
       // Keep timers and audio running when window is hidden/minimized
@@ -750,17 +793,37 @@ function createWindow() {
 
 // When Electron has finished initialization
 app.whenReady().then(() => {
-  // Setup media permissions for camera, microphone, screen sharing, and fullscreen
-  session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
+  // Setup media permissions for camera, microphone, screen sharing, and fullscreen.
+  // Origin-checked: only the app's own page (file:// in packaged prod,
+  // http://localhost:5173 in dev) may be granted these — never a remote
+  // origin that ended up loaded via window-open/will-navigate edge cases.
+  session.defaultSession.setPermissionRequestHandler((webContents, permission, callback, details) => {
     const allowedPermissions = ['media', 'display-capture', 'fullscreen'];
+    const requestingUrl = details.requestingUrl || webContents.getURL();
 
-    if (allowedPermissions.includes(permission)) {
-      console.log(`Granting permission: ${permission}`);
+    if (allowedPermissions.includes(permission) && isAppOrigin(requestingUrl)) {
+      console.log(`Granting permission: ${permission} (origin: ${requestingUrl})`);
       callback(true);
     } else {
-      console.log(`Denying permission: ${permission}`);
+      console.log(`Denying permission: ${permission} (origin: ${requestingUrl})`);
       callback(false);
     }
+  });
+
+  // Permission checks (synchronous, used e.g. for already-granted-permission
+  // queries) must apply the same origin policy as the request handler above —
+  // otherwise a check could report "allowed" for a permission the request
+  // handler would actually deny.
+  session.defaultSession.setPermissionCheckHandler((webContents, permission, requestingOrigin) => {
+    const allowedPermissions = ['media', 'display-capture', 'fullscreen'];
+    const origin = requestingOrigin || webContents?.getURL() || '';
+    const allowed = allowedPermissions.includes(permission) && isAppOrigin(origin);
+
+    if (!allowed) {
+      console.log(`Denying permission check: ${permission} (origin: ${origin})`);
+    }
+
+    return allowed;
   });
 
   // Handle screen sharing requests from LiveKit

--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -623,6 +623,12 @@ function setupIpcHandlers() {
     }
   });
 
+  // Note: get/delete deliberately keep their original null/void contract
+  // (unlike `store` above, which now returns a typed SecureStorageStoreResult).
+  // Callers already treat a null/failed read or delete as "nothing to do"
+  // and don't need availability detail here — only `store` needed a typed
+  // result, since that's the operation that decides whether to fall back to
+  // localStorage and warn the user.
   ipcMain.handle('secure-storage:get', async (_event, key: string) => {
     try {
       if (!safeStorage.isEncryptionAvailable()) {

--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -14,6 +14,7 @@ import { autoUpdater, UpdateInfo, ProgressInfo } from 'electron-updater';
 import { initMain } from 'electron-audio-loopback';
 import * as path from 'path';
 import * as fs from 'fs';
+import { fileURLToPath } from 'url';
 import type { SecureStorageAvailability, SecureStorageStoreResult } from './secure-storage.types';
 
 // ─── App Settings (single JSON file in userData) ────────────────────────────
@@ -85,20 +86,54 @@ function isWayland(): boolean {
 }
 
 /**
- * Determine whether a URL (or origin) belongs to the app itself, as opposed
- * to a remote page loaded via window-open/will-navigate. Used to gate
+ * Resolve a filesystem path to its real path (following symlinks), falling
+ * back to the normalized path when it can't be resolved (e.g. doesn't exist).
+ */
+function toRealPath(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+/**
+ * Whether a filesystem path lives inside the app's `dist` directory — the
+ * directory `createWindow()` loads `index.html` from via `loadFile()` in
+ * production. Compared on resolved real paths so symlinks, `..` segments and
+ * Windows drive-letter casing can't bypass the check (Node's win32
+ * `path.relative` compares case-insensitively).
+ */
+function isPathInsideAppDist(fsPath: string): boolean {
+  const distDir = toRealPath(path.join(app.getAppPath(), 'dist'));
+  const target = toRealPath(fsPath);
+  const rel = path.relative(distDir, target);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+/**
+ * Determine whether a URL belongs to the app itself, as opposed to a remote
+ * page loaded via window-open/will-navigate. Used to gate
  * media/display-capture/fullscreen permission grants so an unexpected
  * remote origin can never silently acquire camera/mic/screen access.
  *
  * Matches exactly how the app loads in each mode:
- * - Packaged production: `mainWindow.loadFile(...)` → `file://` origin.
+ * - Production: `mainWindow.loadFile(<appPath>/dist/index.html)` → a `file://`
+ *   URL whose path must resolve inside the app's `dist` directory. An
+ *   arbitrary `file:` URL (or a bare `file://` origin, which carries no
+ *   path) is NOT the app — callers must pass the full URL for file: loads.
  * - Development: `mainWindow.loadURL('http://localhost:5173/')`.
  */
 function isAppOrigin(urlOrOrigin: string): boolean {
   if (!urlOrOrigin) return false;
   try {
     const parsed = new URL(urlOrOrigin);
-    if (parsed.protocol === 'file:') return true;
+    if (parsed.protocol === 'file:') {
+      // fileURLToPath handles platform normalization (Windows drive letters,
+      // percent-decoding). It throws for a pathless origin like 'file://',
+      // which correctly fails closed below.
+      return isPathInsideAppDist(fileURLToPath(parsed));
+    }
     if (parsed.protocol === 'http:' && parsed.hostname === 'localhost' && parsed.port === '5173') {
       return true;
     }
@@ -822,11 +857,19 @@ app.whenReady().then(() => {
   // handler would actually deny.
   session.defaultSession.setPermissionCheckHandler((webContents, permission, requestingOrigin) => {
     const allowedPermissions = ['media', 'display-capture', 'fullscreen'];
-    const origin = requestingOrigin || webContents?.getURL() || '';
-    const allowed = allowedPermissions.includes(permission) && isAppOrigin(origin);
+    // A file: *origin* carries no path, but isAppOrigin's file: branch needs
+    // the path to verify the page actually lives in the app's dist directory.
+    // For file: loads, evaluate the webContents' full URL instead, so this
+    // handler applies exactly the same policy as the request handler above.
+    // If no webContents is available the bare file:// origin fails closed.
+    let requestingUrl = requestingOrigin || webContents?.getURL() || '';
+    if (requestingUrl.startsWith('file:') && webContents) {
+      requestingUrl = webContents.getURL() || requestingUrl;
+    }
+    const allowed = allowedPermissions.includes(permission) && isAppOrigin(requestingUrl);
 
     if (!allowed) {
-      console.log(`Denying permission check: ${permission} (origin: ${origin})`);
+      console.log(`Denying permission check: ${permission} (origin: ${requestingOrigin || requestingUrl})`);
     }
 
     return allowed;

--- a/frontend/electron/preload.ts
+++ b/frontend/electron/preload.ts
@@ -8,6 +8,7 @@
  */
 
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
+import type { SecureStorageAvailability, SecureStorageStoreResult } from './secure-storage.types';
 
 /**
  * Update information passed from main process
@@ -191,7 +192,7 @@ const electronAPI = {
   },
 
   // Secure token storage (OS keychain via safeStorage)
-  storeRefreshToken: (token: string): Promise<true | null> => {
+  storeRefreshToken: (token: string): Promise<SecureStorageStoreResult> => {
     return ipcRenderer.invoke('secure-storage:store', 'refreshToken', token);
   },
 
@@ -201,6 +202,12 @@ const electronAPI = {
 
   deleteRefreshToken: (): Promise<void> => {
     return ipcRenderer.invoke('secure-storage:delete', 'refreshToken');
+  },
+
+  // Lets the renderer proactively check whether the OS keychain is available
+  // (e.g. to surface a one-time warning) without performing a store/read.
+  getSecureStorageAvailability: (): Promise<SecureStorageAvailability> => {
+    return ipcRenderer.invoke('secure-storage:availability');
   },
 
   // Power save blocker for voice calls

--- a/frontend/electron/secure-storage.types.ts
+++ b/frontend/electron/secure-storage.types.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared types for the secure-storage IPC surface (main <-> preload).
+ *
+ * Kept in a standalone module (rather than only in main.ts) so preload.ts —
+ * which is compiled independently via a raw `tsc` invocation, not a
+ * tsconfig project — can import the same types without pulling in main.ts.
+ */
+
+/**
+ * Whether the OS keychain (via Electron's `safeStorage`) is available for
+ * encrypting values on this system. `'unavailable'` typically means no
+ * OS-level credential store is present (e.g. a Linux desktop without a
+ * keyring daemon), so secrets can't be encrypted at rest.
+ */
+export type SecureStorageAvailability = 'available' | 'unavailable';
+
+/**
+ * Result of a `secure-storage:store` IPC call. Replaces the previous
+ * `true | null` contract, which conflated "encryption unavailable" with
+ * "write failed" and gave the renderer no way to tell the two apart.
+ */
+export interface SecureStorageStoreResult {
+  /** Whether the value was successfully encrypted and written to disk. */
+  stored: boolean;
+  /** Encryption availability at the time of this call. */
+  availability: SecureStorageAvailability;
+}

--- a/frontend/src/__tests__/components/SecureStorageWarning.test.tsx
+++ b/frontend/src/__tests__/components/SecureStorageWarning.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import { SecureStorageWarning } from '../../components/Electron/SecureStorageWarning';
+
+const WARNING_TEXT =
+  'Secure credential storage is unavailable on this system; your session token will be stored unencrypted.';
+const SHOWN_KEY = 'semaphore:secureStorageWarningShown';
+const PENDING_KEY = 'semaphore:secureStorageWarningPending';
+
+describe('SecureStorageWarning', () => {
+  let originalElectronAPI: typeof window.electronAPI;
+
+  beforeEach(() => {
+    originalElectronAPI = window.electronAPI;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.electronAPI = originalElectronAPI;
+    localStorage.clear();
+  });
+
+  it('does nothing outside Electron (electronAPI.isElectron falsy)', async () => {
+    window.electronAPI = undefined;
+    localStorage.setItem(PENDING_KEY, 'true');
+
+    renderWithProviders(<SecureStorageWarning />);
+
+    // Give effects a tick to run, then assert no notification appeared and
+    // the pending marker is untouched (never consumed outside Electron).
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByText(WARNING_TEXT)).not.toBeInTheDocument();
+    expect(localStorage.getItem(PENDING_KEY)).toBe('true');
+  });
+
+  it('shows the warning on mount when a pending marker is present and not dismissed', async () => {
+    window.electronAPI = { isElectron: true };
+    localStorage.setItem(PENDING_KEY, 'true');
+
+    renderWithProviders(<SecureStorageWarning />);
+
+    await waitFor(() => {
+      expect(screen.getByText(WARNING_TEXT)).toBeInTheDocument();
+    });
+
+    // Consuming pending marks the warning as permanently shown and clears
+    // the pending marker.
+    expect(localStorage.getItem(SHOWN_KEY)).toBe('true');
+    expect(localStorage.getItem(PENDING_KEY)).toBeNull();
+  });
+
+  it('shows nothing on mount when no pending marker exists', async () => {
+    window.electronAPI = { isElectron: true };
+
+    renderWithProviders(<SecureStorageWarning />);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByText(WARNING_TEXT)).not.toBeInTheDocument();
+    expect(localStorage.getItem(SHOWN_KEY)).toBeNull();
+  });
+
+  it('shows nothing on mount when already dismissed/shown, even if pending is set', async () => {
+    window.electronAPI = { isElectron: true };
+    localStorage.setItem(SHOWN_KEY, 'true');
+    localStorage.setItem(PENDING_KEY, 'true');
+
+    renderWithProviders(<SecureStorageWarning />);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByText(WARNING_TEXT)).not.toBeInTheDocument();
+    // Defensively cleared since it's irrelevant once dismissed.
+    expect(localStorage.getItem(PENDING_KEY)).toBeNull();
+  });
+
+  it('pending marker survives across a simulated reload (new mount, same localStorage)', async () => {
+    // Simulate the pending marker being set by a pre-mount trigger (e.g.
+    // AuthGate's cold-launch silent refresh) on a prior "page load".
+    localStorage.setItem(PENDING_KEY, 'true');
+    window.electronAPI = { isElectron: true };
+
+    const first = renderWithProviders(<SecureStorageWarning />);
+    await waitFor(() => {
+      expect(screen.getByText(WARNING_TEXT)).toBeInTheDocument();
+    });
+    first.unmount();
+
+    // "Reload": fresh mount, localStorage persists (SHOWN_KEY now set) —
+    // should NOT show again.
+    const second = renderWithProviders(<SecureStorageWarning />);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(second.queryByText(WARNING_TEXT)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/utils/tokenService.electron.test.ts
+++ b/frontend/src/__tests__/utils/tokenService.electron.test.ts
@@ -121,6 +121,16 @@ describe('tokenService — Electron secure storage', () => {
       expect(localStorage.getItem('refreshToken')).toBe('fallback-token');
     });
 
+    it('should fall back to localStorage when the write fails despite encryption being available', async () => {
+      window.electronAPI = {
+        storeRefreshToken: vi.fn().mockResolvedValue({ stored: false, availability: 'available' }),
+      };
+
+      await storeElectronRefreshToken('fallback-token');
+
+      expect(localStorage.getItem('refreshToken')).toBe('fallback-token');
+    });
+
     it('should fall back to localStorage when storeRefreshToken rejects', async () => {
       window.electronAPI = {
         storeRefreshToken: vi.fn().mockRejectedValue(new Error('IPC error')),
@@ -202,6 +212,58 @@ describe('tokenService — Electron secure storage', () => {
       } finally {
         unsubscribe();
       }
+    });
+
+    it('notifies the listener and logs a distinct write-failure message when the write fails despite available encryption', async () => {
+      window.electronAPI = {
+        storeRefreshToken: vi.fn().mockResolvedValue({ stored: false, availability: 'available' }),
+      };
+
+      const warningListener = vi.fn();
+      const unsubscribe = onSecureStorageWarning(warningListener);
+
+      try {
+        await storeElectronRefreshToken('token-1');
+        await storeElectronRefreshToken('token-2');
+
+        // Same one-time user-visible warning mechanism as the unavailable path...
+        expect(warningListener).toHaveBeenCalledTimes(1);
+        expect(localStorage.getItem(WARNING_KEY)).toBe('true');
+        expect(localStorage.getItem(PENDING_KEY)).toBeNull();
+        // ...but the log line must distinguish write-failure from unavailability.
+        expect(logger.warn).toHaveBeenCalledTimes(2);
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('write failed'));
+        expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('unavailable on this'));
+      } finally {
+        unsubscribe();
+      }
+    });
+
+    it('logs different messages for write-failure vs unavailable-encryption fallbacks', async () => {
+      const store = vi.fn()
+        .mockResolvedValueOnce({ stored: false, availability: 'unavailable' })
+        .mockResolvedValueOnce({ stored: false, availability: 'available' });
+      window.electronAPI = { storeRefreshToken: store };
+
+      await storeElectronRefreshToken('token-1');
+      await storeElectronRefreshToken('token-2');
+
+      const messages = vi.mocked(logger.warn).mock.calls.map((call) => String(call[0]));
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toContain('unavailable on this');
+      expect(messages[1]).toContain('write failed');
+      expect(messages[0]).not.toBe(messages[1]);
+    });
+
+    it('sets the durable pending marker for a write-failure with no listener registered', async () => {
+      window.electronAPI = {
+        storeRefreshToken: vi.fn().mockResolvedValue({ stored: false, availability: 'available' }),
+      };
+
+      await storeElectronRefreshToken('token-1');
+
+      expect(localStorage.getItem(WARNING_KEY)).toBeNull();
+      expect(localStorage.getItem(PENDING_KEY)).toBe('true');
     });
 
     it('does not notify listeners when secure storage is available', async () => {

--- a/frontend/src/__tests__/utils/tokenService.electron.test.ts
+++ b/frontend/src/__tests__/utils/tokenService.electron.test.ts
@@ -11,6 +11,7 @@ import {
   setAccessToken,
   getAccessToken,
   onSecureStorageWarning,
+  consumePendingSecureStorageWarning,
 } from '../../utils/tokenService';
 import { logger } from '../../utils/logger';
 
@@ -180,8 +181,9 @@ describe('tokenService — Electron secure storage', () => {
 
   describe('secure storage unavailable warning', () => {
     const WARNING_KEY = 'semaphore:secureStorageWarningShown';
+    const PENDING_KEY = 'semaphore:secureStorageWarningPending';
 
-    it('logs on every unavailable store, but notifies a registered listener only once', async () => {
+    it('logs on every unavailable store, but notifies a registered listener only once (live path)', async () => {
       window.electronAPI = {
         storeRefreshToken: vi.fn().mockResolvedValue({ stored: false, availability: 'unavailable' }),
       };
@@ -196,6 +198,7 @@ describe('tokenService — Electron secure storage', () => {
         expect(warningListener).toHaveBeenCalledTimes(1);
         expect(logger.warn).toHaveBeenCalledTimes(2);
         expect(localStorage.getItem(WARNING_KEY)).toBe('true');
+        expect(localStorage.getItem(PENDING_KEY)).toBeNull();
       } finally {
         unsubscribe();
       }
@@ -215,21 +218,35 @@ describe('tokenService — Electron secure storage', () => {
         expect(warningListener).not.toHaveBeenCalled();
         expect(logger.warn).not.toHaveBeenCalled();
         expect(localStorage.getItem(WARNING_KEY)).toBeNull();
+        expect(localStorage.getItem(PENDING_KEY)).toBeNull();
       } finally {
         unsubscribe();
       }
     });
 
-    it('defers marking the warning as shown until a listener is registered', async () => {
+    it('sets a durable pending marker (not the shown flag) when no listener is registered', async () => {
       window.electronAPI = {
         storeRefreshToken: vi.fn().mockResolvedValue({ stored: false, availability: 'unavailable' }),
       };
 
-      // No listener registered yet (e.g. warning fires before the
-      // authenticated app shell has mounted) — must not mark as shown, so a
-      // later listener can still catch it.
+      // No listener registered yet — this is the common real-world case:
+      // AuthGate's pre-mount silent refresh on cold launch, or
+      // login/register/onboarding, all persist a token before
+      // NotificationProvider/SecureStorageWarning mount.
       await storeElectronRefreshToken('token-1');
+
       expect(localStorage.getItem(WARNING_KEY)).toBeNull();
+      expect(localStorage.getItem(PENDING_KEY)).toBe('true');
+    });
+
+    it('live listener registered later still delivers and consumes any pending marker', async () => {
+      window.electronAPI = {
+        storeRefreshToken: vi.fn().mockResolvedValue({ stored: false, availability: 'unavailable' }),
+      };
+
+      // First call, no listener: sets pending.
+      await storeElectronRefreshToken('token-1');
+      expect(localStorage.getItem(PENDING_KEY)).toBe('true');
 
       const warningListener = vi.fn();
       const unsubscribe = onSecureStorageWarning(warningListener);
@@ -239,6 +256,7 @@ describe('tokenService — Electron secure storage', () => {
 
         expect(warningListener).toHaveBeenCalledTimes(1);
         expect(localStorage.getItem(WARNING_KEY)).toBe('true');
+        expect(localStorage.getItem(PENDING_KEY)).toBeNull();
       } finally {
         unsubscribe();
       }
@@ -256,6 +274,45 @@ describe('tokenService — Electron secure storage', () => {
       await storeElectronRefreshToken('token');
 
       expect(warningListener).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── consumePendingSecureStorageWarning (mount-time consumption) ─────
+
+  describe('consumePendingSecureStorageWarning', () => {
+    const WARNING_KEY = 'semaphore:secureStorageWarningShown';
+    const PENDING_KEY = 'semaphore:secureStorageWarningPending';
+
+    it('returns true and marks shown when pending is set and not dismissed', () => {
+      localStorage.setItem(PENDING_KEY, 'true');
+
+      expect(consumePendingSecureStorageWarning()).toBe(true);
+      expect(localStorage.getItem(WARNING_KEY)).toBe('true');
+      expect(localStorage.getItem(PENDING_KEY)).toBeNull();
+    });
+
+    it('returns false when no pending marker exists', () => {
+      expect(consumePendingSecureStorageWarning()).toBe(false);
+      expect(localStorage.getItem(WARNING_KEY)).toBeNull();
+    });
+
+    it('returns false and clears pending when already shown/dismissed', () => {
+      localStorage.setItem(WARNING_KEY, 'true');
+      localStorage.setItem(PENDING_KEY, 'true');
+
+      expect(consumePendingSecureStorageWarning()).toBe(false);
+      expect(localStorage.getItem(PENDING_KEY)).toBeNull();
+    });
+
+    it('pending marker set before "mount" is consumed exactly once by a later mount-time check', () => {
+      // Simulates the real sequence: trigger fires pre-mount (no listener),
+      // then the component mounts and calls consumePendingSecureStorageWarning.
+      localStorage.setItem(PENDING_KEY, 'true');
+
+      expect(consumePendingSecureStorageWarning()).toBe(true);
+      // A subsequent "remount" (e.g. navigating away and back) must not
+      // show it again.
+      expect(consumePendingSecureStorageWarning()).toBe(false);
     });
   });
 });

--- a/frontend/src/__tests__/utils/tokenService.electron.test.ts
+++ b/frontend/src/__tests__/utils/tokenService.electron.test.ts
@@ -10,7 +10,9 @@ import {
   clearTokens,
   setAccessToken,
   getAccessToken,
+  onSecureStorageWarning,
 } from '../../utils/tokenService';
+import { logger } from '../../utils/logger';
 
 describe('tokenService — Electron secure storage', () => {
   let originalElectronAPI: typeof window.electronAPI;
@@ -87,7 +89,7 @@ describe('tokenService — Electron secure storage', () => {
 
   describe('storeElectronRefreshToken', () => {
     it('should store in secure storage when available', async () => {
-      const mockStore = vi.fn().mockResolvedValue(true);
+      const mockStore = vi.fn().mockResolvedValue({ stored: true, availability: 'available' });
       window.electronAPI = {
         storeRefreshToken: mockStore,
       };
@@ -100,7 +102,7 @@ describe('tokenService — Electron secure storage', () => {
     it('should remove localStorage entry after storing in secure storage', async () => {
       localStorage.setItem('refreshToken', 'legacy-token');
       window.electronAPI = {
-        storeRefreshToken: vi.fn().mockResolvedValue(true),
+        storeRefreshToken: vi.fn().mockResolvedValue({ stored: true, availability: 'available' }),
       };
 
       await storeElectronRefreshToken('new-token');
@@ -108,9 +110,9 @@ describe('tokenService — Electron secure storage', () => {
       expect(localStorage.getItem('refreshToken')).toBeNull();
     });
 
-    it('should fall back to localStorage when safeStorage is unavailable (returns null)', async () => {
+    it('should fall back to localStorage when safeStorage is unavailable', async () => {
       window.electronAPI = {
-        storeRefreshToken: vi.fn().mockResolvedValue(null),
+        storeRefreshToken: vi.fn().mockResolvedValue({ stored: false, availability: 'unavailable' }),
       };
 
       await storeElectronRefreshToken('fallback-token');
@@ -171,6 +173,89 @@ describe('tokenService — Electron secure storage', () => {
       clearTokens();
 
       expect(localStorage.getItem('refreshToken')).toBeNull();
+    });
+  });
+
+  // ─── Secure storage warning (one-time) ────────────────────────
+
+  describe('secure storage unavailable warning', () => {
+    const WARNING_KEY = 'semaphore:secureStorageWarningShown';
+
+    it('logs on every unavailable store, but notifies a registered listener only once', async () => {
+      window.electronAPI = {
+        storeRefreshToken: vi.fn().mockResolvedValue({ stored: false, availability: 'unavailable' }),
+      };
+
+      const warningListener = vi.fn();
+      const unsubscribe = onSecureStorageWarning(warningListener);
+
+      try {
+        await storeElectronRefreshToken('token-1');
+        await storeElectronRefreshToken('token-2');
+
+        expect(warningListener).toHaveBeenCalledTimes(1);
+        expect(logger.warn).toHaveBeenCalledTimes(2);
+        expect(localStorage.getItem(WARNING_KEY)).toBe('true');
+      } finally {
+        unsubscribe();
+      }
+    });
+
+    it('does not notify listeners when secure storage is available', async () => {
+      window.electronAPI = {
+        storeRefreshToken: vi.fn().mockResolvedValue({ stored: true, availability: 'available' }),
+      };
+
+      const warningListener = vi.fn();
+      const unsubscribe = onSecureStorageWarning(warningListener);
+
+      try {
+        await storeElectronRefreshToken('token');
+
+        expect(warningListener).not.toHaveBeenCalled();
+        expect(logger.warn).not.toHaveBeenCalled();
+        expect(localStorage.getItem(WARNING_KEY)).toBeNull();
+      } finally {
+        unsubscribe();
+      }
+    });
+
+    it('defers marking the warning as shown until a listener is registered', async () => {
+      window.electronAPI = {
+        storeRefreshToken: vi.fn().mockResolvedValue({ stored: false, availability: 'unavailable' }),
+      };
+
+      // No listener registered yet (e.g. warning fires before the
+      // authenticated app shell has mounted) — must not mark as shown, so a
+      // later listener can still catch it.
+      await storeElectronRefreshToken('token-1');
+      expect(localStorage.getItem(WARNING_KEY)).toBeNull();
+
+      const warningListener = vi.fn();
+      const unsubscribe = onSecureStorageWarning(warningListener);
+
+      try {
+        await storeElectronRefreshToken('token-2');
+
+        expect(warningListener).toHaveBeenCalledTimes(1);
+        expect(localStorage.getItem(WARNING_KEY)).toBe('true');
+      } finally {
+        unsubscribe();
+      }
+    });
+
+    it('unsubscribe stops further notifications', async () => {
+      window.electronAPI = {
+        storeRefreshToken: vi.fn().mockResolvedValue({ stored: false, availability: 'unavailable' }),
+      };
+
+      const warningListener = vi.fn();
+      const unsubscribe = onSecureStorageWarning(warningListener);
+      unsubscribe();
+
+      await storeElectronRefreshToken('token');
+
+      expect(warningListener).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -14,6 +14,7 @@ import { userControllerGetProfile } from "../api-client/sdk.gen";
 import { SocketProvider } from "../utils/SocketProvider";
 import { AvatarCacheProvider } from "../contexts/AvatarCacheContext";
 import { NotificationProvider } from "../contexts/NotificationContext";
+import { SecureStorageWarning } from "./Electron/SecureStorageWarning";
 import { VoiceProvider } from "../contexts/VoiceContext";
 import { ConnectionStatusBanner } from "./ConnectionStatusBanner";
 import { RoomProvider } from "../contexts/RoomContext";
@@ -155,6 +156,7 @@ export function AuthGate() {
     <SocketProvider>
       <AvatarCacheProvider>
         <NotificationProvider>
+          <SecureStorageWarning />
           <VoiceProvider>
             <ConnectionStatusBanner />
             <RoomProvider>

--- a/frontend/src/components/Electron/SecureStorageWarning.tsx
+++ b/frontend/src/components/Electron/SecureStorageWarning.tsx
@@ -1,0 +1,34 @@
+/**
+ * Secure Storage Warning
+ *
+ * Subscribes to tokenService's one-time "secure storage unavailable"
+ * warning and surfaces it via the app's existing snackbar/notification
+ * mechanism (NotificationContext). Renders nothing itself.
+ *
+ * Mounted inside AuthGate's <NotificationProvider> so it's available
+ * whenever the user is in the authenticated app shell — where the refresh
+ * token gets (re-)persisted on login and on every periodic token refresh.
+ */
+
+import { useEffect } from 'react';
+import { useNotification } from '../../contexts/NotificationContext';
+import { onSecureStorageWarning } from '../../utils/tokenService';
+
+export const SecureStorageWarning = () => {
+  const { showNotification } = useNotification();
+
+  useEffect(() => {
+    if (!window.electronAPI?.isElectron) return;
+
+    return onSecureStorageWarning(() => {
+      showNotification(
+        'Secure credential storage is unavailable on this system; your session token will be stored unencrypted.',
+        'warning'
+      );
+    });
+  }, [showNotification]);
+
+  return null;
+};
+
+export default SecureStorageWarning;

--- a/frontend/src/components/Electron/SecureStorageWarning.tsx
+++ b/frontend/src/components/Electron/SecureStorageWarning.tsx
@@ -1,18 +1,33 @@
 /**
  * Secure Storage Warning
  *
- * Subscribes to tokenService's one-time "secure storage unavailable"
- * warning and surfaces it via the app's existing snackbar/notification
- * mechanism (NotificationContext). Renders nothing itself.
+ * Surfaces tokenService's one-time "secure storage unavailable" warning via
+ * the app's existing snackbar/notification mechanism (NotificationContext).
+ * Renders nothing itself.
+ *
+ * Delivery has two paths:
+ *  - Mount-time consumption: most real-world triggers (AuthGate's pre-mount
+ *    silent refresh on cold launch, login/register/onboarding) fire BEFORE
+ *    this component mounts, so on mount we check for a durable "pending"
+ *    marker left behind by an earlier trigger and show the warning
+ *    immediately if found — no further event required.
+ *  - Live delivery: if a persist happens while this component is already
+ *    mounted (e.g. a later periodic token refresh), the subscription below
+ *    delivers it immediately.
  *
  * Mounted inside AuthGate's <NotificationProvider> so it's available
- * whenever the user is in the authenticated app shell — where the refresh
- * token gets (re-)persisted on login and on every periodic token refresh.
+ * whenever the user is in the authenticated app shell.
  */
 
 import { useEffect } from 'react';
 import { useNotification } from '../../contexts/NotificationContext';
-import { onSecureStorageWarning } from '../../utils/tokenService';
+import {
+  consumePendingSecureStorageWarning,
+  onSecureStorageWarning,
+} from '../../utils/tokenService';
+
+const SECURE_STORAGE_WARNING_MESSAGE =
+  'Secure credential storage is unavailable on this system; your session token will be stored unencrypted.';
 
 export const SecureStorageWarning = () => {
   const { showNotification } = useNotification();
@@ -20,15 +35,15 @@ export const SecureStorageWarning = () => {
   useEffect(() => {
     if (!window.electronAPI?.isElectron) return;
 
+    // Consume any warning that became pending before this component mounted.
+    if (consumePendingSecureStorageWarning()) {
+      showNotification(SECURE_STORAGE_WARNING_MESSAGE, 'warning');
+    }
+
     return onSecureStorageWarning(() => {
-      showNotification(
-        'Secure credential storage is unavailable on this system; your session token will be stored unencrypted.',
-        'warning'
-      );
+      showNotification(SECURE_STORAGE_WARNING_MESSAGE, 'warning');
     });
   }, [showNotification]);
 
   return null;
 };
-
-export default SecureStorageWarning;

--- a/frontend/src/hooks/useNotificationPermission.ts
+++ b/frontend/src/hooks/useNotificationPermission.ts
@@ -83,6 +83,11 @@ export function useNotificationPermission() {
 
     // Note: The Permissions API for notifications is not widely supported
     // This is a best-effort attempt to track permission changes
+    // In Electron, this handler's `permissionStatus.state` may be
+    // inaccurate/stale (Chromium's Permissions API doesn't necessarily
+    // reflect Electron's own deny-by-default permission handler), but it's
+    // unused there in practice: getNotificationPermission() hardcodes
+    // 'granted' for Electron rather than reading this query's result.
     if ('permissions' in navigator && 'query' in navigator.permissions) {
       const handleChange = () => {
         const newPermission = getNotificationPermission();

--- a/frontend/src/types/electron-api.ts
+++ b/frontend/src/types/electron-api.ts
@@ -27,6 +27,20 @@ export interface ElectronNotificationOptions {
   silent?: boolean;
 }
 
+/**
+ * Whether the OS keychain (via Electron's `safeStorage`) is available for
+ * encrypting values on this system. Mirrors `electron/secure-storage.types.ts`
+ * — kept in sync manually since preload.ts and this file are compiled
+ * separately (see other duplicated types below, e.g. UpdateInfo).
+ */
+export type SecureStorageAvailability = 'available' | 'unavailable';
+
+/** Result of a `storeRefreshToken` call. Mirrors `electron/secure-storage.types.ts`. */
+export interface SecureStorageStoreResult {
+  stored: boolean;
+  availability: SecureStorageAvailability;
+}
+
 export interface ElectronAPI {
   platform?: string;
   isElectron?: boolean;
@@ -51,9 +65,10 @@ export interface ElectronAPI {
   ) => (() => void);
   getSettings?: () => Promise<Record<string, unknown>>;
   setSetting?: (key: string, value: unknown) => Promise<unknown>;
-  storeRefreshToken?: (token: string) => Promise<true | null>;
+  storeRefreshToken?: (token: string) => Promise<SecureStorageStoreResult>;
   getRefreshToken?: () => Promise<string | null>;
   deleteRefreshToken?: () => Promise<void>;
+  getSecureStorageAvailability?: () => Promise<SecureStorageAvailability>;
   requestPowerSaveBlock?: () => Promise<number>;
   releasePowerSaveBlock?: (id: number) => Promise<void>;
   [key: string]: unknown;

--- a/frontend/src/utils/tokenService.ts
+++ b/frontend/src/utils/tokenService.ts
@@ -24,6 +24,7 @@ let refreshPromise: Promise<string | null> | null = null;
 // ─── Secure Storage Availability Warning (Electron) ─────────────────────────
 //
 // When the OS keychain isn't available (e.g. no keyring daemon on Linux),
+// or the encrypted write itself fails despite the keychain being available,
 // storeElectronRefreshToken() falls back to persisting the refresh token in
 // plain localStorage instead of encrypted OS-backed storage. That's an
 // invisible security downgrade unless we surface it. We log every occurrence
@@ -94,10 +95,12 @@ export function consumePendingSecureStorageWarning(): boolean {
 }
 
 /**
- * Called whenever a token persist falls back to localStorage because the OS
- * keychain is unavailable. Always logs (so it's visible in devtools/support
- * bundles on every affected launch). If the warning has already been shown
- * (or dismissed), this is a no-op beyond logging. Otherwise:
+ * Called whenever a token persist falls back to localStorage instead of
+ * encrypted OS-backed storage. Always logs the supplied message (so it's
+ * visible in devtools/support bundles on every affected launch — the message
+ * distinguishes *why* the downgrade happened: keychain unavailable vs. a
+ * failed write despite available encryption). If the warning has already
+ * been shown (or dismissed), this is a no-op beyond logging. Otherwise:
  *  - if a listener is currently subscribed (live path), notify it
  *    immediately and mark the warning as permanently shown;
  *  - if not, persist a durable "pending" marker so `SecureStorageWarning`
@@ -105,11 +108,8 @@ export function consumePendingSecureStorageWarning(): boolean {
  *    this is the only trigger event that ever fires (see
  *    `consumePendingSecureStorageWarning`).
  */
-function triggerSecureStorageWarning(): void {
-  logger.warn(
-    "[TokenService] Secure credential storage (OS keychain) is unavailable on this " +
-    "system; your session token will be stored unencrypted in localStorage."
-  );
+function triggerSecureStorageWarning(logMessage: string): void {
+  logger.warn(logMessage);
 
   if (localStorage.getItem(SECURE_STORAGE_WARNING_KEY) === "true") {
     return;
@@ -279,10 +279,23 @@ export async function storeElectronRefreshToken(token: string): Promise<void> {
         return;
       }
       if (result?.availability === "unavailable") {
-        triggerSecureStorageWarning();
+        triggerSecureStorageWarning(
+          "[TokenService] Secure credential storage (OS keychain) is unavailable on this " +
+          "system; your session token will be stored unencrypted in localStorage."
+        );
+      } else {
+        // Encryption is AVAILABLE but the write itself failed (e.g. disk/IPC
+        // error). This is still a silent security downgrade — log a distinct
+        // message so support can tell it apart from keychain unavailability,
+        // and surface the same one-time user-visible warning.
+        triggerSecureStorageWarning(
+          "[TokenService] Secure credential storage write failed even though OS keychain " +
+          "encryption is available; your session token will be stored unencrypted in " +
+          "localStorage."
+        );
       }
-      // Encryption unavailable, or the write otherwise failed — fall through
-      // to localStorage below.
+      // Either way the encrypted write didn't happen — fall through to
+      // localStorage below.
     }
   } catch {
     logger.debug("[TokenService] Secure storage write failed, falling back to localStorage");

--- a/frontend/src/utils/tokenService.ts
+++ b/frontend/src/utils/tokenService.ts
@@ -21,6 +21,64 @@ const authFailureListeners: Set<AuthFailureListener> = new Set();
 // Mutex for preventing concurrent refresh attempts
 let refreshPromise: Promise<string | null> | null = null;
 
+// ─── Secure Storage Availability Warning (Electron) ─────────────────────────
+//
+// When the OS keychain isn't available (e.g. no keyring daemon on Linux),
+// storeElectronRefreshToken() falls back to persisting the refresh token in
+// plain localStorage instead of encrypted OS-backed storage. That's an
+// invisible security downgrade unless we surface it. We log every occurrence
+// (for diagnostics/support), but only ever show the user-visible UI warning
+// once — see `onSecureStorageWarning` below, subscribed to by
+// `SecureStorageWarning` (components/Electron/SecureStorageWarning.tsx).
+
+const SECURE_STORAGE_WARNING_KEY = "semaphore:secureStorageWarningShown";
+
+type SecureStorageWarningListener = () => void;
+const secureStorageWarningListeners: Set<SecureStorageWarningListener> = new Set();
+
+/**
+ * Subscribe to the one-time "secure storage unavailable" warning.
+ * @returns Unsubscribe function
+ */
+export function onSecureStorageWarning(listener: SecureStorageWarningListener): () => void {
+  secureStorageWarningListeners.add(listener);
+  return () => secureStorageWarningListeners.delete(listener);
+}
+
+/**
+ * Called whenever a token persist falls back to localStorage because the OS
+ * keychain is unavailable. Always logs (so it's visible in devtools/support
+ * bundles on every affected launch), but only notifies UI listeners — and
+ * marks the warning as permanently shown — once. If no listener is
+ * registered yet (e.g. this fires before the authenticated app shell with
+ * the notification provider has mounted, such as during initial login), the
+ * "shown" flag is intentionally left unset so the next occurrence can still
+ * reach the user.
+ */
+function triggerSecureStorageWarning(): void {
+  logger.warn(
+    "[TokenService] Secure credential storage (OS keychain) is unavailable on this " +
+    "system; your session token will be stored unencrypted in localStorage."
+  );
+
+  if (localStorage.getItem(SECURE_STORAGE_WARNING_KEY) === "true") {
+    return;
+  }
+
+  if (secureStorageWarningListeners.size === 0) {
+    return;
+  }
+
+  localStorage.setItem(SECURE_STORAGE_WARNING_KEY, "true");
+  secureStorageWarningListeners.forEach((listener) => {
+    try {
+      listener();
+    } catch (error) {
+      logger.error("[TokenService] Error in secure storage warning listener:", error);
+    }
+  });
+}
+
 // In-memory access token storage.
 // Stored in a module-scoped variable instead of localStorage to prevent
 // XSS-based token theft. On page refresh, the token is recovered via
@@ -160,12 +218,16 @@ export async function storeElectronRefreshToken(token: string): Promise<void> {
   try {
     if (window.electronAPI?.storeRefreshToken) {
       const result = await window.electronAPI.storeRefreshToken(token);
-      if (result !== null) {
+      if (result?.stored) {
         // Clean up legacy localStorage entry after successful migration
         localStorage.removeItem("refreshToken");
         return;
       }
-      // safeStorage unavailable — fall through to localStorage
+      if (result?.availability === "unavailable") {
+        triggerSecureStorageWarning();
+      }
+      // Encryption unavailable, or the write otherwise failed — fall through
+      // to localStorage below.
     }
   } catch {
     logger.debug("[TokenService] Secure storage write failed, falling back to localStorage");

--- a/frontend/src/utils/tokenService.ts
+++ b/frontend/src/utils/tokenService.ts
@@ -30,14 +30,35 @@ let refreshPromise: Promise<string | null> | null = null;
 // (for diagnostics/support), but only ever show the user-visible UI warning
 // once — see `onSecureStorageWarning` below, subscribed to by
 // `SecureStorageWarning` (components/Electron/SecureStorageWarning.tsx).
+//
+// Delivery has two paths, because the very first (and often only, in dev)
+// unavailable-store event usually happens during AuthGate's pre-mount silent
+// refresh on cold launch (AuthGate.tsx validateToken()) — before
+// NotificationProvider/SecureStorageWarning exist anywhere in the tree. The
+// same is true of LoginPage/RegisterPage/JoinInvitePage/onboarding's
+// CompletionStep, which all persist a token before the authenticated shell
+// mounts. Waiting for a live listener to eventually show up is not reliable:
+// on a cold launch the *next* trigger is typically next launch's pre-mount
+// refresh again, so the live-only approach could mean the user never sees
+// the warning even though it fires every launch.
+//
+// So: `SECURE_STORAGE_WARNING_KEY` is the "shown" flag — once set, the
+// warning never shows again, full stop. `SECURE_STORAGE_WARNING_PENDING_KEY`
+// is a separate, durable "pending" marker: set whenever an unavailable
+// persist happens with no live listener subscribed. `SecureStorageWarning`
+// consumes it at mount time (see `consumePendingSecureStorageWarning`),
+// which closes the gap — the warning is guaranteed to surface the next time
+// the authenticated shell mounts, with no further trigger event required.
 
 const SECURE_STORAGE_WARNING_KEY = "semaphore:secureStorageWarningShown";
+const SECURE_STORAGE_WARNING_PENDING_KEY = "semaphore:secureStorageWarningPending";
 
 type SecureStorageWarningListener = () => void;
 const secureStorageWarningListeners: Set<SecureStorageWarningListener> = new Set();
 
 /**
- * Subscribe to the one-time "secure storage unavailable" warning.
+ * Subscribe to the one-time "secure storage unavailable" warning's live
+ * delivery path (used when a listener is already mounted at trigger time).
  * @returns Unsubscribe function
  */
 export function onSecureStorageWarning(listener: SecureStorageWarningListener): () => void {
@@ -46,14 +67,43 @@ export function onSecureStorageWarning(listener: SecureStorageWarningListener): 
 }
 
 /**
+ * Consume a pending "secure storage unavailable" warning at mount time.
+ *
+ * Called by `SecureStorageWarning` on mount. Returns true (and marks the
+ * warning permanently shown) exactly once — the first time a pending
+ * warning is found and the warning hasn't already been shown/dismissed.
+ * This is what makes delivery work even when no event fires after mount:
+ * the pending flag was already persisted in localStorage by an earlier,
+ * pre-mount `triggerSecureStorageWarning()` call.
+ */
+export function consumePendingSecureStorageWarning(): boolean {
+  if (localStorage.getItem(SECURE_STORAGE_WARNING_KEY) === "true") {
+    // Already shown/dismissed — pending is irrelevant now; clear it
+    // defensively so it doesn't linger.
+    localStorage.removeItem(SECURE_STORAGE_WARNING_PENDING_KEY);
+    return false;
+  }
+
+  if (localStorage.getItem(SECURE_STORAGE_WARNING_PENDING_KEY) !== "true") {
+    return false;
+  }
+
+  localStorage.setItem(SECURE_STORAGE_WARNING_KEY, "true");
+  localStorage.removeItem(SECURE_STORAGE_WARNING_PENDING_KEY);
+  return true;
+}
+
+/**
  * Called whenever a token persist falls back to localStorage because the OS
  * keychain is unavailable. Always logs (so it's visible in devtools/support
- * bundles on every affected launch), but only notifies UI listeners — and
- * marks the warning as permanently shown — once. If no listener is
- * registered yet (e.g. this fires before the authenticated app shell with
- * the notification provider has mounted, such as during initial login), the
- * "shown" flag is intentionally left unset so the next occurrence can still
- * reach the user.
+ * bundles on every affected launch). If the warning has already been shown
+ * (or dismissed), this is a no-op beyond logging. Otherwise:
+ *  - if a listener is currently subscribed (live path), notify it
+ *    immediately and mark the warning as permanently shown;
+ *  - if not, persist a durable "pending" marker so `SecureStorageWarning`
+ *    can consume it and show the warning as soon as it next mounts, even if
+ *    this is the only trigger event that ever fires (see
+ *    `consumePendingSecureStorageWarning`).
  */
 function triggerSecureStorageWarning(): void {
   logger.warn(
@@ -66,10 +116,15 @@ function triggerSecureStorageWarning(): void {
   }
 
   if (secureStorageWarningListeners.size === 0) {
+    // No live listener mounted right now — persist a durable marker so a
+    // later mount (e.g. SecureStorageWarning once the authenticated shell
+    // renders) can still deliver the warning without needing another event.
+    localStorage.setItem(SECURE_STORAGE_WARNING_PENDING_KEY, "true");
     return;
   }
 
   localStorage.setItem(SECURE_STORAGE_WARNING_KEY, "true");
+  localStorage.removeItem(SECURE_STORAGE_WARNING_PENDING_KEY);
   secureStorageWarningListeners.forEach((listener) => {
     try {
       listener();


### PR DESCRIPTION
## Summary
- `sandbox: true` set explicitly on the renderer (preload verified sandbox-compatible: contextBridge/ipcRenderer only).
- Permission request AND check handlers now grant media/display-capture/fullscreen only to the app's own origin (exact URL-parsed matching — file:// packaged, localhost:5173 dev); everything else is denied and logged.
- safeStorage transparency: new availability IPC + typed store results replace the silent bare-null fallback. When OS keychain encryption is unavailable, the renderer shows a one-time warning that the session token is stored unencrypted (durable pending flag consumed at mount, so pre-mount triggers — login, cold-launch silent refresh — still surface; dismissal is remembered).

## Test plan
- 55 targeted tests (tokenService electron paths, SecureStorageWarning mount/consume/dismiss semantics, AuthGate); full suite 163 files / 1713 tests, type-check, lint, electron+preload compile green.
- Manual follow-up recommended: one smoke run on a Linux box without a keyring daemon (no X display available in the dev environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sAJfCfBfMm8chbZMsh5Y5