### PR TITLE
perf(rbac): Redis permission cache with epoch-based invalidation

### DIFF
--- a/backend/src/community/community.service.spec.ts
+++ b/backend/src/community/community.service.spec.ts
@@ -90,13 +90,104 @@ describe('CommunityService', () => {
       expect(rolesService.createDefaultCommunityRoles).toHaveBeenCalledWith(
         community.id,
         mockDatabase,
+        expect.any(Array),
       );
       expect(rolesService.assignUserToCommunityRole).toHaveBeenCalledWith(
         user.id,
         community.id,
         'admin-role-id',
         mockDatabase,
+        expect.any(Array),
       );
+    });
+
+    it('flushes deferred epoch bumps only after the transaction commits', async () => {
+      const user = UserFactory.build();
+      const community = CommunityFactory.build();
+      const createDto = {
+        name: 'Test Community',
+        description: null,
+        avatar: null,
+        banner: null,
+      } as any;
+
+      const order: string[] = [];
+
+      mockDatabase.community.create.mockResolvedValue(community);
+      mockDatabase.membership.create.mockResolvedValue({});
+      channelsService.createDefaultGeneralChannel.mockResolvedValue({} as any);
+
+      // The (mocked) tx-nested role mutations record their bumps on the
+      // collector the service passes in, exactly like the real ones do.
+      rolesService.createDefaultCommunityRoles.mockImplementation(((
+        _id: string,
+        _tx: unknown,
+        bumps: any[],
+      ) => {
+        bumps.push({ kind: 'community', communityId: community.id });
+        return Promise.resolve('admin-role-id');
+      }) as any);
+      rolesService.assignUserToCommunityRole.mockImplementation(((
+        userId: string,
+        _communityId: string,
+        _roleId: string,
+        _tx: unknown,
+        bumps: any[],
+      ) => {
+        bumps.push({ kind: 'user', userId });
+        return Promise.resolve();
+      }) as any);
+
+      mockDatabase.$transaction.mockImplementation(async (cb: any) => {
+        const result = await cb(mockDatabase);
+        order.push('commit');
+        return result;
+      });
+      permissionsCacheService.executeBumps.mockImplementation(() => {
+        order.push('flush-bumps');
+        return Promise.resolve();
+      });
+
+      const result = await service.create(createDto, user.id);
+
+      expect(result).toEqual(community);
+      // Bumps must flush strictly AFTER the transaction resolves (commit).
+      expect(order).toEqual(['commit', 'flush-bumps']);
+      expect(permissionsCacheService.executeBumps).toHaveBeenCalledWith([
+        { kind: 'community', communityId: community.id },
+        { kind: 'user', userId: user.id },
+      ]);
+      // No direct bumps during the transaction.
+      expect(permissionsCacheService.bumpCommunityEpoch).not.toHaveBeenCalled();
+      expect(permissionsCacheService.bumpUserEpoch).not.toHaveBeenCalled();
+    });
+
+    it('does not flush epoch bumps when the transaction rolls back', async () => {
+      const user = UserFactory.build();
+      const community = CommunityFactory.build();
+      const createDto = {
+        name: 'Test Community',
+        description: null,
+        avatar: null,
+        banner: null,
+      } as any;
+
+      mockDatabase.community.create.mockResolvedValue(community);
+      mockDatabase.membership.create.mockResolvedValue({});
+      channelsService.createDefaultGeneralChannel.mockResolvedValue({} as any);
+      rolesService.createDefaultCommunityRoles.mockResolvedValue(
+        'admin-role-id' as any,
+      );
+      // Fails after the role mutations would have collected bumps.
+      rolesService.assignUserToCommunityRole.mockRejectedValue(
+        new Error('assignment failed'),
+      );
+
+      await expect(service.create(createDto, user.id)).rejects.toThrow(
+        'assignment failed',
+      );
+
+      expect(permissionsCacheService.executeBumps).not.toHaveBeenCalled();
     });
 
     it('should throw ConflictException for duplicate community name', async () => {

--- a/backend/src/community/community.service.spec.ts
+++ b/backend/src/community/community.service.spec.ts
@@ -4,6 +4,7 @@ import { CommunityService } from './community.service';
 import { DatabaseService } from '@/database/database.service';
 import { ChannelsService } from '@/channels/channels.service';
 import { RolesService } from '@/roles/roles.service';
+import { PermissionsCacheService } from '@/roles/permissions-cache.service';
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import {
   createMockDatabase,
@@ -16,6 +17,7 @@ describe('CommunityService', () => {
   let mockDatabase: ReturnType<typeof createMockDatabase>;
   let channelsService: Mocked<ChannelsService>;
   let rolesService: Mocked<RolesService>;
+  let permissionsCacheService: Mocked<PermissionsCacheService>;
 
   beforeEach(async () => {
     mockDatabase = createMockDatabase();
@@ -28,6 +30,7 @@ describe('CommunityService', () => {
     service = unit;
     channelsService = unitRef.get(ChannelsService);
     rolesService = unitRef.get(RolesService);
+    permissionsCacheService = unitRef.get(PermissionsCacheService);
   });
 
   afterEach(() => {
@@ -457,6 +460,12 @@ describe('CommunityService', () => {
       expect(mockDatabase.community.delete).toHaveBeenCalledWith({
         where: { id: community.id },
       });
+      // Role definitions and assignments were removed via raw
+      // tx.role.deleteMany / tx.userRoles.deleteMany above, bypassing
+      // RolesService — remove() must bump the community epoch explicitly.
+      expect(permissionsCacheService.bumpCommunityEpoch).toHaveBeenCalledWith(
+        community.id,
+      );
     });
 
     it('should throw NotFoundException when community not found', async () => {
@@ -468,6 +477,7 @@ describe('CommunityService', () => {
       await expect(service.remove('nonexistent')).rejects.toThrow(
         'Community not found',
       );
+      expect(permissionsCacheService.bumpCommunityEpoch).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/community/community.service.ts
+++ b/backend/src/community/community.service.ts
@@ -12,6 +12,7 @@ import { RolesService } from '@/roles/roles.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { RoomEvents } from '@/rooms/room-subscription.events';
 import { isPrismaError } from '@/common/utils/prisma.utils';
+import { PermissionsCacheService } from '@/roles/permissions-cache.service';
 
 @Injectable()
 export class CommunityService {
@@ -21,6 +22,7 @@ export class CommunityService {
     private readonly channelsService: ChannelsService,
     private readonly rolesService: RolesService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly permissionsCacheService: PermissionsCacheService,
   ) {}
   async create(createCommunityDto: CreateCommunityDto, creatorId: string) {
     try {
@@ -391,5 +393,13 @@ export class CommunityService {
         where: { id },
       });
     });
+
+    // Role definitions and assignments for this community were removed via
+    // raw tx.role.deleteMany / tx.userRoles.deleteMany above (bypasses
+    // RolesService, so they don't self-bump). Bump the community epoch for
+    // completeness/defense-in-depth — in practice no future request can
+    // resolve a permission check against this communityId again, since the
+    // community and its channels/messages are gone.
+    await this.permissionsCacheService.bumpCommunityEpoch(id);
   }
 }

--- a/backend/src/community/community.service.ts
+++ b/backend/src/community/community.service.ts
@@ -12,7 +12,10 @@ import { RolesService } from '@/roles/roles.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { RoomEvents } from '@/rooms/room-subscription.events';
 import { isPrismaError } from '@/common/utils/prisma.utils';
-import { PermissionsCacheService } from '@/roles/permissions-cache.service';
+import {
+  EpochBump,
+  PermissionsCacheService,
+} from '@/roles/permissions-cache.service';
 
 @Injectable()
 export class CommunityService {
@@ -25,8 +28,13 @@ export class CommunityService {
     private readonly permissionsCacheService: PermissionsCacheService,
   ) {}
   async create(createCommunityDto: CreateCommunityDto, creatorId: string) {
+    // Epoch bumps from the tx-nested role mutations below are collected here
+    // and executed only after the transaction commits — bumping while the
+    // transaction is still open would let a concurrent reader cache
+    // pre-commit permission data under the post-commit epoch.
+    const pendingBumps: EpochBump[] = [];
     try {
-      return await this.databaseService.$transaction(async (tx) => {
+      const community = await this.databaseService.$transaction(async (tx) => {
         const community = await tx.community.create({
           data: createCommunityDto,
         });
@@ -49,6 +57,7 @@ export class CommunityService {
         const adminRoleId = await this.rolesService.createDefaultCommunityRoles(
           community.id,
           tx,
+          pendingBumps,
         );
 
         // Assign the creator as admin of the community
@@ -57,10 +66,18 @@ export class CommunityService {
           community.id,
           adminRoleId,
           tx,
+          pendingBumps,
         );
 
         return community;
       });
+
+      // Transaction committed — flush the deferred epoch bumps. On rollback
+      // (transaction threw) this is never reached, which is correct: nothing
+      // changed in the DB. executeBumps never throws (fail-open, logged).
+      await this.permissionsCacheService.executeBumps(pendingBumps);
+
+      return community;
     } catch (error) {
       if (isPrismaError(error, 'P2002')) {
         throw new ConflictException('Duplicate community name');

--- a/backend/src/membership/membership.service.spec.ts
+++ b/backend/src/membership/membership.service.spec.ts
@@ -5,6 +5,7 @@ import { MembershipService } from './membership.service';
 import { DatabaseService } from '@/database/database.service';
 import { CommunityService } from '@/community/community.service';
 import { RolesService } from '@/roles/roles.service';
+import { PermissionsCacheService } from '@/roles/permissions-cache.service';
 
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import {
@@ -24,6 +25,7 @@ describe('MembershipService', () => {
   let communityService: Mocked<CommunityService>;
   let rolesService: Mocked<RolesService>;
   let eventEmitter: Mocked<EventEmitter2>;
+  let permissionsCacheService: Mocked<PermissionsCacheService>;
 
   beforeEach(async () => {
     mockDatabase = createMockDatabase();
@@ -37,6 +39,7 @@ describe('MembershipService', () => {
     communityService = unitRef.get(CommunityService);
     rolesService = unitRef.get(RolesService);
     eventEmitter = unitRef.get(EventEmitter2);
+    permissionsCacheService = unitRef.get(PermissionsCacheService);
   });
 
   afterEach(() => {
@@ -628,6 +631,11 @@ describe('MembershipService', () => {
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         RoomEvents.MEMBERSHIP_REMOVED,
         { userId: user.id, communityId: community.id },
+      );
+      // Role assignments were removed via the raw tx.userRoles.deleteMany
+      // above, which bypasses RolesService — remove() must bump explicitly.
+      expect(permissionsCacheService.bumpUserEpoch).toHaveBeenCalledWith(
+        user.id,
       );
     });
 

--- a/backend/src/membership/membership.service.ts
+++ b/backend/src/membership/membership.service.ts
@@ -14,6 +14,7 @@ import { RolesService } from '@/roles/roles.service';
 import { isPrismaError } from '@/common/utils/prisma.utils';
 import { PUBLIC_USER_SELECT } from '@/common/constants/user-select.constant';
 import { RoomEvents } from '@/rooms/room-subscription.events';
+import { PermissionsCacheService } from '@/roles/permissions-cache.service';
 
 @Injectable()
 export class MembershipService {
@@ -24,6 +25,7 @@ export class MembershipService {
     private readonly communityService: CommunityService,
     private readonly rolesService: RolesService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly permissionsCacheService: PermissionsCacheService,
   ) {}
 
   async create(
@@ -298,6 +300,11 @@ export class MembershipService {
           },
         });
       });
+
+      // Role assignments were removed via the raw tx.userRoles.deleteMany
+      // above (bypasses RolesService, so it doesn't self-bump) — invalidate
+      // this user's cached permissions now that the transaction committed.
+      await this.permissionsCacheService.bumpUserEpoch(userId);
 
       // Emit domain event — the RoomSubscriptionHandler will remove sockets
       this.eventEmitter.emit(RoomEvents.MEMBERSHIP_REMOVED, {

--- a/backend/src/moderation/moderation.service.spec.ts
+++ b/backend/src/moderation/moderation.service.spec.ts
@@ -6,6 +6,7 @@ import { DatabaseService } from '@/database/database.service';
 import { RolesService } from '@/roles/roles.service';
 import { MembershipService } from '@/membership/membership.service';
 import { WebsocketService } from '@/websocket/websocket.service';
+import { PermissionsCacheService } from '@/roles/permissions-cache.service';
 import {
   ForbiddenException,
   NotFoundException,
@@ -28,6 +29,7 @@ describe('ModerationService', () => {
   let membershipService: Mocked<MembershipService>;
   let websocketService: Mocked<WebsocketService>;
   let eventEmitter: Mocked<EventEmitter2>;
+  let permissionsCacheService: Mocked<PermissionsCacheService>;
 
   const moderatorId = 'moderator-123';
   const userId = 'user-456';
@@ -48,6 +50,7 @@ describe('ModerationService', () => {
     membershipService = unitRef.get(MembershipService);
     websocketService = unitRef.get(WebsocketService);
     eventEmitter = unitRef.get(EventEmitter2);
+    permissionsCacheService = unitRef.get(PermissionsCacheService);
 
     // Default: user lookups return empty (enrichment queries)
     mockDatabase.user.findMany.mockResolvedValue([]);
@@ -267,6 +270,12 @@ describe('ModerationService', () => {
         expect.any(String),
         expect.objectContaining({ communityId, userId }),
       );
+      // removeMemberInternal removes role assignments via a raw
+      // tx.userRoles.deleteMany, bypassing RolesService — banUser must
+      // bump the target user's epoch explicitly.
+      expect(permissionsCacheService.bumpUserEpoch).toHaveBeenCalledWith(
+        userId,
+      );
     });
 
     it('should throw ForbiddenException when moderator has lower rank (higher position number)', async () => {
@@ -278,6 +287,7 @@ describe('ModerationService', () => {
       await expect(
         service.banUser(communityId, userId, moderatorId, 'spam'),
       ).rejects.toThrow(ForbiddenException);
+      expect(permissionsCacheService.bumpUserEpoch).not.toHaveBeenCalled();
     });
 
     it('should throw NotFoundException when user is not a member', async () => {
@@ -461,6 +471,12 @@ describe('ModerationService', () => {
         expect.any(String),
         expect.objectContaining({ communityId, userId }),
       );
+      // removeMemberInternal removes role assignments via a raw
+      // tx.userRoles.deleteMany, bypassing RolesService — kickUser must
+      // bump the target user's epoch explicitly.
+      expect(permissionsCacheService.bumpUserEpoch).toHaveBeenCalledWith(
+        userId,
+      );
     });
 
     it('should throw ForbiddenException when moderator has lower rank (higher position number)', async () => {
@@ -472,6 +488,7 @@ describe('ModerationService', () => {
       await expect(
         service.kickUser(communityId, userId, moderatorId, 'rule violation'),
       ).rejects.toThrow(ForbiddenException);
+      expect(permissionsCacheService.bumpUserEpoch).not.toHaveBeenCalled();
     });
   });
 
@@ -508,6 +525,10 @@ describe('ModerationService', () => {
         expect.any(String),
         expect.objectContaining({ communityId, userId }),
       );
+      // Timeouts don't touch UserRoles/Role and aren't consulted by
+      // PermissionsService — no epoch bump is expected.
+      expect(permissionsCacheService.bumpUserEpoch).not.toHaveBeenCalled();
+      expect(permissionsCacheService.bumpCommunityEpoch).not.toHaveBeenCalled();
     });
 
     it('should throw ForbiddenException when moderator has lower rank (higher position number)', async () => {

--- a/backend/src/moderation/moderation.service.ts
+++ b/backend/src/moderation/moderation.service.ts
@@ -21,6 +21,7 @@ import {
   CommunityBan,
   CommunityTimeout,
 } from '@prisma/client';
+import { PermissionsCacheService } from '@/roles/permissions-cache.service';
 
 @Injectable()
 export class ModerationService {
@@ -32,6 +33,7 @@ export class ModerationService {
     private readonly membershipService: MembershipService,
     private readonly websocketService: WebsocketService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly permissionsCacheService: PermissionsCacheService,
   ) {}
 
   /**
@@ -174,6 +176,12 @@ export class ModerationService {
         },
       });
     });
+
+    // removeMemberInternal removed role assignments via a raw
+    // tx.userRoles.deleteMany (bypasses RolesService, so it doesn't
+    // self-bump) — invalidate the banned user's cached permissions now
+    // that the transaction committed.
+    await this.permissionsCacheService.bumpUserEpoch(userId);
 
     // Emit to user's personal room BEFORE removing from community rooms
     // so the banned user receives the event
@@ -342,6 +350,12 @@ export class ModerationService {
         },
       });
     });
+
+    // removeMemberInternal removed role assignments via a raw
+    // tx.userRoles.deleteMany (bypasses RolesService, so it doesn't
+    // self-bump) — invalidate the kicked user's cached permissions now
+    // that the transaction committed.
+    await this.permissionsCacheService.bumpUserEpoch(userId);
 
     // Emit to user's personal room BEFORE removing from community rooms
     // so the kicked user receives the event

--- a/backend/src/onboarding/onboarding.service.spec.ts
+++ b/backend/src/onboarding/onboarding.service.spec.ts
@@ -3,6 +3,7 @@ import { OnboardingService } from './onboarding.service';
 import { DatabaseService } from '@/database/database.service';
 import { REDIS_CLIENT } from '@/redis/redis.constants';
 import { RolesService } from '@/roles/roles.service';
+import { PermissionsCacheService } from '@/roles/permissions-cache.service';
 import { ConflictException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import {
@@ -28,6 +29,7 @@ describe('OnboardingService', () => {
   let mockDatabase: ReturnType<typeof createMockDatabase>;
   let mockRedis: ReturnType<typeof createMockRedis>;
   let rolesService: Mocked<RolesService>;
+  let permissionsCacheService: Mocked<PermissionsCacheService>;
 
   const mockBcrypt = bcrypt as jest.Mocked<typeof bcrypt>;
 
@@ -47,7 +49,7 @@ describe('OnboardingService', () => {
         .mockResolvedValue('mock-community-creator-role-id'),
     };
 
-    const { unit } = await TestBed.solitary(OnboardingService)
+    const { unit, unitRef } = await TestBed.solitary(OnboardingService)
       .mock(DatabaseService)
       .final(mockDatabase)
       .mock(REDIS_CLIENT)
@@ -58,6 +60,7 @@ describe('OnboardingService', () => {
 
     service = unit;
     rolesService = mockRolesService as unknown as Mocked<RolesService>;
+    permissionsCacheService = unitRef.get(PermissionsCacheService);
   });
 
   afterEach(() => {
@@ -376,6 +379,86 @@ describe('OnboardingService', () => {
       );
 
       expect(result.adminUser.username).toBe('admin');
+    });
+
+    it('flushes deferred epoch bumps only after the transaction commits', async () => {
+      const order: string[] = [];
+      const dto: SetupInstanceDto = {
+        ...validSetupDto,
+        createDefaultCommunity: false,
+      };
+
+      mockDatabase.$transaction.mockImplementation(async (callback: any) => {
+        const mockTx = createMockDatabase();
+        mockTx.user.create.mockResolvedValue(mockAdmin);
+        mockTx.instanceInvite.create.mockResolvedValue(mockInvite);
+        const result = await callback(mockTx);
+        order.push('commit');
+        return result;
+      });
+
+      // The (mocked) tx-nested role mutations record their bumps on the
+      // collector the service passes in, like the real implementations do.
+      rolesService.createDefaultInstanceRole.mockImplementation(((
+        _tx: unknown,
+        bumps: any[],
+      ) => {
+        bumps.push({ kind: 'instance' });
+        return Promise.resolve('mock-instance-admin-role-id');
+      }) as any);
+      rolesService.assignUserToInstanceRole.mockImplementation(((
+        userId: string,
+        _roleId: string,
+        _tx: unknown,
+        bumps: any[],
+      ) => {
+        bumps.push({ kind: 'user', userId });
+        return Promise.resolve();
+      }) as any);
+      rolesService.createDefaultCommunityCreatorRole.mockImplementation(((
+        _tx: unknown,
+        bumps: any[],
+      ) => {
+        bumps.push({ kind: 'instance' });
+        return Promise.resolve('mock-community-creator-role-id');
+      }) as any);
+      permissionsCacheService.executeBumps.mockImplementation(() => {
+        order.push('flush-bumps');
+        return Promise.resolve();
+      });
+
+      await service.completeSetup(dto, 'valid-token');
+
+      // Bumps must flush strictly AFTER the transaction resolves (commit).
+      expect(order).toEqual(['commit', 'flush-bumps']);
+      expect(permissionsCacheService.executeBumps).toHaveBeenCalledWith([
+        { kind: 'instance' },
+        { kind: 'user', userId: mockAdmin.id },
+        { kind: 'instance' },
+      ]);
+    });
+
+    it('does not flush epoch bumps when the setup transaction rolls back', async () => {
+      const dto: SetupInstanceDto = {
+        ...validSetupDto,
+        createDefaultCommunity: false,
+      };
+
+      mockDatabase.$transaction.mockImplementation((callback: any) => {
+        const mockTx = createMockDatabase();
+        mockTx.user.create.mockResolvedValue(mockAdmin);
+        mockTx.instanceInvite.create.mockResolvedValue(mockInvite);
+        return callback(mockTx);
+      });
+      rolesService.createDefaultInstanceRole.mockRejectedValue(
+        new Error('instance role creation failed'),
+      );
+
+      await expect(service.completeSetup(dto, 'valid-token')).rejects.toThrow(
+        'instance role creation failed',
+      );
+
+      expect(permissionsCacheService.executeBumps).not.toHaveBeenCalled();
     });
 
     it('should use default community name if not provided', async () => {

--- a/backend/src/onboarding/onboarding.service.ts
+++ b/backend/src/onboarding/onboarding.service.ts
@@ -3,6 +3,10 @@ import { DatabaseService } from '@/database/database.service';
 import { REDIS_CLIENT } from '@/redis/redis.constants';
 import Redis from 'ioredis';
 import { RolesService } from '@/roles/roles.service';
+import {
+  EpochBump,
+  PermissionsCacheService,
+} from '@/roles/permissions-cache.service';
 import { InstanceRole } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
 import { randomUUID } from 'crypto';
@@ -18,6 +22,7 @@ export class OnboardingService {
     private readonly databaseService: DatabaseService,
     @Inject(REDIS_CLIENT) private readonly redis: Redis,
     private readonly rolesService: RolesService,
+    private readonly permissionsCacheService: PermissionsCacheService,
   ) {}
 
   /**
@@ -111,6 +116,11 @@ export class OnboardingService {
       throw new ConflictException('Instance setup is no longer needed');
     }
 
+    // Epoch bumps from the tx-nested role mutations below are collected here
+    // and executed only after the transaction commits (see
+    // PermissionsCacheService — bumping pre-commit races concurrent readers).
+    const pendingBumps: EpochBump[] = [];
+
     const result = await this.databaseService.$transaction(async (tx) => {
       // 1. Create admin user
       const hashedPassword = await bcrypt.hash(dto.adminPassword, 10);
@@ -186,6 +196,7 @@ export class OnboardingService {
         const adminRoleId = await this.rolesService.createDefaultCommunityRoles(
           defaultCommunity.id,
           tx,
+          pendingBumps,
         );
 
         // Assign the admin user to the Community Admin role
@@ -194,6 +205,7 @@ export class OnboardingService {
           defaultCommunity.id,
           adminRoleId,
           tx,
+          pendingBumps,
         );
 
         this.logger.log(
@@ -224,18 +236,22 @@ export class OnboardingService {
 
       // 3. Create default instance admin role and assign to OWNER
       const instanceAdminRoleId =
-        await this.rolesService.createDefaultInstanceRole(tx);
+        await this.rolesService.createDefaultInstanceRole(tx, pendingBumps);
       await this.rolesService.assignUserToInstanceRole(
         adminUser.id,
         instanceAdminRoleId,
         tx,
+        pendingBumps,
       );
       this.logger.log(
         `Created default instance admin role and assigned to OWNER user`,
       );
 
       // 4. Create default Community Creator role (available for assignment to users)
-      await this.rolesService.createDefaultCommunityCreatorRole(tx);
+      await this.rolesService.createDefaultCommunityCreatorRole(
+        tx,
+        pendingBumps,
+      );
       this.logger.log(`Created default Community Creator role`);
 
       // 5. Create a permanent instance invite for future users
@@ -259,6 +275,11 @@ export class OnboardingService {
         defaultCommunity,
       };
     });
+
+    // Transaction committed — flush the deferred epoch bumps. On rollback
+    // this line is never reached, which is correct (nothing changed in the
+    // DB). executeBumps never throws (fail-open, logged).
+    await this.permissionsCacheService.executeBumps(pendingBumps);
 
     // Clear the setup token from Redis after successful transaction
     await this.redis.del(this.SETUP_TOKEN_KEY);

--- a/backend/src/roles/permissions-cache.service.spec.ts
+++ b/backend/src/roles/permissions-cache.service.spec.ts
@@ -1,0 +1,397 @@
+import Redis from 'ioredis';
+import { RbacActions } from '@prisma/client';
+import { PermissionsCacheService } from './permissions-cache.service';
+
+function makeRedis(overrides: Record<string, any> = {}): Redis {
+  return {
+    status: 'ready',
+    mget: jest.fn(),
+    get: jest.fn(),
+    set: jest.fn(),
+    incr: jest.fn(),
+    ...overrides,
+  } as unknown as Redis;
+}
+
+function spyOnWarn(service: PermissionsCacheService): jest.SpyInstance {
+  return jest
+    .spyOn(
+      (service as unknown as { logger: { warn: (msg: string) => void } })
+        .logger,
+      'warn',
+    )
+    .mockImplementation(() => undefined);
+}
+
+function spyOnError(service: PermissionsCacheService): jest.SpyInstance {
+  return jest
+    .spyOn(
+      (service as unknown as { logger: { error: (msg: string) => void } })
+        .logger,
+      'error',
+    )
+    .mockImplementation(() => undefined);
+}
+
+describe('PermissionsCacheService', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const actions: RbacActions[] = [
+    RbacActions.CREATE_MESSAGE,
+    RbacActions.READ_MESSAGE,
+  ];
+
+  describe('getCachedActions — hit', () => {
+    it('returns cached actions when the value key exists', async () => {
+      const redis = makeRedis({
+        mget: jest.fn().mockResolvedValue(['0', '0']),
+        get: jest.fn().mockResolvedValue(JSON.stringify(actions)),
+      });
+      const service = new PermissionsCacheService(redis);
+
+      const result = await service.getCachedActions('user-1', {
+        kind: 'instance',
+      });
+
+      expect(result).toEqual({ status: 'hit', actions });
+      expect(redis.mget).toHaveBeenCalledWith(
+        'rbac:epoch:user:user-1',
+        'rbac:epoch:instance',
+      );
+      expect(redis.get).toHaveBeenCalledWith(
+        'rbac:actions:user-1:instance:0:0',
+      );
+    });
+
+    it('builds the community-scoped value key from communityId', async () => {
+      const redis = makeRedis({
+        mget: jest.fn().mockResolvedValue(['2', '5']),
+        get: jest.fn().mockResolvedValue(JSON.stringify(actions)),
+      });
+      const service = new PermissionsCacheService(redis);
+
+      const result = await service.getCachedActions('user-1', {
+        kind: 'community',
+        communityId: 'community-9',
+      });
+
+      expect(result).toEqual({ status: 'hit', actions });
+      expect(redis.mget).toHaveBeenCalledWith(
+        'rbac:epoch:user:user-1',
+        'rbac:epoch:community:community-9',
+      );
+      expect(redis.get).toHaveBeenCalledWith(
+        'rbac:actions:user-1:community-9:2:5',
+      );
+    });
+
+    it('treats a corrupt cached value as a miss rather than throwing', async () => {
+      const redis = makeRedis({
+        mget: jest.fn().mockResolvedValue(['0', '0']),
+        get: jest.fn().mockResolvedValue('not-json{'),
+      });
+      const service = new PermissionsCacheService(redis);
+
+      const result = await service.getCachedActions('user-1', {
+        kind: 'instance',
+      });
+
+      expect(result).toEqual({
+        status: 'miss',
+        epochs: { userEpoch: 0, scopeEpoch: 0 },
+      });
+    });
+  });
+
+  describe('getCachedActions — miss, then populate, then hit', () => {
+    it('miss reports current epochs; a subsequent populate + read hits', async () => {
+      const store = new Map<string, string>();
+      const redis = makeRedis({
+        mget: jest.fn().mockResolvedValue([null, null]),
+        get: jest.fn((key: string) => Promise.resolve(store.get(key) ?? null)),
+        set: jest.fn((key: string, value: string) => {
+          store.set(key, value);
+          return Promise.resolve('OK');
+        }),
+      });
+      const service = new PermissionsCacheService(redis);
+      const scope = { kind: 'community' as const, communityId: 'community-1' };
+
+      const miss = await service.getCachedActions('user-1', scope);
+      expect(miss).toEqual({
+        status: 'miss',
+        epochs: { userEpoch: 0, scopeEpoch: 0 },
+      });
+      if (miss.status !== 'miss') throw new Error('expected miss');
+
+      await service.setCachedActions('user-1', scope, miss.epochs, actions);
+      expect(redis.set).toHaveBeenCalledWith(
+        'rbac:actions:user-1:community-1:0:0',
+        JSON.stringify(actions),
+        'EX',
+        300,
+      );
+
+      // Second read now sees the populated key (epochs still 0:0)
+      const hit = await service.getCachedActions('user-1', scope);
+      expect(hit).toEqual({ status: 'hit', actions });
+    });
+  });
+
+  describe('epoch bump invalidates', () => {
+    it('a bumped user epoch makes the previously cached entry unreachable', async () => {
+      const epochStore = new Map<string, string>();
+      const valueStore = new Map<string, string>();
+      const redis = makeRedis({
+        mget: jest.fn((...keys: string[]) =>
+          Promise.resolve(keys.map((k) => epochStore.get(k) ?? null)),
+        ),
+        get: jest.fn((key: string) =>
+          Promise.resolve(valueStore.get(key) ?? null),
+        ),
+        set: jest.fn((key: string, value: string) => {
+          valueStore.set(key, value);
+          return Promise.resolve('OK');
+        }),
+        incr: jest.fn((key: string) => {
+          const next = (
+            parseInt(epochStore.get(key) ?? '0', 10) + 1
+          ).toString();
+          epochStore.set(key, next);
+          return Promise.resolve(parseInt(next, 10));
+        }),
+      });
+      const service = new PermissionsCacheService(redis);
+      const scope = { kind: 'community' as const, communityId: 'community-1' };
+
+      const miss = await service.getCachedActions('user-1', scope);
+      if (miss.status !== 'miss') throw new Error('expected miss');
+      await service.setCachedActions('user-1', scope, miss.epochs, actions);
+
+      // Confirm it's cached
+      expect(await service.getCachedActions('user-1', scope)).toEqual({
+        status: 'hit',
+        actions,
+      });
+
+      // Bump the user's epoch — old value key is now orphaned
+      await service.bumpUserEpoch('user-1');
+
+      const afterBump = await service.getCachedActions('user-1', scope);
+      expect(afterBump).toEqual({
+        status: 'miss',
+        epochs: { userEpoch: 1, scopeEpoch: 0 },
+      });
+    });
+
+    it('a bumped community epoch makes the previously cached entry unreachable', async () => {
+      const epochStore = new Map<string, string>();
+      const valueStore = new Map<string, string>();
+      const redis = makeRedis({
+        mget: jest.fn((...keys: string[]) =>
+          Promise.resolve(keys.map((k) => epochStore.get(k) ?? null)),
+        ),
+        get: jest.fn((key: string) =>
+          Promise.resolve(valueStore.get(key) ?? null),
+        ),
+        set: jest.fn((key: string, value: string) => {
+          valueStore.set(key, value);
+          return Promise.resolve('OK');
+        }),
+        incr: jest.fn((key: string) => {
+          const next = (
+            parseInt(epochStore.get(key) ?? '0', 10) + 1
+          ).toString();
+          epochStore.set(key, next);
+          return Promise.resolve(parseInt(next, 10));
+        }),
+      });
+      const service = new PermissionsCacheService(redis);
+      const scope = { kind: 'community' as const, communityId: 'community-1' };
+
+      const miss = await service.getCachedActions('user-1', scope);
+      if (miss.status !== 'miss') throw new Error('expected miss');
+      await service.setCachedActions('user-1', scope, miss.epochs, actions);
+
+      await service.bumpCommunityEpoch('community-1');
+
+      const afterBump = await service.getCachedActions('user-1', scope);
+      expect(afterBump).toEqual({
+        status: 'miss',
+        epochs: { userEpoch: 0, scopeEpoch: 1 },
+      });
+      // A different community's cache is untouched by this bump.
+      expect(redis.incr).toHaveBeenCalledWith(
+        'rbac:epoch:community:community-1',
+      );
+    });
+
+    it('a bumped instance epoch invalidates instance-scope entries only', async () => {
+      const epochStore = new Map<string, string>();
+      const redis = makeRedis({
+        mget: jest.fn((...keys: string[]) =>
+          Promise.resolve(keys.map((k) => epochStore.get(k) ?? null)),
+        ),
+        incr: jest.fn((key: string) => {
+          const next = (
+            parseInt(epochStore.get(key) ?? '0', 10) + 1
+          ).toString();
+          epochStore.set(key, next);
+          return Promise.resolve(parseInt(next, 10));
+        }),
+      });
+      const service = new PermissionsCacheService(redis);
+
+      await service.bumpInstanceEpoch();
+
+      expect(redis.incr).toHaveBeenCalledWith('rbac:epoch:instance');
+    });
+  });
+
+  describe('fail-open on Redis error', () => {
+    it('getCachedActions reports unavailable when mget rejects', async () => {
+      const redis = makeRedis({
+        mget: jest.fn().mockRejectedValue(new Error('ECONNREFUSED')),
+      });
+      const service = new PermissionsCacheService(redis);
+      spyOnWarn(service);
+
+      const result = await service.getCachedActions('user-1', {
+        kind: 'instance',
+      });
+
+      expect(result).toEqual({ status: 'unavailable' });
+    });
+
+    it('setCachedActions swallows errors and never throws', async () => {
+      const redis = makeRedis({
+        set: jest.fn().mockRejectedValue(new Error('ECONNREFUSED')),
+      });
+      const service = new PermissionsCacheService(redis);
+
+      await expect(
+        service.setCachedActions(
+          'user-1',
+          { kind: 'instance' },
+          { userEpoch: 0, scopeEpoch: 0 },
+          actions,
+        ),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('fail-open on Redis hang (timeout race)', () => {
+    it('falls through to unavailable when the read never resolves within the timeout', async () => {
+      const redis = makeRedis({
+        // Pending forever — simulates a wedged connection.
+        mget: jest.fn(() => new Promise(() => undefined)),
+      });
+      const service = new PermissionsCacheService(redis);
+      spyOnWarn(service);
+
+      const resultPromise = service.getCachedActions('user-1', {
+        kind: 'instance',
+      });
+      await jest.advanceTimersByTimeAsync(1501);
+
+      await expect(resultPromise).resolves.toEqual({ status: 'unavailable' });
+    });
+
+    it('bump falls through (logs, does not throw) when the INCR never resolves', async () => {
+      const redis = makeRedis({
+        incr: jest.fn(() => new Promise(() => undefined)),
+      });
+      const service = new PermissionsCacheService(redis);
+      const errorSpy = spyOnError(service);
+
+      const bumpPromise = service.bumpUserEpoch('user-1');
+      await jest.advanceTimersByTimeAsync(1501);
+      await bumpPromise;
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toContain('timed out');
+    });
+
+    it('does not fail open when the read resolves before the timeout', async () => {
+      const redis = makeRedis({
+        mget: jest.fn().mockResolvedValue(['0', '0']),
+        get: jest.fn().mockResolvedValue(JSON.stringify(actions)),
+      });
+      const service = new PermissionsCacheService(redis);
+
+      const result = await service.getCachedActions('user-1', {
+        kind: 'instance',
+      });
+      await jest.runAllTimersAsync();
+
+      expect(result).toEqual({ status: 'hit', actions });
+    });
+  });
+
+  describe('fast fail-open when Redis is not ready', () => {
+    it('skips the round trip entirely when redis.status is not ready', async () => {
+      const redis = makeRedis({ status: 'reconnecting' });
+      const service = new PermissionsCacheService(redis);
+      const warnSpy = spyOnWarn(service);
+
+      const result = await service.getCachedActions('user-1', {
+        kind: 'instance',
+      });
+
+      expect(result).toEqual({ status: 'unavailable' });
+      expect(redis.mget).not.toHaveBeenCalled();
+      expect(warnSpy.mock.calls[0][0]).toContain('reconnecting');
+    });
+  });
+
+  describe('bump error handling', () => {
+    it('logs an error and does not throw when INCR rejects', async () => {
+      const redis = makeRedis({
+        incr: jest.fn().mockRejectedValue(new Error('Redis down')),
+      });
+      const service = new PermissionsCacheService(redis);
+      const errorSpy = spyOnError(service);
+
+      await expect(
+        service.bumpCommunityEpoch('community-1'),
+      ).resolves.toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toContain('Redis down');
+    });
+  });
+
+  describe('warning rate limiting on read failures', () => {
+    it('logs at most one warning per 30 seconds', async () => {
+      const redis = makeRedis({
+        mget: jest.fn().mockRejectedValue(new Error('Redis down')),
+      });
+      const service = new PermissionsCacheService(redis);
+      const warnSpy = spyOnWarn(service);
+
+      await service.getCachedActions('user-1', { kind: 'instance' });
+      await service.getCachedActions('user-1', { kind: 'instance' });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs again after the rate-limit window elapses', async () => {
+      const redis = makeRedis({
+        mget: jest.fn().mockRejectedValue(new Error('Redis down')),
+      });
+      const service = new PermissionsCacheService(redis);
+      const warnSpy = spyOnWarn(service);
+
+      await service.getCachedActions('user-1', { kind: 'instance' });
+      await jest.advanceTimersByTimeAsync(30_001);
+      await service.getCachedActions('user-1', { kind: 'instance' });
+
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/backend/src/roles/permissions-cache.service.spec.ts
+++ b/backend/src/roles/permissions-cache.service.spec.ts
@@ -366,6 +366,86 @@ describe('PermissionsCacheService', () => {
     });
   });
 
+  describe('executeBump / executeBumps (deferred post-commit bumps)', () => {
+    it('executeBump maps each bump kind to the correct epoch key', async () => {
+      const incr = jest.fn().mockResolvedValue(1);
+      const service = new PermissionsCacheService(makeRedis({ incr }));
+
+      await service.executeBump({ kind: 'user', userId: 'user-1' });
+      await service.executeBump({
+        kind: 'community',
+        communityId: 'community-1',
+      });
+      await service.executeBump({ kind: 'instance' });
+
+      expect(incr.mock.calls.map((c) => c[0])).toEqual([
+        'rbac:epoch:user:user-1',
+        'rbac:epoch:community:community-1',
+        'rbac:epoch:instance',
+      ]);
+    });
+
+    it('executeBumps executes every collected bump', async () => {
+      const incr = jest.fn().mockResolvedValue(1);
+      const service = new PermissionsCacheService(makeRedis({ incr }));
+
+      await service.executeBumps([
+        { kind: 'community', communityId: 'community-1' },
+        { kind: 'user', userId: 'user-1' },
+        { kind: 'instance' },
+      ]);
+
+      expect(incr.mock.calls.map((c) => c[0])).toEqual([
+        'rbac:epoch:community:community-1',
+        'rbac:epoch:user:user-1',
+        'rbac:epoch:instance',
+      ]);
+    });
+
+    it('executeBumps coalesces duplicate bumps for the same key', async () => {
+      const incr = jest.fn().mockResolvedValue(1);
+      const service = new PermissionsCacheService(makeRedis({ incr }));
+
+      await service.executeBumps([
+        { kind: 'user', userId: 'user-1' },
+        { kind: 'instance' },
+        { kind: 'user', userId: 'user-1' },
+        { kind: 'instance' },
+        { kind: 'user', userId: 'user-2' },
+      ]);
+
+      expect(incr.mock.calls.map((c) => c[0])).toEqual([
+        'rbac:epoch:user:user-1',
+        'rbac:epoch:instance',
+        'rbac:epoch:user:user-2',
+      ]);
+    });
+
+    it('executeBumps is a no-op for an empty collector', async () => {
+      const incr = jest.fn().mockResolvedValue(1);
+      const service = new PermissionsCacheService(makeRedis({ incr }));
+
+      await service.executeBumps([]);
+
+      expect(incr).not.toHaveBeenCalled();
+    });
+
+    it('executeBumps never throws — failures are logged per bump', async () => {
+      const incr = jest.fn().mockRejectedValue(new Error('Redis down'));
+      const service = new PermissionsCacheService(makeRedis({ incr }));
+      const errorSpy = spyOnError(service);
+
+      await expect(
+        service.executeBumps([
+          { kind: 'user', userId: 'user-1' },
+          { kind: 'instance' },
+        ]),
+      ).resolves.toBeUndefined();
+
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('warning rate limiting on read failures', () => {
     it('logs at most one warning per 30 seconds', async () => {
       const redis = makeRedis({

--- a/backend/src/roles/permissions-cache.service.spec.ts
+++ b/backend/src/roles/permissions-cache.service.spec.ts
@@ -332,6 +332,40 @@ describe('PermissionsCacheService', () => {
 
       expect(result).toEqual({ status: 'hit', actions });
     });
+
+    it('does not produce an unhandled rejection when the underlying Redis call rejects after the timeout already won the race', async () => {
+      const unhandled = jest.fn();
+      process.on('unhandledRejection', unhandled);
+
+      try {
+        let rejectIncr!: (err: Error) => void;
+        const redis = makeRedis({
+          incr: jest.fn(
+            () =>
+              new Promise((_resolve, reject) => {
+                rejectIncr = reject;
+              }),
+          ),
+        });
+        const service = new PermissionsCacheService(redis);
+        spyOnError(service);
+
+        const bumpPromise = service.bumpUserEpoch('user-1');
+        await jest.advanceTimersByTimeAsync(1501);
+        await bumpPromise;
+
+        // The INCR call is still pending from the service's perspective —
+        // reject it now, after the timeout has already resolved the race.
+        rejectIncr(new Error('late redis failure'));
+        await jest.advanceTimersByTimeAsync(0);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(unhandled).not.toHaveBeenCalled();
+      } finally {
+        process.off('unhandledRejection', unhandled);
+      }
+    });
   });
 
   describe('fast fail-open when Redis is not ready', () => {

--- a/backend/src/roles/permissions-cache.service.ts
+++ b/backend/src/roles/permissions-cache.service.ts
@@ -1,0 +1,296 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import Redis from 'ioredis';
+import { RbacActions } from '@prisma/client';
+import { REDIS_CLIENT } from '@/redis/redis.constants';
+
+/** Cached-value TTL. Old-epoch value keys are never explicitly deleted —
+ * they simply become unreachable once the epoch bumps, and expire on their
+ * own after this many seconds. */
+const VALUE_TTL_SECONDS = 300;
+
+/** Max time to wait for Redis before treating the cache as unavailable and
+ * falling through to the DB. Mirrors FailOpenThrottlerStorage/WsThrottleGuard
+ * — a slow cache must never make permission checks slower than a plain DB
+ * query. */
+const REDIS_TIMEOUT_MS = 1500;
+
+/** Minimum interval between "cache unavailable" warning logs, so a sustained
+ * Redis outage doesn't flood the logs on every request. */
+const WARN_INTERVAL_MS = 30_000;
+
+export type PermissionScope =
+  | { kind: 'instance' }
+  | { kind: 'community'; communityId: string };
+
+export interface PermissionEpochs {
+  userEpoch: number;
+  scopeEpoch: number;
+}
+
+export type PermissionCacheReadResult =
+  | { status: 'hit'; actions: RbacActions[] }
+  | { status: 'miss'; epochs: PermissionEpochs }
+  | { status: 'unavailable' };
+
+/**
+ * Redis-backed cache for RBAC permission lookups — specifically the
+ * flattened `actions` arrays produced by the two `userRoles.findMany(...)`
+ * queries in PermissionsService (instance-level and community-level). Those
+ * queries run on every guarded request; this cache lets most of them skip
+ * the DB round trip entirely.
+ *
+ * ## Epoch-based invalidation (no SCAN/pattern deletes)
+ *
+ * Three epoch counters, each a plain Redis key bumped with INCR. A missing
+ * epoch key reads as epoch 0:
+ *
+ *   rbac:epoch:user:{userId}           bumped on any role ASSIGNMENT change
+ *                                       for that user (community or instance)
+ *   rbac:epoch:community:{communityId} bumped on any role DEFINITION change
+ *                                       (create/update/delete) in that community
+ *   rbac:epoch:instance                bumped on any instance-level role
+ *                                       DEFINITION change
+ *
+ * The cached lookup result lives at a key that embeds both the user's and
+ * the scope's current epoch:
+ *
+ *   rbac:actions:{userId}:instance:{userEpoch}:{instanceEpoch}
+ *   rbac:actions:{userId}:{communityId}:{userEpoch}:{communityEpoch}
+ *
+ * Value: `JSON.stringify(RbacActions[])`, TTL 300s (SET EX) — the only data
+ * PermissionsService actually needs from the two `findMany` results is the
+ * flattened `role.actions` union, so that's all that's cached.
+ *
+ * Bumping an epoch never touches the value keys directly — it just changes
+ * which value key subsequent reads address. The old value key is now
+ * unreachable (nothing will ever ask for it again) and simply expires via
+ * its TTL. This is what avoids SCAN/KEYS-based fan-out deletes: invalidation
+ * is O(1) regardless of how many stale cache entries exist.
+ *
+ * ## Fail-open
+ *
+ * Reads: any Redis error, or a call that doesn't resolve within
+ * REDIS_TIMEOUT_MS, is treated as `{ status: 'unavailable' }` — the caller
+ * falls through to the DB. Failures are logged at `warn`, throttled to once
+ * per WARN_INTERVAL_MS.
+ *
+ * Bumps: always awaited (never fire-and-forget) so a mutation cannot return
+ * before the invalidation is visible to subsequent reads — a missed bump
+ * means a stale permission grant for up to VALUE_TTL_SECONDS, which this
+ * cache treats as unacceptable to risk knowingly. On error/timeout the bump
+ * is logged at `error` (every time — bumps are rare, so no throttling) and
+ * swallowed rather than thrown, so a wedged Redis cannot turn role
+ * management into a 500.
+ */
+@Injectable()
+export class PermissionsCacheService {
+  private readonly logger = new Logger(PermissionsCacheService.name);
+  private lastUnavailableWarnAt = Number.NEGATIVE_INFINITY;
+
+  constructor(@Inject(REDIS_CLIENT) private readonly redis: Redis) {}
+
+  /**
+   * Attempts to read the cached actions for a user/scope. Never throws.
+   */
+  async getCachedActions(
+    userId: string,
+    scope: PermissionScope,
+  ): Promise<PermissionCacheReadResult> {
+    if (!this.isRedisReady()) {
+      this.warnUnavailable(`Redis connection status is '${this.redis.status}'`);
+      return { status: 'unavailable' };
+    }
+
+    try {
+      return await this.withTimeout(this.readActions(userId, scope));
+    } catch (error) {
+      this.warnUnavailable(errorMessage(error));
+      return { status: 'unavailable' };
+    }
+  }
+
+  /**
+   * Populates the cache for a user/scope, using the epochs captured at the
+   * time of the preceding `getCachedActions` MISS (not epochs re-read now).
+   * This ordering matters: if a role mutation (and its epoch bump) happens
+   * concurrently with the DB query that produced `actions`, writing under
+   * the *old* (pre-bump) epoch makes this entry immediately unreachable —
+   * safe. Writing under a freshly re-read epoch could instead cache
+   * possibly-stale `actions` under the epoch that's currently considered
+   * valid, which would be a real staleness bug. Never throws.
+   */
+  async setCachedActions(
+    userId: string,
+    scope: PermissionScope,
+    epochs: PermissionEpochs,
+    actions: RbacActions[],
+  ): Promise<void> {
+    if (!this.isRedisReady()) return;
+
+    try {
+      await this.withTimeout(this.writeActions(userId, scope, epochs, actions));
+    } catch (error) {
+      // Population failures are non-critical — the next request just misses
+      // and re-populates. Not throttled: debug-level, not a warning.
+      this.logger.debug(
+        `Failed to populate RBAC permission cache: ${errorMessage(error)}`,
+      );
+    }
+  }
+
+  /** Bump on any role ASSIGNMENT change (create/delete of a UserRoles row)
+   * for this user — invalidates all of that user's cached entries (both
+   * instance and every community scope). */
+  async bumpUserEpoch(userId: string): Promise<void> {
+    await this.bump(this.userEpochKey(userId));
+  }
+
+  /** Bump on any role DEFINITION change (create/update/delete of a Role row)
+   * scoped to this community. */
+  async bumpCommunityEpoch(communityId: string): Promise<void> {
+    await this.bump(this.communityEpochKey(communityId));
+  }
+
+  /** Bump on any instance-level role DEFINITION change. */
+  async bumpInstanceEpoch(): Promise<void> {
+    await this.bump(this.instanceEpochKey());
+  }
+
+  // ---------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------
+
+  private async bump(key: string): Promise<void> {
+    try {
+      await this.withTimeout(this.redis.incr(key));
+    } catch (error) {
+      this.logger.error(
+        `Failed to bump RBAC epoch key '${key}' — cached permissions under ` +
+          `the previous epoch may be served as stale grants for up to ` +
+          `${VALUE_TTL_SECONDS}s: ${errorMessage(error)}`,
+      );
+    }
+  }
+
+  private async readActions(
+    userId: string,
+    scope: PermissionScope,
+  ): Promise<PermissionCacheReadResult> {
+    const epochs = await this.readEpochs(userId, scope);
+    const key = this.valueKey(userId, scope, epochs);
+    const raw = await this.redis.get(key);
+
+    if (!raw) {
+      return { status: 'miss', epochs };
+    }
+
+    try {
+      return { status: 'hit', actions: JSON.parse(raw) as RbacActions[] };
+    } catch {
+      // Corrupt entry — treat as a miss rather than throwing.
+      return { status: 'miss', epochs };
+    }
+  }
+
+  private async writeActions(
+    userId: string,
+    scope: PermissionScope,
+    epochs: PermissionEpochs,
+    actions: RbacActions[],
+  ): Promise<void> {
+    const key = this.valueKey(userId, scope, epochs);
+    await this.redis.set(key, JSON.stringify(actions), 'EX', VALUE_TTL_SECONDS);
+  }
+
+  /** Single MGET round trip for both epochs. */
+  private async readEpochs(
+    userId: string,
+    scope: PermissionScope,
+  ): Promise<PermissionEpochs> {
+    const [userEpochRaw, scopeEpochRaw] = await this.redis.mget(
+      this.userEpochKey(userId),
+      this.scopeEpochKey(scope),
+    );
+
+    return {
+      userEpoch: toEpoch(userEpochRaw),
+      scopeEpoch: toEpoch(scopeEpochRaw),
+    };
+  }
+
+  private valueKey(
+    userId: string,
+    scope: PermissionScope,
+    epochs: PermissionEpochs,
+  ): string {
+    const scopePart =
+      scope.kind === 'instance' ? 'instance' : scope.communityId;
+    return `rbac:actions:${userId}:${scopePart}:${epochs.userEpoch}:${epochs.scopeEpoch}`;
+  }
+
+  private userEpochKey(userId: string): string {
+    return `rbac:epoch:user:${userId}`;
+  }
+
+  private communityEpochKey(communityId: string): string {
+    return `rbac:epoch:community:${communityId}`;
+  }
+
+  private instanceEpochKey(): string {
+    return 'rbac:epoch:instance';
+  }
+
+  private scopeEpochKey(scope: PermissionScope): string {
+    return scope.kind === 'instance'
+      ? this.instanceEpochKey()
+      : this.communityEpochKey(scope.communityId);
+  }
+
+  /** Fast path during outages: skip waiting out the full timeout on every
+   * call when we already know the connection isn't ready. */
+  private isRedisReady(): boolean {
+    return this.redis.status === 'ready';
+  }
+
+  private withTimeout<T>(promise: Promise<T>): Promise<T> {
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(
+        () =>
+          reject(
+            new Error(
+              `RBAC permission cache timed out after ${REDIS_TIMEOUT_MS}ms`,
+            ),
+          ),
+        REDIS_TIMEOUT_MS,
+      );
+      timeoutHandle.unref?.();
+    });
+
+    return Promise.race([promise, timeoutPromise]).finally(() =>
+      clearTimeout(timeoutHandle),
+    );
+  }
+
+  private warnUnavailable(reason: string): void {
+    const now = Date.now();
+    if (now - this.lastUnavailableWarnAt < WARN_INTERVAL_MS) {
+      return;
+    }
+    this.lastUnavailableWarnAt = now;
+    this.logger.warn(
+      `RBAC permission cache unavailable, falling through to DB: ${reason}`,
+    );
+  }
+}
+
+function toEpoch(raw: string | null): number {
+  if (!raw) return 0;
+  const parsed = parseInt(raw, 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/backend/src/roles/permissions-cache.service.ts
+++ b/backend/src/roles/permissions-cache.service.ts
@@ -22,6 +22,16 @@ export type PermissionScope =
   | { kind: 'instance' }
   | { kind: 'community'; communityId: string };
 
+/**
+ * A deferred epoch bump, described as data so it can be collected inside a
+ * caller-owned transaction and executed only after that transaction commits.
+ * See RolesService for the collection side and `executeBumps` for the flush.
+ */
+export type EpochBump =
+  | { kind: 'user'; userId: string }
+  | { kind: 'community'; communityId: string }
+  | { kind: 'instance' };
+
 export interface PermissionEpochs {
   userEpoch: number;
   scopeEpoch: number;
@@ -81,6 +91,20 @@ export type PermissionCacheReadResult =
  * is logged at `error` (every time — bumps are rare, so no throttling) and
  * swallowed rather than thrown, so a wedged Redis cannot turn role
  * management into a 500.
+ *
+ * ## Bump ordering vs. transactions
+ *
+ * A bump must happen strictly AFTER the corresponding DB write commits.
+ * Bumping while the transaction is still open creates a race: a concurrent
+ * reader can miss under the NEW epoch, query the DB (which still shows
+ * pre-commit data), and cache that stale result under the post-commit
+ * epoch — a stale grant that persists until the next bump or TTL expiry.
+ * Mutations that own their write (no caller transaction) simply bump right
+ * after the awaited write. Mutations that run inside a caller-owned
+ * transaction instead record an `EpochBump` onto the caller's collector,
+ * and the caller flushes it via `executeBumps` after `$transaction`
+ * resolves. If the transaction rolls back, the collected bumps are simply
+ * never executed — correct, since nothing changed in the DB.
  */
 @Injectable()
 export class PermissionsCacheService {
@@ -154,6 +178,41 @@ export class PermissionsCacheService {
   /** Bump on any instance-level role DEFINITION change. */
   async bumpInstanceEpoch(): Promise<void> {
     await this.bump(this.instanceEpochKey());
+  }
+
+  /** Execute a single bump described as data (see EpochBump). Never throws —
+   * same fail-open posture as the direct bump methods. */
+  async executeBump(bump: EpochBump): Promise<void> {
+    switch (bump.kind) {
+      case 'user':
+        return this.bumpUserEpoch(bump.userId);
+      case 'community':
+        return this.bumpCommunityEpoch(bump.communityId);
+      case 'instance':
+        return this.bumpInstanceEpoch();
+    }
+  }
+
+  /**
+   * Flush epoch bumps that were deferred during a caller-owned transaction.
+   * Call this immediately after `$transaction` resolves (i.e. after commit),
+   * awaited. Duplicate bumps for the same epoch key are coalesced into one
+   * INCR. Never throws — each underlying bump already logs-and-swallows its
+   * own failures.
+   */
+  async executeBumps(bumps: EpochBump[]): Promise<void> {
+    const seen = new Set<string>();
+    for (const bump of bumps) {
+      const key =
+        bump.kind === 'user'
+          ? this.userEpochKey(bump.userId)
+          : bump.kind === 'community'
+            ? this.communityEpochKey(bump.communityId)
+            : this.instanceEpochKey();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      await this.executeBump(bump);
+    }
   }
 
   // ---------------------------------------------------------------------

--- a/backend/src/roles/permissions-cache.service.ts
+++ b/backend/src/roles/permissions-cache.service.ts
@@ -84,13 +84,16 @@ export type PermissionCacheReadResult =
  * falls through to the DB. Failures are logged at `warn`, throttled to once
  * per WARN_INTERVAL_MS.
  *
- * Bumps: always awaited (never fire-and-forget) so a mutation cannot return
- * before the invalidation is visible to subsequent reads — a missed bump
- * means a stale permission grant for up to VALUE_TTL_SECONDS, which this
- * cache treats as unacceptable to risk knowingly. On error/timeout the bump
- * is logged at `error` (every time — bumps are rare, so no throttling) and
- * swallowed rather than thrown, so a wedged Redis cannot turn role
- * management into a 500.
+ * Bumps: always awaited (never fire-and-forget), so on the happy path the
+ * invalidation is guaranteed visible to subsequent reads before the mutation
+ * returns. That guarantee does NOT hold under Redis failure: `bump()` below
+ * runs the INCR through `withTimeout`, and on error or timeout it logs at
+ * `error` (every time — bumps are rare, so no throttling) and swallows the
+ * failure rather than rethrowing — fail-open, same posture as reads — so a
+ * wedged Redis cannot turn role management into a 500. In that case the bump
+ * may not have applied, and staleness is bounded only by VALUE_TTL_SECONDS
+ * (300s): affected cache entries self-expire by then even if the bump never
+ * lands.
  *
  * ## Bump ordering vs. transactions
  *
@@ -326,6 +329,15 @@ export class PermissionsCacheService {
       );
       timeoutHandle.unref?.();
     });
+
+    // Defensive: if the timeout wins the race below, `promise` (bump's
+    // redis.incr, readActions', or writeActions' underlying Redis calls) may
+    // still be pending. Attaching .catch() on this reference doesn't affect
+    // the value Promise.race resolves/rejects with below — that still comes
+    // from `promise`'s own resolution/rejection — it just guarantees a later
+    // rejection can never surface as an unhandled rejection, without relying
+    // on Promise.race's internal subscription behavior to provide that.
+    promise.catch(() => undefined);
 
     return Promise.race([promise, timeoutPromise]).finally(() =>
       clearTimeout(timeoutHandle),

--- a/backend/src/roles/permissions.service.spec.ts
+++ b/backend/src/roles/permissions.service.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed } from '@suites/unit';
+import type { Mocked } from '@suites/doubles.jest';
 import { PermissionsService } from './permissions.service';
 import { DatabaseService } from '@/database/database.service';
+import { PermissionsCacheService } from './permissions-cache.service';
 import { RbacResourceType } from '@/auth/rbac-resource.decorator';
 import { RbacActions } from '@prisma/client';
 import {
@@ -15,16 +17,25 @@ import {
 describe('PermissionsService', () => {
   let service: PermissionsService;
   let mockDatabase: ReturnType<typeof createMockDatabase>;
+  let permissionsCacheService: Mocked<PermissionsCacheService>;
 
   beforeEach(async () => {
     mockDatabase = createMockDatabase();
 
-    const { unit } = await TestBed.solitary(PermissionsService)
+    const { unit, unitRef } = await TestBed.solitary(PermissionsService)
       .mock(DatabaseService)
       .final(mockDatabase)
       .compile();
 
     service = unit;
+    permissionsCacheService = unitRef.get(PermissionsCacheService);
+
+    // Default: cache unavailable, so every existing test below exercises the
+    // DB path exactly as before. Cache-specific behavior (hit short-circuit,
+    // miss populate) is covered in its own describe block further down.
+    permissionsCacheService.getCachedActions.mockResolvedValue({
+      status: 'unavailable',
+    });
   });
 
   afterEach(() => {
@@ -637,6 +648,153 @@ describe('PermissionsService', () => {
         );
 
         expect(result).toBe(false);
+      });
+    });
+
+    describe('Permission cache integration', () => {
+      it('short-circuits the DB findMany on a cache hit (instance scope)', async () => {
+        const user = UserFactory.build();
+        permissionsCacheService.getCachedActions.mockResolvedValue({
+          status: 'hit',
+          actions: [RbacActions.CREATE_COMMUNITY],
+        });
+
+        const result = await service.verifyActionsForUserAndResource(
+          user.id,
+          undefined,
+          undefined,
+          [RbacActions.CREATE_COMMUNITY],
+        );
+
+        expect(result).toBe(true);
+        expect(mockDatabase.userRoles.findMany).not.toHaveBeenCalled();
+        expect(permissionsCacheService.getCachedActions).toHaveBeenCalledWith(
+          user.id,
+          { kind: 'instance' },
+        );
+        expect(permissionsCacheService.setCachedActions).not.toHaveBeenCalled();
+      });
+
+      it('short-circuits the DB findMany on a cache hit (community scope)', async () => {
+        const user = UserFactory.build();
+        const community = CommunityFactory.build();
+        permissionsCacheService.getCachedActions.mockResolvedValue({
+          status: 'hit',
+          actions: [RbacActions.DELETE_CHANNEL],
+        });
+
+        const result = await service.verifyActionsForUserAndResource(
+          user.id,
+          community.id,
+          RbacResourceType.COMMUNITY,
+          [RbacActions.DELETE_CHANNEL],
+        );
+
+        expect(result).toBe(true);
+        expect(mockDatabase.userRoles.findMany).not.toHaveBeenCalled();
+        expect(permissionsCacheService.getCachedActions).toHaveBeenCalledWith(
+          user.id,
+          { kind: 'community', communityId: community.id },
+        );
+      });
+
+      it('queries the DB and populates the cache with miss-time epochs on a miss', async () => {
+        const user = UserFactory.build();
+        const community = CommunityFactory.build();
+        const role = RoleFactory.buildAdmin();
+        const epochs = { userEpoch: 3, scopeEpoch: 7 };
+
+        permissionsCacheService.getCachedActions.mockResolvedValue({
+          status: 'miss',
+          epochs,
+        });
+        mockDatabase.userRoles.findMany.mockResolvedValue([
+          {
+            userId: user.id,
+            communityId: community.id,
+            roleId: role.id,
+            isInstanceRole: false,
+            role,
+          },
+        ]);
+
+        const result = await service.verifyActionsForUserAndResource(
+          user.id,
+          community.id,
+          RbacResourceType.COMMUNITY,
+          [RbacActions.DELETE_CHANNEL],
+        );
+
+        expect(result).toBe(true);
+        expect(mockDatabase.userRoles.findMany).toHaveBeenCalled();
+        expect(permissionsCacheService.setCachedActions).toHaveBeenCalledWith(
+          user.id,
+          { kind: 'community', communityId: community.id },
+          epochs,
+          role.actions,
+        );
+      });
+
+      it('queries the DB but does not attempt to populate the cache when unavailable', async () => {
+        const user = UserFactory.build();
+        const role = RoleFactory.buildAdmin();
+
+        permissionsCacheService.getCachedActions.mockResolvedValue({
+          status: 'unavailable',
+        });
+        mockDatabase.userRoles.findMany.mockResolvedValue([
+          {
+            userId: user.id,
+            roleId: role.id,
+            isInstanceRole: true,
+            role,
+          },
+        ]);
+
+        const result = await service.verifyActionsForUserAndResource(
+          user.id,
+          undefined,
+          undefined,
+          [RbacActions.CREATE_COMMUNITY],
+        );
+
+        expect(result).toBe(true);
+        expect(mockDatabase.userRoles.findMany).toHaveBeenCalled();
+        expect(permissionsCacheService.setCachedActions).not.toHaveBeenCalled();
+      });
+
+      it('uncached membership/resource-resolution checks always hit the DB regardless of cache state', async () => {
+        const user = UserFactory.build();
+        const channel = ChannelFactory.build({ isPrivate: true });
+        const role = RoleFactory.buildMember();
+        permissionsCacheService.getCachedActions.mockResolvedValue({
+          status: 'hit',
+          actions: role.actions,
+        });
+
+        mockDatabase.channel.findUnique.mockResolvedValue({
+          id: channel.id,
+          communityId: channel.communityId,
+          isPrivate: true,
+        });
+        mockDatabase.channelMembership.findUnique.mockResolvedValue({
+          userId: user.id,
+          channelId: channel.id,
+        });
+
+        const result = await service.verifyActionsForUserAndResource(
+          user.id,
+          channel.id,
+          RbacResourceType.CHANNEL,
+          [RbacActions.READ_MESSAGE],
+        );
+
+        expect(result).toBe(true);
+        // Channel resolution and private-channel membership are never cached.
+        expect(mockDatabase.channel.findUnique).toHaveBeenCalled();
+        expect(mockDatabase.channelMembership.findUnique).toHaveBeenCalled();
+        // The role lookup itself did come from cache.
+        expect(mockDatabase.userRoles.findMany).not.toHaveBeenCalled();
       });
     });
   });

--- a/backend/src/roles/permissions.service.ts
+++ b/backend/src/roles/permissions.service.ts
@@ -2,18 +2,67 @@ import { RbacResourceType } from '@/auth/rbac-resource.decorator';
 import { DatabaseService } from '@/database/database.service';
 import { Injectable, Logger } from '@nestjs/common';
 import { RbacActions } from '@prisma/client';
+import {
+  PermissionScope,
+  PermissionsCacheService,
+} from './permissions-cache.service';
 
 /**
  * RBAC permission verification (hot path — runs on every guarded request).
  *
  * Extracted from RolesService so that verification is separate from role
  * management (CRUD, default-role setup), which remains in RolesService.
+ *
+ * The two `userRoles.findMany` lookups (instance-level and community-level)
+ * are cached via PermissionsCacheService — see that service's doc comment
+ * for the epoch-based invalidation design. Every other lookup in this file
+ * (channel/message/DM/alias-group resolution, private-channel and DM
+ * membership checks) stays on the direct DB path: those are either cheap
+ * primary-key lookups or correctness-sensitive membership checks that the
+ * cache design intentionally excludes.
  */
 @Injectable()
 export class PermissionsService {
   private readonly logger = new Logger(PermissionsService.name);
 
-  constructor(private readonly databaseService: DatabaseService) {}
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly permissionsCacheService: PermissionsCacheService,
+  ) {}
+
+  /**
+   * Resolves the flattened `actions` for a user/scope, consulting the cache
+   * first. On a cache hit, `dbQuery` is never called. On a miss, `dbQuery`
+   * runs and — unless the cache was unavailable — the result is written
+   * back under the epochs captured at miss time.
+   */
+  private async resolveActions(
+    userId: string,
+    scope: PermissionScope,
+    dbQuery: () => Promise<RbacActions[]>,
+  ): Promise<RbacActions[]> {
+    const cacheResult = await this.permissionsCacheService.getCachedActions(
+      userId,
+      scope,
+    );
+
+    if (cacheResult.status === 'hit') {
+      return cacheResult.actions;
+    }
+
+    const actions = await dbQuery();
+
+    if (cacheResult.status === 'miss') {
+      await this.permissionsCacheService.setCachedActions(
+        userId,
+        scope,
+        cacheResult.epochs,
+        actions,
+      );
+    }
+
+    return actions;
+  }
 
   async verifyActionsForUserAndResource(
     userId: string,
@@ -26,18 +75,25 @@ export class PermissionsService {
       resourceId === undefined ||
       resourceType === RbacResourceType.INSTANCE
     ) {
-      const userRoles = await this.databaseService.userRoles.findMany({
-        where: {
-          userId,
-          isInstanceRole: true,
-        },
-        include: {
-          role: true,
-        },
-      });
+      const allActions = await this.resolveActions(
+        userId,
+        { kind: 'instance' },
+        async () => {
+          const userRoles = await this.databaseService.userRoles.findMany({
+            where: {
+              userId,
+              isInstanceRole: true,
+            },
+            include: {
+              role: true,
+            },
+          });
 
-      const roles = userRoles.map((ur) => ur.role);
-      const allActions = roles.flatMap((role) => role.actions);
+          const roles = userRoles.map((ur) => ur.role);
+          return roles.flatMap((role) => role.actions);
+        },
+      );
+
       return action.every((a) => allActions.includes(a));
     }
 
@@ -176,19 +232,25 @@ export class PermissionsService {
     }
 
     // Check user roles in the resolved community
-    const userRoles = await this.databaseService.userRoles.findMany({
-      where: {
-        userId,
-        communityId,
-        isInstanceRole: false,
-      },
-      include: {
-        role: true,
-      },
-    });
+    const allActions = await this.resolveActions(
+      userId,
+      { kind: 'community', communityId },
+      async () => {
+        const userRoles = await this.databaseService.userRoles.findMany({
+          where: {
+            userId,
+            communityId,
+            isInstanceRole: false,
+          },
+          include: {
+            role: true,
+          },
+        });
 
-    const roles = userRoles.map((ur) => ur.role);
-    const allActions = roles.flatMap((role) => role.actions);
+        const roles = userRoles.map((ur) => ur.role);
+        return roles.flatMap((role) => role.actions);
+      },
+    );
 
     // Check if the user has all the required actions
     return action.every((a) => allActions.includes(a));

--- a/backend/src/roles/roles.module.ts
+++ b/backend/src/roles/roles.module.ts
@@ -1,13 +1,15 @@
 import { Module } from '@nestjs/common';
 import { RolesService } from './roles.service';
 import { PermissionsService } from './permissions.service';
+import { PermissionsCacheService } from './permissions-cache.service';
 import { DatabaseModule } from '@/database/database.module';
+import { RedisModule } from '@/redis/redis.module';
 import { RolesController } from './roles.controller';
 
 @Module({
-  imports: [DatabaseModule],
-  providers: [RolesService, PermissionsService],
-  exports: [RolesService, PermissionsService],
+  imports: [DatabaseModule, RedisModule],
+  providers: [RolesService, PermissionsService, PermissionsCacheService],
+  exports: [RolesService, PermissionsService, PermissionsCacheService],
   controllers: [RolesController],
 })
 export class RolesModule {}

--- a/backend/src/roles/roles.service.spec.ts
+++ b/backend/src/roles/roles.service.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed } from '@suites/unit';
+import type { Mocked } from '@suites/doubles.jest';
 import { RolesService } from './roles.service';
 import { DatabaseService } from '@/database/database.service';
+import { PermissionsCacheService } from './permissions-cache.service';
 import { RbacActions } from '@prisma/client';
 import {
   createMockDatabase,
@@ -19,16 +21,18 @@ import {
 describe('RolesService', () => {
   let service: RolesService;
   let mockDatabase: ReturnType<typeof createMockDatabase>;
+  let permissionsCacheService: Mocked<PermissionsCacheService>;
 
   beforeEach(async () => {
     mockDatabase = createMockDatabase();
 
-    const { unit } = await TestBed.solitary(RolesService)
+    const { unit, unitRef } = await TestBed.solitary(RolesService)
       .mock(DatabaseService)
       .final(mockDatabase)
       .compile();
 
     service = unit;
+    permissionsCacheService = unitRef.get(PermissionsCacheService);
   });
 
   afterEach(() => {
@@ -2030,6 +2034,298 @@ describe('RolesService', () => {
       );
 
       expect(result.roles[0].position).toBe(10);
+    });
+  });
+
+  // ===========================================================================
+  // Permission cache epoch bumps — one assertion per mutation site enumerated
+  // in the RBAC permission cache task. Every create/delete of a UserRoles row
+  // must bump the affected user's epoch; every create/update/delete of a Role
+  // row must bump the owning community's epoch (or the instance epoch for
+  // communityId: null roles).
+  // ===========================================================================
+  describe('Permission cache epoch bumps', () => {
+    it('createDefaultCommunityRoles bumps the community epoch', async () => {
+      const communityId = 'community-bump-1';
+      mockDatabase.role.create.mockResolvedValue(
+        RoleFactory.build({ name: 'Community Admin', communityId }),
+      );
+
+      await service.createDefaultCommunityRoles(communityId);
+
+      expect(permissionsCacheService.bumpCommunityEpoch).toHaveBeenCalledWith(
+        communityId,
+      );
+    });
+
+    it('assignUserToCommunityRole bumps the target user epoch', async () => {
+      const userId = 'user-bump-1';
+      const communityId = 'community-bump-1';
+      const roleId = 'role-bump-1';
+      mockDatabase.role.findUnique.mockResolvedValue(
+        RoleFactory.build({ id: roleId, communityId }),
+      );
+      mockDatabase.userRoles.create.mockResolvedValue({});
+
+      await service.assignUserToCommunityRole(userId, communityId, roleId);
+
+      expect(permissionsCacheService.bumpUserEpoch).toHaveBeenCalledWith(
+        userId,
+      );
+    });
+
+    it('createMemberRoleForCommunity bumps the community epoch', async () => {
+      const communityId = 'community-bump-2';
+      mockDatabase.role.create.mockResolvedValue(
+        RoleFactory.build({ name: 'Member', communityId }),
+      );
+
+      await service.createMemberRoleForCommunity(communityId);
+
+      expect(permissionsCacheService.bumpCommunityEpoch).toHaveBeenCalledWith(
+        communityId,
+      );
+    });
+
+    it('resetDefaultCommunityRoles bumps the community epoch', async () => {
+      const communityId = 'community-bump-3';
+      mockDatabase.$transaction.mockImplementation((fn: any) =>
+        fn(mockDatabase),
+      );
+      mockDatabase.role.findFirst.mockResolvedValue(
+        RoleFactory.build({ communityId }),
+      );
+      mockDatabase.role.update.mockResolvedValue(RoleFactory.build());
+      mockDatabase.role.findMany.mockResolvedValue([]);
+
+      await service.resetDefaultCommunityRoles(communityId);
+
+      expect(permissionsCacheService.bumpCommunityEpoch).toHaveBeenCalledWith(
+        communityId,
+      );
+    });
+
+    it('createCommunityRole bumps the community epoch', async () => {
+      const communityId = 'community-bump-4';
+      mockDatabase.role.findFirst.mockResolvedValue(null);
+      mockDatabase.role.aggregate.mockResolvedValue({ _max: { position: 20 } });
+      mockDatabase.role.create.mockResolvedValue(
+        RoleFactory.build({ communityId }),
+      );
+
+      await service.createCommunityRole(communityId, {
+        name: 'New Role',
+        actions: [RbacActions.CREATE_MESSAGE],
+      });
+
+      expect(permissionsCacheService.bumpCommunityEpoch).toHaveBeenCalledWith(
+        communityId,
+      );
+    });
+
+    it('updateRole bumps the community epoch', async () => {
+      const communityId = 'community-bump-5';
+      const roleId = 'role-bump-5';
+      const existingRole = RoleFactory.build({
+        id: roleId,
+        communityId,
+        isDefault: false,
+      });
+      mockDatabase.role.findUnique.mockResolvedValue(existingRole);
+      mockDatabase.role.update.mockResolvedValue({
+        ...existingRole,
+        actions: [RbacActions.READ_MESSAGE],
+      });
+
+      await service.updateRole(roleId, communityId, {
+        actions: [RbacActions.READ_MESSAGE],
+      });
+
+      expect(permissionsCacheService.bumpCommunityEpoch).toHaveBeenCalledWith(
+        communityId,
+      );
+    });
+
+    it('deleteRole bumps the community epoch', async () => {
+      const communityId = 'community-bump-6';
+      const roleId = 'role-bump-6';
+      const role = RoleFactory.build({
+        id: roleId,
+        communityId,
+        isDefault: false,
+      });
+      mockDatabase.role.findUnique.mockResolvedValue({
+        ...role,
+        UserRoles: [],
+      });
+      mockDatabase.role.delete.mockResolvedValue(role);
+
+      await service.deleteRole(roleId, communityId);
+
+      expect(permissionsCacheService.bumpCommunityEpoch).toHaveBeenCalledWith(
+        communityId,
+      );
+    });
+
+    it('removeUserFromCommunityRole bumps the target user epoch', async () => {
+      const userId = 'user-bump-2';
+      const communityId = 'community-bump-7';
+      const roleId = 'role-bump-7';
+      const userRole = { id: 'user-role-bump', userId, communityId, roleId };
+      mockDatabase.userRoles.findFirst.mockResolvedValue(userRole);
+      mockDatabase.userRoles.delete.mockResolvedValue(userRole);
+
+      await service.removeUserFromCommunityRole(userId, communityId, roleId);
+
+      expect(permissionsCacheService.bumpUserEpoch).toHaveBeenCalledWith(
+        userId,
+      );
+    });
+
+    it('createDefaultInstanceRole bumps the instance epoch', async () => {
+      mockDatabase.role.findFirst.mockResolvedValue(null);
+      mockDatabase.role.create.mockResolvedValue(
+        RoleFactory.build({ communityId: null }),
+      );
+
+      await service.createDefaultInstanceRole();
+
+      expect(permissionsCacheService.bumpInstanceEpoch).toHaveBeenCalled();
+    });
+
+    it('createInstanceRole bumps the instance epoch', async () => {
+      mockDatabase.role.findFirst.mockResolvedValue(null);
+      mockDatabase.role.create.mockResolvedValue(
+        RoleFactory.build({ communityId: null }),
+      );
+
+      await service.createInstanceRole('Custom Instance Role', [
+        RbacActions.READ_USER,
+      ]);
+
+      expect(permissionsCacheService.bumpInstanceEpoch).toHaveBeenCalled();
+    });
+
+    it('updateInstanceRole bumps the instance epoch', async () => {
+      const roleId = 'role-bump-8';
+      const existingRole = RoleFactory.build({
+        id: roleId,
+        communityId: null,
+        isDefault: false,
+      });
+      mockDatabase.role.findUnique.mockResolvedValue(existingRole);
+      mockDatabase.role.update.mockResolvedValue({
+        ...existingRole,
+        actions: [RbacActions.READ_USER],
+      });
+
+      await service.updateInstanceRole(roleId, {
+        actions: [RbacActions.READ_USER],
+      });
+
+      expect(permissionsCacheService.bumpInstanceEpoch).toHaveBeenCalled();
+    });
+
+    it('deleteInstanceRole bumps the instance epoch', async () => {
+      const roleId = 'role-bump-9';
+      const role = RoleFactory.build({
+        id: roleId,
+        communityId: null,
+        name: 'Custom Instance Role',
+      });
+      mockDatabase.role.findUnique.mockResolvedValue({
+        ...role,
+        UserRoles: [],
+      });
+      mockDatabase.role.delete.mockResolvedValue(role);
+
+      await service.deleteInstanceRole(roleId);
+
+      expect(permissionsCacheService.bumpInstanceEpoch).toHaveBeenCalled();
+    });
+
+    it('assignUserToInstanceRole bumps the target user epoch', async () => {
+      const userId = 'user-bump-3';
+      const roleId = 'role-bump-10';
+      mockDatabase.role.findUnique.mockResolvedValue(
+        RoleFactory.build({ id: roleId }),
+      );
+      mockDatabase.userRoles.findFirst.mockResolvedValue(null);
+      mockDatabase.userRoles.create.mockResolvedValue({});
+
+      await service.assignUserToInstanceRole(userId, roleId);
+
+      expect(permissionsCacheService.bumpUserEpoch).toHaveBeenCalledWith(
+        userId,
+      );
+    });
+
+    it('removeUserFromInstanceRole bumps the target user epoch', async () => {
+      const userId = 'user-bump-4';
+      const userRole = { id: 'user-role-bump-2' };
+      mockDatabase.userRoles.findFirst.mockResolvedValue(userRole);
+      mockDatabase.userRoles.delete.mockResolvedValue(userRole);
+
+      await service.removeUserFromInstanceRole(userId, 'role-bump-11');
+
+      expect(permissionsCacheService.bumpUserEpoch).toHaveBeenCalledWith(
+        userId,
+      );
+    });
+
+    it('createDefaultCommunityCreatorRole bumps the instance epoch', async () => {
+      mockDatabase.role.findFirst.mockResolvedValue(null);
+      mockDatabase.role.create.mockResolvedValue(
+        RoleFactory.build({ communityId: null }),
+      );
+
+      await service.createDefaultCommunityCreatorRole();
+
+      expect(permissionsCacheService.bumpInstanceEpoch).toHaveBeenCalled();
+    });
+
+    it('reorderRoles bumps the community epoch', async () => {
+      const communityId = 'community-bump-8';
+      const adminRole = RoleFactory.buildAdmin({ communityId });
+      const memberRole = RoleFactory.buildMember({
+        communityId,
+        name: 'Member',
+      });
+
+      mockDatabase.role.findMany.mockResolvedValueOnce([adminRole, memberRole]);
+      mockDatabase.role.update.mockResolvedValue({});
+      mockDatabase.role.findMany.mockResolvedValueOnce([
+        { ...adminRole, position: 10 },
+        { ...memberRole, position: 100 },
+      ]);
+
+      await service.reorderRoles(communityId, [adminRole.id]);
+
+      expect(permissionsCacheService.bumpCommunityEpoch).toHaveBeenCalledWith(
+        communityId,
+      );
+    });
+
+    it('ensureDefaultInstanceRolesExist bumps the instance epoch for each newly created role', async () => {
+      mockDatabase.role.findFirst.mockResolvedValue(null);
+      mockDatabase.role.create.mockResolvedValue(
+        RoleFactory.build({ communityId: null, isDefault: true }),
+      );
+
+      await service.ensureDefaultInstanceRolesExist();
+
+      // 4 default instance roles, all missing -> 4 creates -> 4 bumps
+      expect(permissionsCacheService.bumpInstanceEpoch).toHaveBeenCalledTimes(
+        4,
+      );
+    });
+
+    it('ensureDefaultInstanceRolesExist does not bump when the role already exists', async () => {
+      mockDatabase.role.findFirst.mockResolvedValue(RoleFactory.build());
+
+      await service.ensureDefaultInstanceRolesExist();
+
+      expect(permissionsCacheService.bumpInstanceEpoch).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/roles/roles.service.spec.ts
+++ b/backend/src/roles/roles.service.spec.ts
@@ -2,7 +2,10 @@ import { TestBed } from '@suites/unit';
 import type { Mocked } from '@suites/doubles.jest';
 import { RolesService } from './roles.service';
 import { DatabaseService } from '@/database/database.service';
-import { PermissionsCacheService } from './permissions-cache.service';
+import {
+  PermissionsCacheService,
+  type EpochBump,
+} from './permissions-cache.service';
 import { RbacActions } from '@prisma/client';
 import {
   createMockDatabase,
@@ -2326,6 +2329,267 @@ describe('RolesService', () => {
       await service.ensureDefaultInstanceRolesExist();
 
       expect(permissionsCacheService.bumpInstanceEpoch).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // Deferred epoch bumps — when a method runs inside a caller-owned
+  // transaction (tx + pendingBumps collector), it must NOT bump during the
+  // transaction; it records the bump on the collector instead, and the
+  // transaction owner flushes after commit via executeBumps. Bumping while
+  // the transaction is open would let a concurrent reader cache pre-commit
+  // permission data under the post-commit epoch.
+  // ===========================================================================
+  describe('Deferred epoch bumps inside caller-owned transactions', () => {
+    const expectNoImmediateBumps = () => {
+      expect(permissionsCacheService.bumpUserEpoch).not.toHaveBeenCalled();
+      expect(permissionsCacheService.bumpCommunityEpoch).not.toHaveBeenCalled();
+      expect(permissionsCacheService.bumpInstanceEpoch).not.toHaveBeenCalled();
+      expect(permissionsCacheService.executeBump).not.toHaveBeenCalled();
+      expect(permissionsCacheService.executeBumps).not.toHaveBeenCalled();
+    };
+
+    it('createDefaultCommunityRoles defers the community bump when tx-nested', async () => {
+      const communityId = 'community-defer-1';
+      const pendingBumps: EpochBump[] = [];
+      mockDatabase.role.create.mockResolvedValue(
+        RoleFactory.build({ name: 'Community Admin', communityId }),
+      );
+
+      await service.createDefaultCommunityRoles(
+        communityId,
+        mockDatabase as any,
+        pendingBumps,
+      );
+
+      expectNoImmediateBumps();
+      expect(pendingBumps).toEqual([{ kind: 'community', communityId }]);
+    });
+
+    it('assignUserToCommunityRole defers the user bump when tx-nested', async () => {
+      const userId = 'user-defer-1';
+      const communityId = 'community-defer-2';
+      const roleId = 'role-defer-1';
+      const pendingBumps: EpochBump[] = [];
+      mockDatabase.role.findUnique.mockResolvedValue(
+        RoleFactory.build({ id: roleId, communityId }),
+      );
+      mockDatabase.userRoles.create.mockResolvedValue({});
+
+      await service.assignUserToCommunityRole(
+        userId,
+        communityId,
+        roleId,
+        mockDatabase as any,
+        pendingBumps,
+      );
+
+      expectNoImmediateBumps();
+      expect(pendingBumps).toEqual([{ kind: 'user', userId }]);
+    });
+
+    it('createMemberRoleForCommunity defers the community bump when tx-nested', async () => {
+      const communityId = 'community-defer-3';
+      const pendingBumps: EpochBump[] = [];
+      mockDatabase.role.create.mockResolvedValue(
+        RoleFactory.build({ name: 'Member', communityId }),
+      );
+
+      await service.createMemberRoleForCommunity(
+        communityId,
+        mockDatabase as any,
+        pendingBumps,
+      );
+
+      expectNoImmediateBumps();
+      expect(pendingBumps).toEqual([{ kind: 'community', communityId }]);
+    });
+
+    it('createCommunityRole defers the community bump when tx-nested', async () => {
+      const communityId = 'community-defer-4';
+      const pendingBumps: EpochBump[] = [];
+      mockDatabase.role.findFirst.mockResolvedValue(null);
+      mockDatabase.role.aggregate.mockResolvedValue({ _max: { position: 20 } });
+      mockDatabase.role.create.mockResolvedValue(
+        RoleFactory.build({ communityId }),
+      );
+
+      await service.createCommunityRole(
+        communityId,
+        { name: 'New Role', actions: [RbacActions.CREATE_MESSAGE] },
+        undefined,
+        undefined,
+        mockDatabase as any,
+        pendingBumps,
+      );
+
+      expectNoImmediateBumps();
+      expect(pendingBumps).toEqual([{ kind: 'community', communityId }]);
+    });
+
+    it('updateRole defers the community bump when tx-nested', async () => {
+      const communityId = 'community-defer-5';
+      const roleId = 'role-defer-5';
+      const pendingBumps: EpochBump[] = [];
+      const existingRole = RoleFactory.build({
+        id: roleId,
+        communityId,
+        isDefault: false,
+      });
+      mockDatabase.role.findUnique.mockResolvedValue(existingRole);
+      mockDatabase.role.update.mockResolvedValue({
+        ...existingRole,
+        actions: [RbacActions.READ_MESSAGE],
+      });
+
+      await service.updateRole(
+        roleId,
+        communityId,
+        { actions: [RbacActions.READ_MESSAGE] },
+        undefined,
+        undefined,
+        mockDatabase as any,
+        pendingBumps,
+      );
+
+      expectNoImmediateBumps();
+      expect(pendingBumps).toEqual([{ kind: 'community', communityId }]);
+    });
+
+    it('deleteRole defers the community bump when tx-nested', async () => {
+      const communityId = 'community-defer-6';
+      const roleId = 'role-defer-6';
+      const pendingBumps: EpochBump[] = [];
+      const role = RoleFactory.build({
+        id: roleId,
+        communityId,
+        isDefault: false,
+      });
+      mockDatabase.role.findUnique.mockResolvedValue({
+        ...role,
+        UserRoles: [],
+      });
+      mockDatabase.role.delete.mockResolvedValue(role);
+
+      await service.deleteRole(
+        roleId,
+        communityId,
+        mockDatabase as any,
+        pendingBumps,
+      );
+
+      expectNoImmediateBumps();
+      expect(pendingBumps).toEqual([{ kind: 'community', communityId }]);
+    });
+
+    it('removeUserFromCommunityRole defers the user bump when tx-nested', async () => {
+      const userId = 'user-defer-2';
+      const communityId = 'community-defer-7';
+      const roleId = 'role-defer-7';
+      const pendingBumps: EpochBump[] = [];
+      const userRole = { id: 'user-role-defer', userId, communityId, roleId };
+      mockDatabase.userRoles.findFirst.mockResolvedValue(userRole);
+      mockDatabase.userRoles.delete.mockResolvedValue(userRole);
+
+      await service.removeUserFromCommunityRole(
+        userId,
+        communityId,
+        roleId,
+        mockDatabase as any,
+        pendingBumps,
+      );
+
+      expectNoImmediateBumps();
+      expect(pendingBumps).toEqual([{ kind: 'user', userId }]);
+    });
+
+    it('createDefaultInstanceRole defers the instance bump when tx-nested', async () => {
+      const pendingBumps: EpochBump[] = [];
+      mockDatabase.role.findFirst.mockResolvedValue(null);
+      mockDatabase.role.create.mockResolvedValue(
+        RoleFactory.build({ communityId: null }),
+      );
+
+      await service.createDefaultInstanceRole(
+        mockDatabase as any,
+        pendingBumps,
+      );
+
+      expectNoImmediateBumps();
+      expect(pendingBumps).toEqual([{ kind: 'instance' }]);
+    });
+
+    it('assignUserToInstanceRole defers the user bump when tx-nested', async () => {
+      const userId = 'user-defer-3';
+      const roleId = 'role-defer-8';
+      const pendingBumps: EpochBump[] = [];
+      mockDatabase.role.findUnique.mockResolvedValue(
+        RoleFactory.build({ id: roleId }),
+      );
+      mockDatabase.userRoles.findFirst.mockResolvedValue(null);
+      mockDatabase.userRoles.create.mockResolvedValue({});
+
+      await service.assignUserToInstanceRole(
+        userId,
+        roleId,
+        mockDatabase as any,
+        pendingBumps,
+      );
+
+      expectNoImmediateBumps();
+      expect(pendingBumps).toEqual([{ kind: 'user', userId }]);
+    });
+
+    it('createDefaultCommunityCreatorRole defers the instance bump when tx-nested', async () => {
+      const pendingBumps: EpochBump[] = [];
+      mockDatabase.role.findFirst.mockResolvedValue(null);
+      mockDatabase.role.create.mockResolvedValue(
+        RoleFactory.build({ communityId: null }),
+      );
+
+      await service.createDefaultCommunityCreatorRole(
+        mockDatabase as any,
+        pendingBumps,
+      );
+
+      expectNoImmediateBumps();
+      expect(pendingBumps).toEqual([{ kind: 'instance' }]);
+    });
+
+    it('does not record a bump when the idempotent create finds an existing role', async () => {
+      const pendingBumps: EpochBump[] = [];
+      mockDatabase.role.findFirst.mockResolvedValue(
+        RoleFactory.build({ communityId: null }),
+      );
+
+      await service.createDefaultInstanceRole(
+        mockDatabase as any,
+        pendingBumps,
+      );
+
+      expectNoImmediateBumps();
+      expect(pendingBumps).toEqual([]);
+    });
+
+    it('falls back to an immediate bump when tx is given without a collector', async () => {
+      const userId = 'user-defer-fallback';
+      const communityId = 'community-defer-8';
+      const roleId = 'role-defer-9';
+      mockDatabase.role.findUnique.mockResolvedValue(
+        RoleFactory.build({ id: roleId, communityId }),
+      );
+      mockDatabase.userRoles.create.mockResolvedValue({});
+
+      await service.assignUserToCommunityRole(
+        userId,
+        communityId,
+        roleId,
+        mockDatabase as any,
+      );
+
+      expect(permissionsCacheService.bumpUserEpoch).toHaveBeenCalledWith(
+        userId,
+      );
     });
   });
 });

--- a/backend/src/roles/roles.service.ts
+++ b/backend/src/roles/roles.service.ts
@@ -2,6 +2,7 @@ import { DatabaseService } from '@/database/database.service';
 import { isPrismaError } from '@/common/utils/prisma.utils';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { RoomEvents } from '@/rooms/room-subscription.events';
+import { PermissionsCacheService } from './permissions-cache.service';
 import {
   Injectable,
   Logger,
@@ -37,6 +38,7 @@ export class RolesService implements OnModuleInit {
   constructor(
     private readonly databaseService: DatabaseService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly permissionsCacheService: PermissionsCacheService,
   ) {}
 
   /**
@@ -195,6 +197,9 @@ export class RolesService implements OnModuleInit {
       }
     }
 
+    // Role definitions changed for this community.
+    await this.permissionsCacheService.bumpCommunityEpoch(communityId);
+
     return adminRoleId!;
   }
 
@@ -223,6 +228,12 @@ export class RolesService implements OnModuleInit {
         isInstanceRole: false,
       },
     });
+
+    // Role assignment changed for this user — always bump, even inside a
+    // transaction (unlike the event emission below): worst case is a
+    // spurious cache miss if the transaction later rolls back, which is
+    // safe. A skipped bump is not.
+    await this.permissionsCacheService.bumpUserEpoch(userId);
 
     // Only emit when not called within a transaction (e.g., community creation)
     if (!tx) {
@@ -325,6 +336,8 @@ export class RolesService implements OnModuleInit {
       },
     });
 
+    await this.permissionsCacheService.bumpCommunityEpoch(communityId);
+
     return role.id;
   }
 
@@ -366,6 +379,8 @@ export class RolesService implements OnModuleInit {
         }
       }
     });
+
+    await this.permissionsCacheService.bumpCommunityEpoch(communityId);
 
     this.logger.log(`Reset default roles for community ${communityId}`);
     return this.getCommunityRoles(communityId);
@@ -465,6 +480,8 @@ export class RolesService implements OnModuleInit {
     });
 
     this.logger.log(`Reordered roles for community ${communityId}`);
+
+    await this.permissionsCacheService.bumpCommunityEpoch(communityId);
 
     // Emit per-role events with correct payload shape
     for (const roleId of reorderableIds) {
@@ -570,6 +587,8 @@ export class RolesService implements OnModuleInit {
     this.logger.log(
       `Created custom role "${createRoleDto.name}" for community ${communityId}`,
     );
+
+    await this.permissionsCacheService.bumpCommunityEpoch(communityId);
 
     // Only emit when not called within a transaction (e.g., community creation)
     if (!tx) {
@@ -698,6 +717,8 @@ export class RolesService implements OnModuleInit {
 
     this.logger.log(`Updated role ${roleId}`);
 
+    await this.permissionsCacheService.bumpCommunityEpoch(communityId);
+
     if (!tx) {
       this.eventEmitter.emit(RoomEvents.ROLE_UPDATED, {
         communityId,
@@ -763,6 +784,8 @@ export class RolesService implements OnModuleInit {
 
     this.logger.log(`Deleted role ${roleId}`);
 
+    await this.permissionsCacheService.bumpCommunityEpoch(communityId);
+
     if (!tx) {
       this.eventEmitter.emit(RoomEvents.ROLE_DELETED, {
         communityId,
@@ -803,6 +826,8 @@ export class RolesService implements OnModuleInit {
     this.logger.log(
       `Removed user ${userId} from role ${roleId} in community ${communityId}`,
     );
+
+    await this.permissionsCacheService.bumpUserEpoch(userId);
 
     if (!tx) {
       this.eventEmitter.emit(RoomEvents.ROLE_UNASSIGNED, {
@@ -877,6 +902,8 @@ export class RolesService implements OnModuleInit {
       },
     });
 
+    await this.permissionsCacheService.bumpInstanceEpoch();
+
     this.logger.log(`Created default instance admin role: ${role.id}`);
     return role.id;
   }
@@ -948,6 +975,8 @@ export class RolesService implements OnModuleInit {
         isDefault: false,
       },
     });
+
+    await this.permissionsCacheService.bumpInstanceEpoch();
 
     this.logger.log(`Created custom instance role: ${name}`);
 
@@ -1024,6 +1053,8 @@ export class RolesService implements OnModuleInit {
       },
     });
 
+    await this.permissionsCacheService.bumpInstanceEpoch();
+
     this.logger.log(`Updated instance role ${roleId}`);
 
     return {
@@ -1073,6 +1104,8 @@ export class RolesService implements OnModuleInit {
       where: { id: roleId },
     });
 
+    await this.permissionsCacheService.bumpInstanceEpoch();
+
     this.logger.log(`Deleted instance role ${roleId}`);
   }
 
@@ -1117,6 +1150,8 @@ export class RolesService implements OnModuleInit {
       },
     });
 
+    await this.permissionsCacheService.bumpUserEpoch(userId);
+
     this.logger.log(
       `Assigned user ${userId} to instance role ${roleId} (${role.name})`,
     );
@@ -1144,6 +1179,8 @@ export class RolesService implements OnModuleInit {
     await this.databaseService.userRoles.delete({
       where: { id: userRole.id },
     });
+
+    await this.permissionsCacheService.bumpUserEpoch(userId);
 
     this.logger.log(`Removed user ${userId} from instance role ${roleId}`);
   }
@@ -1210,6 +1247,8 @@ export class RolesService implements OnModuleInit {
         isDefault: true,
       },
     });
+
+    await this.permissionsCacheService.bumpInstanceEpoch();
 
     this.logger.log(`Created default Community Creator role: ${role.id}`);
     return role.id;
@@ -1286,6 +1325,8 @@ export class RolesService implements OnModuleInit {
           isDefault: true,
         },
       });
+
+      await this.permissionsCacheService.bumpInstanceEpoch();
 
       this.logger.log(`Created default instance role: ${roleConfig.name}`);
       return role.id;

--- a/backend/src/roles/roles.service.ts
+++ b/backend/src/roles/roles.service.ts
@@ -2,7 +2,10 @@ import { DatabaseService } from '@/database/database.service';
 import { isPrismaError } from '@/common/utils/prisma.utils';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { RoomEvents } from '@/rooms/room-subscription.events';
-import { PermissionsCacheService } from './permissions-cache.service';
+import {
+  EpochBump,
+  PermissionsCacheService,
+} from './permissions-cache.service';
 import {
   Injectable,
   Logger,
@@ -54,6 +57,47 @@ export class RolesService implements OnModuleInit {
       this.logger.warn(
         `Could not ensure default instance roles exist: ${message}`,
       );
+    }
+  }
+
+  /**
+   * Epoch-bump helper for role mutations that can run inside a caller-owned
+   * transaction. Two modes:
+   *
+   * - Without `tx`: the mutation's write is already committed, so bump
+   *   immediately (awaited) — the invalidation is visible before the
+   *   mutation returns.
+   * - With `tx` + `pendingBumps`: the write is NOT committed yet. Bumping
+   *   now would open a race where a concurrent reader misses under the new
+   *   epoch, reads pre-commit data from the DB, and caches it under the
+   *   post-commit epoch — a stale grant. So instead the bump is recorded on
+   *   the caller's collector; the transaction owner flushes it via
+   *   `PermissionsCacheService.executeBumps` right after `$transaction`
+   *   resolves. On rollback the collected bumps are never executed, which
+   *   is correct (nothing changed in the DB).
+   * - With `tx` but no collector (defensive fallback — every tx caller in
+   *   the codebase passes one): bump immediately anyway. That re-opens the
+   *   narrow pre-commit race above, but silently dropping the bump would be
+   *   strictly worse (guaranteed stale grant for up to the value TTL).
+   */
+  private async bumpNowOrDefer(
+    bump: EpochBump,
+    tx?: Prisma.TransactionClient,
+    pendingBumps?: EpochBump[],
+  ): Promise<void> {
+    if (tx && pendingBumps) {
+      pendingBumps.push(bump);
+      return;
+    }
+    switch (bump.kind) {
+      case 'user':
+        return this.permissionsCacheService.bumpUserEpoch(bump.userId);
+      case 'community':
+        return this.permissionsCacheService.bumpCommunityEpoch(
+          bump.communityId,
+        );
+      case 'instance':
+        return this.permissionsCacheService.bumpInstanceEpoch();
     }
   }
 
@@ -174,6 +218,7 @@ export class RolesService implements OnModuleInit {
   async createDefaultCommunityRoles(
     communityId: string,
     tx?: Prisma.TransactionClient,
+    pendingBumps?: EpochBump[],
   ): Promise<string> {
     const database = tx || this.databaseService;
     const defaultRoles = getDefaultCommunityRoles();
@@ -197,8 +242,13 @@ export class RolesService implements OnModuleInit {
       }
     }
 
-    // Role definitions changed for this community.
-    await this.permissionsCacheService.bumpCommunityEpoch(communityId);
+    // Role definitions changed for this community (bump deferred to after
+    // commit when running inside a caller-owned transaction).
+    await this.bumpNowOrDefer(
+      { kind: 'community', communityId },
+      tx,
+      pendingBumps,
+    );
 
     return adminRoleId!;
   }
@@ -211,6 +261,7 @@ export class RolesService implements OnModuleInit {
     communityId: string,
     roleId: string,
     tx?: Prisma.TransactionClient,
+    pendingBumps?: EpochBump[],
   ): Promise<void> {
     const database = tx || this.databaseService;
 
@@ -229,11 +280,10 @@ export class RolesService implements OnModuleInit {
       },
     });
 
-    // Role assignment changed for this user — always bump, even inside a
-    // transaction (unlike the event emission below): worst case is a
-    // spurious cache miss if the transaction later rolls back, which is
-    // safe. A skipped bump is not.
-    await this.permissionsCacheService.bumpUserEpoch(userId);
+    // Role assignment changed for this user. Like the event emission below,
+    // the bump must not happen while a caller-owned transaction is still
+    // open — see bumpNowOrDefer for the pre-commit race this avoids.
+    await this.bumpNowOrDefer({ kind: 'user', userId }, tx, pendingBumps);
 
     // Only emit when not called within a transaction (e.g., community creation)
     if (!tx) {
@@ -323,6 +373,7 @@ export class RolesService implements OnModuleInit {
   async createMemberRoleForCommunity(
     communityId: string,
     tx?: Prisma.TransactionClient,
+    pendingBumps?: EpochBump[],
   ): Promise<string> {
     const database = tx || this.databaseService;
 
@@ -336,7 +387,11 @@ export class RolesService implements OnModuleInit {
       },
     });
 
-    await this.permissionsCacheService.bumpCommunityEpoch(communityId);
+    await this.bumpNowOrDefer(
+      { kind: 'community', communityId },
+      tx,
+      pendingBumps,
+    );
 
     return role.id;
   }
@@ -507,6 +562,7 @@ export class RolesService implements OnModuleInit {
     userId?: string,
     userInstanceRole?: string,
     tx?: Prisma.TransactionClient,
+    pendingBumps?: EpochBump[],
   ): Promise<RoleDto> {
     const database = tx || this.databaseService;
 
@@ -588,7 +644,11 @@ export class RolesService implements OnModuleInit {
       `Created custom role "${createRoleDto.name}" for community ${communityId}`,
     );
 
-    await this.permissionsCacheService.bumpCommunityEpoch(communityId);
+    await this.bumpNowOrDefer(
+      { kind: 'community', communityId },
+      tx,
+      pendingBumps,
+    );
 
     // Only emit when not called within a transaction (e.g., community creation)
     if (!tx) {
@@ -619,6 +679,7 @@ export class RolesService implements OnModuleInit {
     userId?: string,
     userInstanceRole?: string,
     tx?: Prisma.TransactionClient,
+    pendingBumps?: EpochBump[],
   ): Promise<RoleDto> {
     const database = tx || this.databaseService;
 
@@ -717,7 +778,11 @@ export class RolesService implements OnModuleInit {
 
     this.logger.log(`Updated role ${roleId}`);
 
-    await this.permissionsCacheService.bumpCommunityEpoch(communityId);
+    await this.bumpNowOrDefer(
+      { kind: 'community', communityId },
+      tx,
+      pendingBumps,
+    );
 
     if (!tx) {
       this.eventEmitter.emit(RoomEvents.ROLE_UPDATED, {
@@ -744,6 +809,7 @@ export class RolesService implements OnModuleInit {
     roleId: string,
     communityId: string,
     tx?: Prisma.TransactionClient,
+    pendingBumps?: EpochBump[],
   ): Promise<void> {
     const database = tx || this.databaseService;
 
@@ -784,7 +850,11 @@ export class RolesService implements OnModuleInit {
 
     this.logger.log(`Deleted role ${roleId}`);
 
-    await this.permissionsCacheService.bumpCommunityEpoch(communityId);
+    await this.bumpNowOrDefer(
+      { kind: 'community', communityId },
+      tx,
+      pendingBumps,
+    );
 
     if (!tx) {
       this.eventEmitter.emit(RoomEvents.ROLE_DELETED, {
@@ -802,6 +872,7 @@ export class RolesService implements OnModuleInit {
     communityId: string,
     roleId: string,
     tx?: Prisma.TransactionClient,
+    pendingBumps?: EpochBump[],
   ): Promise<void> {
     const database = tx || this.databaseService;
 
@@ -827,7 +898,7 @@ export class RolesService implements OnModuleInit {
       `Removed user ${userId} from role ${roleId} in community ${communityId}`,
     );
 
-    await this.permissionsCacheService.bumpUserEpoch(userId);
+    await this.bumpNowOrDefer({ kind: 'user', userId }, tx, pendingBumps);
 
     if (!tx) {
       this.eventEmitter.emit(RoomEvents.ROLE_UNASSIGNED, {
@@ -878,6 +949,7 @@ export class RolesService implements OnModuleInit {
    */
   async createDefaultInstanceRole(
     tx?: Prisma.TransactionClient,
+    pendingBumps?: EpochBump[],
   ): Promise<string> {
     const database = tx || this.databaseService;
 
@@ -902,7 +974,7 @@ export class RolesService implements OnModuleInit {
       },
     });
 
-    await this.permissionsCacheService.bumpInstanceEpoch();
+    await this.bumpNowOrDefer({ kind: 'instance' }, tx, pendingBumps);
 
     this.logger.log(`Created default instance admin role: ${role.id}`);
     return role.id;
@@ -1116,6 +1188,7 @@ export class RolesService implements OnModuleInit {
     userId: string,
     roleId: string,
     tx?: Prisma.TransactionClient,
+    pendingBumps?: EpochBump[],
   ): Promise<void> {
     const database = tx || this.databaseService;
 
@@ -1150,7 +1223,7 @@ export class RolesService implements OnModuleInit {
       },
     });
 
-    await this.permissionsCacheService.bumpUserEpoch(userId);
+    await this.bumpNowOrDefer({ kind: 'user', userId }, tx, pendingBumps);
 
     this.logger.log(
       `Assigned user ${userId} to instance role ${roleId} (${role.name})`,
@@ -1224,6 +1297,7 @@ export class RolesService implements OnModuleInit {
    */
   async createDefaultCommunityCreatorRole(
     tx?: Prisma.TransactionClient,
+    pendingBumps?: EpochBump[],
   ): Promise<string> {
     const database = tx || this.databaseService;
 
@@ -1248,7 +1322,7 @@ export class RolesService implements OnModuleInit {
       },
     });
 
-    await this.permissionsCacheService.bumpInstanceEpoch();
+    await this.bumpNowOrDefer({ kind: 'instance' }, tx, pendingBumps);
 
     this.logger.log(`Created default Community Creator role: ${role.id}`);
     return role.id;

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -5,6 +5,7 @@ import { DatabaseService } from '@/database/database.service';
 import { InviteService } from '@/invite/invite.service';
 import { ChannelsService } from '@/channels/channels.service';
 import { RolesService } from '@/roles/roles.service';
+import { PermissionsCacheService } from '@/roles/permissions-cache.service';
 import {
   ConflictException,
   ForbiddenException,
@@ -28,6 +29,7 @@ describe('UserService', () => {
   let inviteService: Mocked<InviteService>;
   let channelsService: Mocked<ChannelsService>;
   let rolesService: Mocked<RolesService>;
+  let permissionsCacheService: Mocked<PermissionsCacheService>;
 
   beforeEach(async () => {
     mockDatabase = createMockDatabase();
@@ -41,6 +43,7 @@ describe('UserService', () => {
     inviteService = unitRef.get(InviteService);
     channelsService = unitRef.get(ChannelsService);
     rolesService = unitRef.get(RolesService);
+    permissionsCacheService = unitRef.get(PermissionsCacheService);
 
     // Mock bcrypt
     (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
@@ -362,6 +365,7 @@ describe('UserService', () => {
         communityId,
         memberRole.id,
         expect.anything(),
+        expect.any(Array),
       );
     });
 
@@ -397,6 +401,7 @@ describe('UserService', () => {
       expect(rolesService.createMemberRoleForCommunity).toHaveBeenCalledWith(
         communityId,
         expect.anything(),
+        expect.any(Array),
       );
     });
 
@@ -458,6 +463,107 @@ describe('UserService', () => {
       );
 
       expect(result).toEqual(newUser);
+    });
+
+    it('flushes deferred epoch bumps only after the transaction commits', async () => {
+      const communityId = 'community-123';
+      const invite = InstanceInviteFactory.build();
+      (invite as any).defaultCommunities = [
+        { id: 'dc-1', inviteId: invite.id, communityId },
+      ];
+      const newUser = UserFactory.build();
+      const memberRole = RoleFactory.buildMember();
+      const order: string[] = [];
+
+      mockDatabase.user.findFirst.mockResolvedValue(null);
+      mockDatabase.user.count.mockResolvedValue(1);
+      inviteService.validateInviteCode.mockResolvedValue(invite as any);
+      inviteService.redeemInviteWithTx.mockResolvedValue(invite as any);
+      mockDatabase.user.create.mockResolvedValue(newUser);
+      channelsService.addUserToGeneralChannel.mockResolvedValue(
+        undefined as any,
+      );
+      rolesService.getCommunityMemberRole.mockResolvedValue(memberRole as any);
+      // The (mocked) tx-nested role mutation records its bump on the
+      // collector the service passes in, like the real implementation does.
+      rolesService.assignUserToCommunityRole.mockImplementation(((
+        userId: string,
+        _communityId: string,
+        _roleId: string,
+        _tx: unknown,
+        bumps: any[],
+      ) => {
+        bumps.push({ kind: 'user', userId });
+        return Promise.resolve();
+      }) as any);
+
+      mockDatabase.$transaction.mockImplementation(async (cb: any) => {
+        const result = await cb(mockDatabase);
+        order.push('commit');
+        return result;
+      });
+      permissionsCacheService.executeBumps.mockImplementation(() => {
+        order.push('flush-bumps');
+        return Promise.resolve();
+      });
+
+      const result = await service.createUser(
+        'invite-code',
+        'user',
+        'password',
+      );
+
+      expect(result).toEqual(newUser);
+      // Bumps must flush strictly AFTER the transaction resolves (commit).
+      expect(order).toEqual(['commit', 'flush-bumps']);
+      expect(permissionsCacheService.executeBumps).toHaveBeenCalledWith([
+        { kind: 'user', userId: newUser.id },
+      ]);
+      expect(permissionsCacheService.bumpUserEpoch).not.toHaveBeenCalled();
+    });
+
+    it('does not flush epoch bumps when the transaction rolls back', async () => {
+      const communityId = 'community-123';
+      const invite = InstanceInviteFactory.build();
+      (invite as any).defaultCommunities = [
+        { id: 'dc-1', inviteId: invite.id, communityId },
+      ];
+      const newUser = UserFactory.build();
+      const memberRole = RoleFactory.buildMember();
+
+      mockDatabase.user.findFirst.mockResolvedValue(null);
+      mockDatabase.user.count.mockResolvedValue(1);
+      inviteService.validateInviteCode.mockResolvedValue(invite as any);
+      inviteService.redeemInviteWithTx.mockResolvedValue(invite as any);
+      mockDatabase.user.create.mockResolvedValue(newUser);
+      channelsService.addUserToGeneralChannel.mockResolvedValue(
+        undefined as any,
+      );
+      rolesService.getCommunityMemberRole.mockResolvedValue(memberRole as any);
+      rolesService.assignUserToCommunityRole.mockImplementation(((
+        userId: string,
+        _communityId: string,
+        _roleId: string,
+        _tx: unknown,
+        bumps: any[],
+      ) => {
+        bumps.push({ kind: 'user', userId });
+        return Promise.resolve();
+      }) as any);
+
+      // Simulate a commit failure AFTER the callback (and its bump
+      // collection) succeeded — the deferred bumps must never execute.
+      mockDatabase.$transaction.mockImplementation(async (cb: any) => {
+        await cb(mockDatabase);
+        throw new Error('commit failed');
+      });
+
+      await expect(
+        service.createUser('invite-code', 'user', 'password'),
+      ).rejects.toThrow('commit failed');
+
+      expect(permissionsCacheService.executeBumps).not.toHaveBeenCalled();
+      expect(permissionsCacheService.bumpUserEpoch).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -12,6 +12,10 @@ import { DatabaseService } from '../database/database.service';
 import { InviteService } from '../invite/invite.service';
 import { ChannelsService } from '../channels/channels.service';
 import { RolesService } from '../roles/roles.service';
+import {
+  EpochBump,
+  PermissionsCacheService,
+} from '../roles/permissions-cache.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { RoomEvents } from '@/rooms/room-subscription.events';
 import { UserEntity } from './dto/user-response.dto';
@@ -28,6 +32,7 @@ export class UserService {
     private channelsService: ChannelsService,
     private rolesService: RolesService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly permissionsCacheService: PermissionsCacheService,
   ) {}
 
   async findByUsername(username: string): Promise<User | null> {
@@ -71,6 +76,11 @@ export class UserService {
     const role = userCount === 0 ? InstanceRole.OWNER : InstanceRole.USER;
     const verified = userCount === 0;
     const hashedPassword = await bcrypt.hash(password, 10);
+
+    // Epoch bumps from the tx-nested role mutations below are collected here
+    // and executed only after the transaction commits (see
+    // PermissionsCacheService — bumping pre-commit races concurrent readers).
+    const pendingBumps: EpochBump[] = [];
 
     const user = await this.databaseService.$transaction(async (tx) => {
       const lowerName = username.toLowerCase();
@@ -136,6 +146,7 @@ export class UserService {
               await this.rolesService.createMemberRoleForCommunity(
                 communityId,
                 tx,
+                pendingBumps,
               );
               memberRole =
                 await this.rolesService.getCommunityMemberRole(communityId);
@@ -147,6 +158,7 @@ export class UserService {
                 communityId,
                 memberRole.id,
                 tx,
+                pendingBumps,
               );
               this.logger.log(
                 `Assigned Member role to user ${createdUser.id} in community ${communityId}`,
@@ -168,6 +180,11 @@ export class UserService {
 
       return createdUser;
     });
+
+    // Transaction committed — flush the deferred epoch bumps. On rollback
+    // this line is never reached, which is correct (nothing changed in the
+    // DB). executeBumps never throws (fail-open, logged).
+    await this.permissionsCacheService.executeBumps(pendingBumps);
 
     return user;
   }


### PR DESCRIPTION
## Summary
- Every guarded request was resolving permissions from the database (`userRoles.findMany` on each call through RbacGuard). This adds a transparent Redis cache in front of the two role-lookup queries.
- **Epoch-based invalidation** (no SCAN/pattern deletes): per-user and per-community epoch keys; cached values embed both epochs + 300s TTL, so any bump instantly orphans stale entries. All 22 role-assignment/definition mutation sites bump the right epoch (independently re-enumerated in review) — revocation is effectively immediate.
- **Transaction-safe**: tx-nested role mutations defer their bumps until after the enclosing transaction commits (collector pattern); rollback never flushes. This closes a pre-commit re-cache race.
- **Fail-open reads** mirroring `FailOpenThrottlerStorage`: 1500ms timeout race (slow Redis can't make permission checks slower than the DB path), status fast-path, 30s-throttled warns.
- Never cached: private-channel membership, DM membership, OWNER short-circuit, ban state — all stay live per-request.

## Test plan
- 2416 tests green (+57 for this change): cache hit/miss/epoch-invalidation, hang path (pending promise + fake timers), per-mutation-site bump assertions, commit→flush ordering + rollback→no-flush per nested-tx caller, dedupe/error-swallowing.
- Guards' allow/deny decisions unchanged (cached shape verified field-for-field against what the permission flow consumes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sAJfCfBfMm8chbZMsh5Y5