### PR TITLE
perf(frontend): stop presence events re-rendering whole member lists

### DIFF
--- a/frontend/src/__tests__/components/MemberList.test.tsx
+++ b/frontend/src/__tests__/components/MemberList.test.tsx
@@ -2,11 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, within } from '@testing-library/react';
 import { renderWithProviders } from '../test-utils';
 import MemberList, { type MemberData } from '../../components/Message/MemberList';
+import UserAvatar from '../../components/Common/UserAvatar';
 
-// Mock UserProfileContext
+// Mock UserProfileContext. openProfile must be referentially stable across
+// renders (like the real useCallback-backed context value) — otherwise
+// React.memo(MemberRow) can never bail out, since a fresh function reference
+// on every render would fail the shallow prop comparison regardless of
+// whether `member` changed.
+const { mockOpenProfile } = vi.hoisted(() => ({ mockOpenProfile: vi.fn() }));
 vi.mock('../../contexts/UserProfileContext', () => ({
   useUserProfile: () => ({
-    openProfile: vi.fn(),
+    openProfile: mockOpenProfile,
   }),
 }));
 
@@ -15,9 +21,12 @@ vi.mock('../../components/Moderation', () => ({
   UserModerationMenu: () => null,
 }));
 
-// Mock UserAvatar to avoid FileCacheProvider dependency
+// Mock UserAvatar to avoid FileCacheProvider dependency. Wrapped in vi.fn()
+// so tests can inspect exactly which member ids re-rendered — UserAvatar is
+// only invoked when its parent MemberRow's function body actually runs, so
+// call counts are a reliable proxy for row re-renders.
 vi.mock('../../components/Common/UserAvatar', () => ({
-  default: () => <div data-testid="user-avatar" />,
+  default: vi.fn(() => <div data-testid="user-avatar" />),
 }));
 
 function createMember(overrides: Partial<MemberData> = {}): MemberData {
@@ -149,5 +158,38 @@ describe('MemberList', () => {
     expect(screen.getByText(/Admin — 2/)).toBeInTheDocument();
     // Online section should show count of 1
     expect(screen.getByText(/Online — 1/)).toBeInTheDocument();
+  });
+
+  describe('MemberRow memoization', () => {
+    it('re-renders only the member row whose object identity changed, not the whole list', () => {
+      const memberA = createMember({ id: 'user-a', username: 'alice', displayName: 'Alice', isOnline: false });
+      const memberB = createMember({ id: 'user-b', username: 'bob', displayName: 'Bob', isOnline: false });
+      const memberC = createMember({ id: 'user-c', username: 'carol', displayName: 'Carol', isOnline: false });
+
+      const { rerender } = renderWithProviders(
+        <MemberList members={[memberA, memberB, memberC]} title="Members" />,
+      );
+
+      const renderCount = (id: string) =>
+        vi.mocked(UserAvatar).mock.calls.filter((call) => call[0].userId === id).length;
+
+      expect(renderCount('user-a')).toBe(1);
+      expect(renderCount('user-b')).toBe(1);
+      expect(renderCount('user-c')).toBe(1);
+
+      // Simulate the identity-preserving merge: only member A gets a new
+      // object (as an online-status change would produce); B and C keep the
+      // exact same references they had before.
+      const updatedMemberA = { ...memberA, isOnline: true };
+
+      rerender(<MemberList members={[updatedMemberA, memberB, memberC]} title="Members" />);
+
+      // Row A re-rendered (its underlying UserAvatar mock was invoked again)...
+      expect(renderCount('user-a')).toBe(2);
+      // ...but rows B and C, whose member objects are referentially
+      // unchanged, were skipped entirely by React.memo(MemberRow).
+      expect(renderCount('user-b')).toBe(1);
+      expect(renderCount('user-c')).toBe(1);
+    });
   });
 });

--- a/frontend/src/__tests__/components/MemberListContainer.test.tsx
+++ b/frontend/src/__tests__/components/MemberListContainer.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, act } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../msw/server';
+import { renderWithProviders } from '../test-utils';
+import MemberListContainer from '../../components/Message/MemberListContainer';
+import { VoiceSessionType } from '../../contexts/VoiceContext';
+import { handleUserOnline } from '../../socket-hub/handlers/presenceHandlers';
+import type { MemberData } from '../../components/Message/MemberList';
+
+vi.mock('../../api-client/client.gen', async (importOriginal) => {
+  const { createClient, createConfig } = await import('../../api-client/client');
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    client: createClient(createConfig({ baseUrl: 'http://localhost:3000' })),
+  };
+});
+
+const BASE_URL = 'http://localhost:3000';
+
+let capturedMembersHistory: MemberData[][] = [];
+vi.mock('../../components/Message/MemberList', () => ({
+  default: (props: { members: MemberData[] }) => {
+    capturedMembersHistory.push(props.members);
+    return <div data-testid="member-list-mock">{props.members.length}</div>;
+  },
+}));
+
+describe('MemberListContainer identity-preserving merge', () => {
+  beforeEach(() => {
+    capturedMembersHistory = [];
+  });
+
+  it('reuses the previous member object for members unaffected by a presence event, and creates a new one for the affected member', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/membership/community/community-1`, () =>
+        HttpResponse.json([
+          {
+            id: 'membership-a',
+            userId: 'user-a',
+            communityId: 'community-1',
+            joinedAt: '2025-01-01T00:00:00Z',
+            roles: [],
+            user: {
+              id: 'user-a',
+              username: 'alice',
+              displayName: 'Alice',
+              avatarUrl: null,
+              status: null,
+            },
+          },
+          {
+            id: 'membership-b',
+            userId: 'user-b',
+            communityId: 'community-1',
+            joinedAt: '2025-01-01T00:00:00Z',
+            roles: [],
+            user: {
+              id: 'user-b',
+              username: 'bob',
+              displayName: 'Bob',
+              avatarUrl: null,
+              status: null,
+            },
+          },
+        ]),
+      ),
+      http.get(`${BASE_URL}/api/presence/users/:userIds`, () =>
+        HttpResponse.json({ presence: { 'user-a': false, 'user-b': false } }),
+      ),
+    );
+
+    const { queryClient } = renderWithProviders(
+      <MemberListContainer
+        contextType={VoiceSessionType.Channel}
+        contextId="channel-1"
+        communityId="community-1"
+        isPrivate={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('member-list-mock')).toHaveTextContent('2');
+    });
+
+    const beforeMembers = capturedMembersHistory[capturedMembersHistory.length - 1];
+    const memberABefore = beforeMembers.find((m) => m.id === 'user-a')!;
+    const memberBBefore = beforeMembers.find((m) => m.id === 'user-b')!;
+    expect(memberABefore.isOnline).toBe(false);
+    expect(memberBBefore.isOnline).toBe(false);
+
+    // Same surgical patch path socket-hub uses in production: setQueryData,
+    // not invalidate/refetch.
+    act(() => {
+      handleUserOnline({ userId: 'user-a' }, queryClient);
+    });
+
+    await waitFor(() => {
+      const latest = capturedMembersHistory[capturedMembersHistory.length - 1];
+      const latestA = latest.find((m) => m.id === 'user-a')!;
+      expect(latestA.isOnline).toBe(true);
+    });
+
+    const afterMembers = capturedMembersHistory[capturedMembersHistory.length - 1];
+    const memberAAfter = afterMembers.find((m) => m.id === 'user-a')!;
+    const memberBAfter = afterMembers.find((m) => m.id === 'user-b')!;
+
+    // The updated member gets a fresh object identity...
+    expect(memberAAfter).not.toBe(memberABefore);
+    // ...but the unaffected member keeps the exact same object reference,
+    // so React.memo(MemberRow) can bail out of re-rendering it.
+    expect(memberBAfter).toBe(memberBBefore);
+    expect(memberBAfter.isOnline).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/socket-hub/handlers/presenceHandlers.test.ts
+++ b/frontend/src/__tests__/socket-hub/handlers/presenceHandlers.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { QueryClient } from '@tanstack/react-query';
 import { handleUserOnline, handleUserOffline } from '../../../socket-hub/handlers/presenceHandlers';
 import {
   presenceControllerGetUserPresenceQueryKey,
   presenceControllerGetBulkPresenceQueryKey,
+  presenceControllerGetMultipleUserPresenceQueryKey,
 } from '../../../api-client/@tanstack/react-query.gen';
 
 describe('presenceHandlers', () => {
@@ -29,6 +30,43 @@ describe('presenceHandlers', () => {
       expect(data!.presence.u1).toBe(true);
       expect(data!.presence.u2).toBe(true);
     });
+
+    it('patches cached multi-presence queries in place without invalidating', () => {
+      const queryClient = new QueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      const key = presenceControllerGetMultipleUserPresenceQueryKey({ path: { userIds: 'u1,u2' } });
+      queryClient.setQueryData(key, { presence: { u1: false, u2: true } });
+
+      handleUserOnline({ userId: 'u1' }, queryClient);
+
+      expect(queryClient.getQueryData(key)).toEqual({ presence: { u1: true, u2: true } });
+      expect(invalidateSpy).not.toHaveBeenCalled();
+    });
+
+    it('leaves multi-presence queries that do not include the user untouched', () => {
+      const queryClient = new QueryClient();
+      const key = presenceControllerGetMultipleUserPresenceQueryKey({ path: { userIds: 'u3,u4' } });
+      const original = { presence: { u3: false, u4: false } };
+      queryClient.setQueryData(key, original);
+
+      handleUserOnline({ userId: 'u1' }, queryClient);
+
+      expect(queryClient.getQueryData(key)).toEqual(original);
+    });
+
+    it('falls back to invalidating a multi-presence query whose key cannot be parsed', () => {
+      const queryClient = new QueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      // Simulate a cached query whose key doesn't carry a parseable `path.userIds`
+      // (e.g. a future/alternate query shape) — the handler must not silently
+      // skip it, it must fall back to invalidating just that query.
+      const unparseableKey = [{ _id: 'presenceControllerGetMultipleUserPresence', baseUrl: 'http://x' }] as const;
+      queryClient.setQueryData(unparseableKey, { presence: { u1: false } });
+
+      handleUserOnline({ userId: 'u1' }, queryClient);
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: unparseableKey, exact: true });
+    });
   });
 
   describe('handleUserOffline', () => {
@@ -40,6 +78,29 @@ describe('presenceHandlers', () => {
       handleUserOffline({ userId: 'u1' }, queryClient);
 
       expect(queryClient.getQueryData(key)).toEqual({ isOnline: false });
+    });
+
+    it('patches cached multi-presence queries in place without invalidating', () => {
+      const queryClient = new QueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      const key = presenceControllerGetMultipleUserPresenceQueryKey({ path: { userIds: 'u1,u2' } });
+      queryClient.setQueryData(key, { presence: { u1: true, u2: true } });
+
+      handleUserOffline({ userId: 'u1' }, queryClient);
+
+      expect(queryClient.getQueryData(key)).toEqual({ presence: { u1: false, u2: true } });
+      expect(invalidateSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to invalidating a multi-presence query whose key cannot be parsed', () => {
+      const queryClient = new QueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      const unparseableKey = [{ _id: 'presenceControllerGetMultipleUserPresence', baseUrl: 'http://x' }] as const;
+      queryClient.setQueryData(unparseableKey, { presence: { u1: true } });
+
+      handleUserOffline({ userId: 'u1' }, queryClient);
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: unparseableKey, exact: true });
     });
   });
 });

--- a/frontend/src/components/Message/MemberList.tsx
+++ b/frontend/src/components/Message/MemberList.tsx
@@ -89,7 +89,7 @@ const MemberRow: React.FC<{
   member: MemberData;
   onOpenProfile: (userId: string) => void;
   onOpenMenu: (position: { top: number; left: number }, member: MemberData) => void;
-}> = ({ member, onOpenProfile, onOpenMenu }) => {
+}> = React.memo(function MemberRow({ member, onOpenProfile, onOpenMenu }) {
   const theme = useTheme();
   const { shouldUseTouchUI } = useResponsive();
 
@@ -179,7 +179,7 @@ const MemberRow: React.FC<{
       />
     </ListItemButton>
   );
-};
+});
 
 const MemberList: React.FC<MemberListProps> = ({
   members,

--- a/frontend/src/components/Message/MemberListContainer.tsx
+++ b/frontend/src/components/Message/MemberListContainer.tsx
@@ -18,6 +18,20 @@ interface MemberListContainerProps {
 }
 
 /**
+ * Compare two `displayRole` values by content rather than reference, since
+ * `computeDisplayRole` builds a fresh object every time `baseMembers`
+ * recomputes even when the underlying role hasn't changed.
+ */
+function sameDisplayRole(
+  a?: MemberData["displayRole"],
+  b?: MemberData["displayRole"],
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.id === b.id && a.name === b.name && a.position === b.position;
+}
+
+/**
  * Compute a member's "display role" from their roles list.
  * The display role is the role with the lowest position (highest priority),
  * excluding the default "Member" role (position 100, isDefault=true).
@@ -95,6 +109,7 @@ const MemberListContainer: React.FC<MemberListContainerProps> = ({
             displayName: membership.user!.displayName,
             avatarUrl: membership.user!.avatarUrl,
             status: membership.user!.status,
+            displayRole: undefined as MemberData["displayRole"],
           }));
       }
       // Public channel: use community members (includes roles)
@@ -118,6 +133,7 @@ const MemberListContainer: React.FC<MemberListContainerProps> = ({
           avatarUrl: member.user.avatarUrl,
           // The DM members endpoint does not return a status field
           status: undefined,
+          displayRole: undefined as MemberData["displayRole"],
         }));
     }
   }, [contextType, isPrivate, channelMembers, communityMembers, dmGroup]);
@@ -139,13 +155,41 @@ const MemberListContainer: React.FC<MemberListContainerProps> = ({
     staleTime: 60_000,
   });
 
+  // Identity cache: preserves referential equality for member objects whose
+  // row-relevant fields haven't changed, so React.memo(MemberRow) can skip
+  // re-rendering members untouched by a given presence event. Rebuilt fresh
+  // from baseMembers on every recompute, so members that disappear are
+  // naturally evicted.
+  const memberIdentityCacheRef = React.useRef<Map<string, MemberData>>(new Map());
+
   // Transform and normalize member data with presence
   const { members, isLoading, error, title } = React.useMemo(() => {
-    const membersWithPresence: MemberData[] = baseMembers
-      .map((member) => ({
-        ...member,
-        isOnline: presenceData?.presence?.[member.id] || false,
-      }));
+    const previousCache = memberIdentityCacheRef.current;
+    const nextCache = new Map<string, MemberData>();
+
+    const membersWithPresence: MemberData[] = baseMembers.map((member) => {
+      const isOnline = presenceData?.presence?.[member.id] || false;
+      const previous = previousCache.get(member.id);
+
+      if (
+        previous &&
+        previous.username === member.username &&
+        previous.displayName === member.displayName &&
+        previous.avatarUrl === member.avatarUrl &&
+        previous.status === member.status &&
+        previous.isOnline === isOnline &&
+        sameDisplayRole(previous.displayRole, member.displayRole)
+      ) {
+        nextCache.set(member.id, previous);
+        return previous;
+      }
+
+      const next: MemberData = { ...member, isOnline };
+      nextCache.set(member.id, next);
+      return next;
+    });
+
+    memberIdentityCacheRef.current = nextCache;
 
     const combinedLoading = contextType === VoiceSessionType.Channel
       ? (isPrivate === undefined ? true : isPrivate ? isChannelMembersLoading : isCommunityLoading) || isPresenceLoading

--- a/frontend/src/socket-hub/handlers/presenceHandlers.ts
+++ b/frontend/src/socket-hub/handlers/presenceHandlers.ts
@@ -1,4 +1,4 @@
-import type { QueryClient } from '@tanstack/react-query';
+import type { QueryClient, QueryKey } from '@tanstack/react-query';
 import type { UserPresenceInfo, UserProfileUpdatedPayload, ServerEvents } from '@semaphore-chat/shared';
 import type { UserControllerGetProfileResponse } from '../../api-client';
 import {
@@ -8,6 +8,57 @@ import {
   userControllerGetProfileQueryKey,
 } from '../../api-client/@tanstack/react-query.gen';
 import type { SocketEventHandler } from './types';
+
+/**
+ * Extract the comma-joined `userIds` path param that
+ * `presenceControllerGetMultipleUserPresenceQueryKey` embeds in the query key
+ * (`[{ _id, baseUrl, path: { userIds: 'a,b,c' } }]`). Returns null when the
+ * key doesn't have the expected shape, so callers can fall back to
+ * invalidating instead of guessing.
+ */
+function parseMultiPresenceUserIds(queryKey: QueryKey): string[] | null {
+  const keyPart = queryKey[0];
+  if (typeof keyPart !== 'object' || keyPart === null) return null;
+
+  const path = (keyPart as { path?: unknown }).path;
+  if (typeof path !== 'object' || path === null) return null;
+
+  const userIds = (path as { userIds?: unknown }).userIds;
+  if (typeof userIds !== 'string' || userIds.length === 0) return null;
+
+  return userIds.split(',').filter(Boolean);
+}
+
+/**
+ * Patch every cached `presenceControllerGetMultipleUserPresence` query whose
+ * parsed userIds include `userId`, in place — no refetch, no re-render of
+ * unrelated queries. Queries whose key can't be parsed confidently fall back
+ * to a targeted invalidation of just that query (safety net).
+ */
+function patchMultiPresenceCaches(queryClient: QueryClient, userId: string, isOnline: boolean): void {
+  const queries = queryClient.getQueryCache().findAll({
+    queryKey: [{ _id: 'presenceControllerGetMultipleUserPresence' }],
+  });
+
+  for (const query of queries) {
+    const userIds = parseMultiPresenceUserIds(query.queryKey);
+
+    if (userIds === null) {
+      void queryClient.invalidateQueries({ queryKey: query.queryKey, exact: true });
+      continue;
+    }
+
+    if (!userIds.includes(userId)) continue;
+
+    queryClient.setQueryData(
+      query.queryKey,
+      (old: { presence: Record<string, boolean> } | undefined) => {
+        if (!old) return old;
+        return { ...old, presence: { ...old.presence, [userId]: isOnline } };
+      },
+    );
+  }
+}
 
 export const handleUserOnline: SocketEventHandler<typeof ServerEvents.USER_ONLINE> = (
   data: UserPresenceInfo,
@@ -26,15 +77,7 @@ export const handleUserOnline: SocketEventHandler<typeof ServerEvents.USER_ONLIN
     },
   );
 
-  queryClient.invalidateQueries({
-    predicate: (query) => {
-      const key = query.queryKey[0];
-      if (typeof key === 'object' && key !== null && '_id' in key) {
-        return (key as { _id: string })._id === 'presenceControllerGetMultipleUserPresence';
-      }
-      return false;
-    },
-  });
+  patchMultiPresenceCaches(queryClient, data.userId, true);
 };
 
 export const handleUserOffline: SocketEventHandler<typeof ServerEvents.USER_OFFLINE> = (
@@ -54,15 +97,7 @@ export const handleUserOffline: SocketEventHandler<typeof ServerEvents.USER_OFFL
     },
   );
 
-  queryClient.invalidateQueries({
-    predicate: (query) => {
-      const key = query.queryKey[0];
-      if (typeof key === 'object' && key !== null && '_id' in key) {
-        return (key as { _id: string })._id === 'presenceControllerGetMultipleUserPresence';
-      }
-      return false;
-    },
-  });
+  patchMultiPresenceCaches(queryClient, data.userId, false);
 };
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Presence events (user online/offline) were invalidating every cached multi-presence query — refetch storms — and rebuilding every member object, re-rendering entire member lists per event.
- Three coordinated fixes: `MemberRow` is memoized (callback props verified referentially stable at source); `MemberListContainer` merges presence with identity preservation (unchanged members keep their previous object; cache evicts naturally on rebuild); `presenceHandlers` patch `presence[userId]` in place via `setQueryData`, with a per-query invalidate fallback for any key the parser can't confidently read.
- Net effect: one presence event re-renders exactly the affected row. This also aligns presence with the repo's documented "direct cache update" WebSocket pattern.

## Test plan
- New tests: referential-identity (user B's object is `toBe`-identical after user A's presence change), render-count regression guard (removing the memo fails it), in-place patch + no-invalidate assertions, unparseable-key fallback.
- Full suite 163 files / 1706 tests, type-check, lint green. No visual or behavioral changes; presence response shapes untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sAJfCfBfMm8chbZMsh5Y5