### PR TITLE
feat(storage): S3-compatible object storage for file uploads

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -206,6 +206,28 @@ jobs:
         ports:
           - 6379:6379
 
+      # S3-compatible object storage for storage-s3.e2e-spec.ts. GitHub
+      # Actions service containers cannot override a container's CMD/args
+      # (only `options` flags are supported, appended to `docker create` —
+      # there is no way to pass positional `server /data` args the way
+      # docker-compose's `minio` service does above). `minio/minio`'s
+      # default CMD (`minio` with no subcommand) just prints --help and
+      # exits, which was verified empirically before picking this image —
+      # `bitnamilegacy/minio` starts its server from env vars alone with no
+      # command override needed, so it works as a bare `services:` entry.
+      minio:
+        image: bitnamilegacy/minio:latest
+        env:
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
+        options: >-
+          --health-cmd "curl -f http://localhost:9000/minio/health/live"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+        ports:
+          - 9000:9000
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -243,3 +265,10 @@ jobs:
           JWT_SECRET: test-secret-key
           JWT_REFRESH_SECRET: test-refresh-secret-key
           NODE_ENV: test
+          # storage-s3.e2e-spec.ts only: points the suite at the `minio`
+          # service above instead of its compose-network default
+          # (http://minio:9000, unreachable by hostname from a
+          # non-containerized GHA job — services are only reachable via
+          # localhost:<port>).
+          S3_TEST_ENDPOINT: http://localhost:9000
+          S3_TEST_BUCKET: semaphore-dev

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -210,13 +210,14 @@ jobs:
       # Actions service containers cannot override a container's CMD/args
       # (only `options` flags are supported, appended to `docker create` —
       # there is no way to pass positional `server /data` args the way
-      # docker-compose's `minio` service does above). `minio/minio`'s
+      # docker-compose's `minio` service does). `minio/minio:latest`'s
       # default CMD (`minio` with no subcommand) just prints --help and
-      # exits, which was verified empirically before picking this image —
-      # `bitnamilegacy/minio` starts its server from env vars alone with no
-      # command override needed, so it works as a bare `services:` entry.
+      # exits, so it can't run as a bare service — but MinIO publishes
+      # `edge-cicd` specifically for CI: its CMD is `minio server /data`
+      # (verified via docker inspect + a boot test with env vars only),
+      # so it works as a bare `services:` entry on the first-party image.
       minio:
-        image: bitnamilegacy/minio:latest
+        image: minio/minio:edge-cicd
         env:
           MINIO_ROOT_USER: minioadmin
           MINIO_ROOT_PASSWORD: minioadmin
@@ -254,6 +255,13 @@ jobs:
         run: pnpm run prisma:migrate
         env:
           DATABASE_URL: postgresql://semaphore:semaphore@localhost:5432/test
+
+      # storage-s3.e2e-spec.ts's video-thumbnail leg shells out to the
+      # runner's system ffmpeg (fluent-ffmpeg, no bundled binary). Thumbnail
+      # failures are non-fatal to uploads, so without this check a missing
+      # ffmpeg surfaces as a confusing hasThumbnail assertion failure.
+      - name: Verify ffmpeg is available
+        run: ffmpeg -version | head -1
 
       - name: Run E2E tests
         working-directory: ./backend

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -260,8 +260,24 @@ jobs:
       # runner's system ffmpeg (fluent-ffmpeg, no bundled binary). Thumbnail
       # failures are non-fatal to uploads, so without this check a missing
       # ffmpeg surfaces as a confusing hasThumbnail assertion failure.
+      #
+      # ubuntu-latest does NOT ship ffmpeg preinstalled (confirmed via a CI
+      # run where the old verify step's `ffmpeg -version | head -1` printed
+      # "ffmpeg: command not found" yet the step still reported success —
+      # `bash -e` without `pipefail`, GitHub Actions' default shell mode,
+      # only checks the exit code of the *last* command in a pipe, i.e.
+      # `head`, which exits 0 even on empty input). Install it explicitly
+      # rather than assuming the runner image provides it.
+      - name: Install ffmpeg
+        run: sudo apt-get update -y && sudo apt-get install -y ffmpeg
+
+      # Hard-fail (via pipefail) if ffmpeg is somehow still missing after the
+      # install step above, instead of silently continuing like the old
+      # unguarded pipe did.
       - name: Verify ffmpeg is available
-        run: ffmpeg -version | head -1
+        run: |
+          set -euo pipefail
+          ffmpeg -version | head -1
 
       - name: Run E2E tests
         working-directory: ./backend

--- a/backend/env.sample
+++ b/backend/env.sample
@@ -28,6 +28,27 @@ REPLAY_SEGMENTS_PATH=/app/storage/replay-segments
 REPLAY_EGRESS_OUTPUT_PATH=/out
 REPLAY_SEGMENT_CLEANUP_AGE_MINUTES=20
 
+# File Storage Backend (message attachments, avatars, banners, emoji, sounds)
+# STORAGE_TYPE=LOCAL (default) stores uploads on the local filesystem at
+# FILE_UPLOAD_DEST. STORAGE_TYPE=S3 stores them in an S3-compatible bucket
+# instead — FILE_UPLOAD_DEST is still used as local scratch space (multer
+# staging + ffmpeg thumbnail generation need a real file on disk).
+# Storage is resolved per file record, so switching STORAGE_TYPE only
+# affects new uploads; existing files keep working from wherever they were
+# originally stored.
+# STORAGE_TYPE=LOCAL
+# FILE_UPLOAD_DEST=./uploads
+#
+# S3_* vars below are required only when STORAGE_TYPE=S3. For local dev
+# against the MinIO service (docker compose --profile s3 up -d minio):
+# STORAGE_TYPE=S3
+# S3_BUCKET=semaphore-dev
+# S3_REGION=us-east-1
+# S3_ACCESS_KEY_ID=minioadmin
+# S3_SECRET_ACCESS_KEY=minioadmin
+# S3_ENDPOINT=http://minio:9000
+# S3_FORCE_PATH_STYLE=true
+
 # Push Notifications (Web Push / VAPID)
 # Generate keys with: npx web-push generate-vapid-keys
 # Each instance needs unique keys - treat like JWT secrets

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,8 @@
     "generate:openapi": "nest build && node dist/src/generate-openapi.js"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.700.0",
+    "@aws-sdk/lib-storage": "^3.700.0",
     "@nest-lab/throttler-storage-redis": "^1.2.0",
     "@nestjs/common": "^11.1.11",
     "@nestjs/config": "^4.0.2",

--- a/backend/src/config/env.validation.spec.ts
+++ b/backend/src/config/env.validation.spec.ts
@@ -195,6 +195,73 @@ describe('validateEnv', () => {
     });
   });
 
+  describe('Test 6c: S3 storage vars required only when STORAGE_TYPE=S3', () => {
+    it('passes when STORAGE_TYPE is unset (LOCAL default) with no S3 vars', () => {
+      const config = { ...BASE_CONFIG };
+
+      expect(() => validateEnv(config)).not.toThrow();
+    });
+
+    it('passes when STORAGE_TYPE=LOCAL explicitly with no S3 vars', () => {
+      const config = { ...BASE_CONFIG, STORAGE_TYPE: 'LOCAL' };
+
+      expect(() => validateEnv(config)).not.toThrow();
+    });
+
+    it('throws listing every missing S3 var when STORAGE_TYPE=S3 and none are set', () => {
+      const config = { ...BASE_CONFIG, STORAGE_TYPE: 'S3' };
+
+      let error: Error | null = null;
+      try {
+        validateEnv(config);
+      } catch (e) {
+        error = e as Error;
+      }
+
+      expect(error).not.toBeNull();
+      expect(error!.message).toMatch(
+        /S3_BUCKET is required when STORAGE_TYPE=S3/,
+      );
+      expect(error!.message).toMatch(
+        /S3_REGION is required when STORAGE_TYPE=S3/,
+      );
+      expect(error!.message).toMatch(
+        /S3_ACCESS_KEY_ID is required when STORAGE_TYPE=S3/,
+      );
+      expect(error!.message).toMatch(
+        /S3_SECRET_ACCESS_KEY is required when STORAGE_TYPE=S3/,
+      );
+    });
+
+    it('passes when STORAGE_TYPE=S3 with all required S3 vars set (no endpoint needed for AWS)', () => {
+      const config = {
+        ...BASE_CONFIG,
+        STORAGE_TYPE: 'S3',
+        S3_BUCKET: 'my-bucket',
+        S3_REGION: 'us-east-1',
+        S3_ACCESS_KEY_ID: 'AKIA...',
+        S3_SECRET_ACCESS_KEY: 'secret',
+      };
+
+      expect(() => validateEnv(config)).not.toThrow();
+    });
+
+    it('passes when STORAGE_TYPE=S3 with MinIO-style endpoint and path-style flag set', () => {
+      const config = {
+        ...BASE_CONFIG,
+        STORAGE_TYPE: 'S3',
+        S3_BUCKET: 'my-bucket',
+        S3_REGION: 'us-east-1',
+        S3_ACCESS_KEY_ID: 'minioadmin',
+        S3_SECRET_ACCESS_KEY: 'minioadmin',
+        S3_ENDPOINT: 'http://minio:9000',
+        S3_FORCE_PATH_STYLE: 'true',
+      };
+
+      expect(() => validateEnv(config)).not.toThrow();
+    });
+  });
+
   describe('Test 7: Unknown extra env vars are ignored', () => {
     it('does not throw when extra unknown vars are present and passes them through', () => {
       const config = {

--- a/backend/src/config/env.validation.spec.ts
+++ b/backend/src/config/env.validation.spec.ts
@@ -260,6 +260,24 @@ describe('validateEnv', () => {
 
       expect(() => validateEnv(config)).not.toThrow();
     });
+
+    it('passes when STORAGE_TYPE=AZURE_BLOB (a real, reserved-for-later enum value)', () => {
+      const config = { ...BASE_CONFIG, STORAGE_TYPE: 'AZURE_BLOB' };
+
+      expect(() => validateEnv(config)).not.toThrow();
+    });
+
+    it("throws on a typo'd STORAGE_TYPE instead of silently falling back to LOCAL", () => {
+      const config = { ...BASE_CONFIG, STORAGE_TYPE: 's3' };
+
+      expect(() => validateEnv(config)).toThrow(/STORAGE_TYPE/);
+    });
+
+    it('throws on an unrecognized STORAGE_TYPE value', () => {
+      const config = { ...BASE_CONFIG, STORAGE_TYPE: 'AWS_S3' };
+
+      expect(() => validateEnv(config)).toThrow(/STORAGE_TYPE/);
+    });
   });
 
   describe('Test 7: Unknown extra env vars are ignored', () => {

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -14,6 +14,7 @@
 import { plainToInstance } from 'class-transformer';
 import {
   IsEnum,
+  IsIn,
   IsNotEmpty,
   IsOptional,
   IsString,
@@ -134,9 +135,17 @@ export class EnvironmentVariables {
   // STORAGE_TYPE=S3 (checked imperatively below) — S3_ENDPOINT and
   // S3_FORCE_PATH_STYLE stay optional even then (AWS S3 needs neither;
   // they're for S3-compatible services like MinIO).
+  //
+  // @IsIn is restricted to the real `StorageType` Prisma enum members
+  // (LOCAL, S3, AZURE_BLOB — see schema.prisma) so a typo (e.g. "s3",
+  // "AWS_S3") fails fast at startup instead of silently falling back to
+  // LOCAL via StorageService.getProvider()'s `default:` branch. AZURE_BLOB
+  // is included even though StorageService.getProvider() currently throws
+  // NotImplementedException for it — it's a real, intentionally-reserved
+  // enum value (see storage.service.ts), not a typo.
 
   @IsOptional()
-  @IsString()
+  @IsIn(['LOCAL', 'S3', 'AZURE_BLOB'])
   STORAGE_TYPE?: string;
 
   @IsOptional()

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -128,6 +128,40 @@ export class EnvironmentVariables {
   @IsOptional()
   @IsString()
   PUBLIC_APP_URL?: string;
+
+  // File storage backend (PR-16) --------------------------------------
+  // STORAGE_TYPE defaults to LOCAL. S3_* vars are only required when
+  // STORAGE_TYPE=S3 (checked imperatively below) — S3_ENDPOINT and
+  // S3_FORCE_PATH_STYLE stay optional even then (AWS S3 needs neither;
+  // they're for S3-compatible services like MinIO).
+
+  @IsOptional()
+  @IsString()
+  STORAGE_TYPE?: string;
+
+  @IsOptional()
+  @IsString()
+  S3_BUCKET?: string;
+
+  @IsOptional()
+  @IsString()
+  S3_REGION?: string;
+
+  @IsOptional()
+  @IsString()
+  S3_ENDPOINT?: string;
+
+  @IsOptional()
+  @IsString()
+  S3_ACCESS_KEY_ID?: string;
+
+  @IsOptional()
+  @IsString()
+  S3_SECRET_ACCESS_KEY?: string;
+
+  @IsOptional()
+  @IsString()
+  S3_FORCE_PATH_STYLE?: string;
 }
 
 /**
@@ -195,6 +229,23 @@ export function validateEnv(
   // SMTP_HOST requires SMTP_FROM — a from-address is mandatory to send mail.
   if (config.SMTP_HOST && !config.SMTP_FROM) {
     errors.push('SMTP_HOST requires SMTP_FROM to be set.');
+  }
+
+  // S3 storage vars are required only when STORAGE_TYPE=S3. S3_ENDPOINT and
+  // S3_FORCE_PATH_STYLE are never required — they exist for S3-compatible
+  // services (MinIO) rather than AWS S3 itself.
+  if (validated.STORAGE_TYPE === 'S3') {
+    const REQUIRED_FOR_S3 = [
+      'S3_BUCKET',
+      'S3_REGION',
+      'S3_ACCESS_KEY_ID',
+      'S3_SECRET_ACCESS_KEY',
+    ] as const;
+    for (const key of REQUIRED_FOR_S3) {
+      if (!config[key]) {
+        errors.push(`${key} is required when STORAGE_TYPE=S3`);
+      }
+    }
   }
 
   if (errors.length > 0) {

--- a/backend/src/file-upload/file-upload.service.spec.ts
+++ b/backend/src/file-upload/file-upload.service.spec.ts
@@ -9,6 +9,8 @@ import { ThumbnailService } from '@/file/thumbnail.service';
 import { UnprocessableEntityException } from '@nestjs/common';
 import { ResourceType, FileType, StorageType } from '@prisma/client';
 import * as crypto from 'crypto';
+import { Readable } from 'stream';
+import type { IStorageProvider } from '@/storage/interfaces/storage-provider.interface';
 import { FileUploadResponseDto } from './dto/file-upload-response.dto';
 
 jest.mock('./validators/resource-type-file.validator');
@@ -19,6 +21,7 @@ describe('FileUploadService', () => {
   let storageService: Mocked<StorageService>;
   let storageQuotaService: Mocked<StorageQuotaService>;
   let thumbnailService: Mocked<ThumbnailService>;
+  let mockS3Provider: jest.Mocked<IStorageProvider>;
 
   const mockUser = {
     id: 'user-123',
@@ -52,9 +55,24 @@ describe('FileUploadService', () => {
     // Reset mocks
     jest.clearAllMocks();
 
-    // Default mock implementations - use StorageService instead of direct fs calls
-    storageService.readFile.mockResolvedValue(Buffer.from('test'));
+    // Default mock implementations - use StorageService instead of direct fs calls.
+    // Checksum computation streams the file through createReadStream (never
+    // buffers the whole file) — give it a real async-iterable stream.
+    storageService.createReadStream.mockImplementation(
+      () => Readable.from([Buffer.from('test')]) as any,
+    );
     storageService.deleteFile.mockResolvedValue(undefined);
+    // Default active storage type: LOCAL (zero-behavior-change default).
+    storageService.getDefaultStorageType.mockReturnValue(StorageType.LOCAL);
+    mockS3Provider = {
+      writeStream: jest.fn().mockResolvedValue({ size: 1024 }),
+      getReadStream: jest.fn(),
+      deleteFile: jest.fn().mockResolvedValue(undefined),
+      fileExists: jest.fn(),
+      getFileStats: jest.fn(),
+      getFileUrl: jest.fn(),
+    };
+    storageService.getProvider.mockReturnValue(mockS3Provider);
 
     // Default quota check passes
     storageQuotaService.canUploadFile.mockResolvedValue({
@@ -208,6 +226,7 @@ describe('FileUploadService', () => {
         expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledWith(
           '/tmp/clip-123.mp4',
           'file-video-1',
+          StorageType.LOCAL,
         );
         expect(databaseService.file.update).toHaveBeenCalledWith({
           where: { id: 'file-video-1' },
@@ -485,6 +504,7 @@ describe('FileUploadService', () => {
       expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledWith(
         '/tmp/clip.mp4',
         'file-video-1',
+        StorageType.LOCAL,
       );
       expect(databaseService.file.update).toHaveBeenCalledWith({
         where: { id: 'file-video-1' },
@@ -565,13 +585,147 @@ describe('FileUploadService', () => {
 
       await service.uploadFile(mockFile, createDto, mockUser);
 
-      expect(storageService.readFile).toHaveBeenCalledWith('/tmp/test-123.png');
+      expect(storageService.createReadStream).toHaveBeenCalledWith(
+        '/tmp/test-123.png',
+      );
       expect(crypto.createHash).toHaveBeenCalledWith('sha256');
       expect(databaseService.file.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
           checksum: 'abc123def456',
         }),
       });
+    });
+  });
+
+  describe('uploadFile — S3 storage (STORAGE_TYPE=S3)', () => {
+    const createDto = {
+      resourceType: ResourceType.MESSAGE_ATTACHMENT,
+      resourceId: 'msg-123',
+    };
+
+    beforeEach(() => {
+      storageService.getDefaultStorageType.mockReturnValue(StorageType.S3);
+
+      const {
+        ResourceTypeFileValidator,
+      } = require('./validators/resource-type-file.validator');
+      ResourceTypeFileValidator.mockImplementation(() => ({
+        isValid: jest.fn().mockResolvedValue(true),
+      }));
+    });
+
+    it('streams the staged tmp file to the S3 provider and persists the bare filename as the key', async () => {
+      databaseService.file.create.mockResolvedValue({
+        id: 'file-s3-1',
+      } as any);
+
+      await service.uploadFile(mockFile, createDto, mockUser);
+
+      expect(storageService.getProvider).toHaveBeenCalledWith(StorageType.S3);
+      expect(mockS3Provider.writeStream).toHaveBeenCalledWith(
+        'test-123.png', // file.filename — bare multer-generated key
+        expect.anything(),
+        { contentType: 'image/png' },
+      );
+      expect(databaseService.file.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          storageType: StorageType.S3,
+          storagePath: 'test-123.png',
+        }),
+      });
+    });
+
+    it('deletes the local tmp file after a successful S3 upload + DB insert', async () => {
+      databaseService.file.create.mockResolvedValue({
+        id: 'file-s3-2',
+      } as any);
+
+      await service.uploadFile(mockFile, createDto, mockUser);
+
+      expect(storageService.deleteFile).toHaveBeenCalledWith(
+        '/tmp/test-123.png',
+      );
+    });
+
+    it('never deletes the local tmp path for LOCAL uploads (it IS the permanent storage)', async () => {
+      storageService.getDefaultStorageType.mockReturnValue(StorageType.LOCAL);
+      databaseService.file.create.mockResolvedValue({
+        id: 'file-local-1',
+      } as any);
+
+      await service.uploadFile(mockFile, createDto, mockUser);
+
+      expect(storageService.deleteFile).not.toHaveBeenCalled();
+    });
+
+    it('cleans up the local tmp file and rethrows when the S3 upload itself fails', async () => {
+      mockS3Provider.writeStream.mockRejectedValue(new Error('S3 unreachable'));
+
+      await expect(
+        service.uploadFile(mockFile, createDto, mockUser),
+      ).rejects.toThrow('S3 unreachable');
+
+      expect(storageService.deleteFile).toHaveBeenCalledWith(
+        '/tmp/test-123.png',
+      );
+      expect(databaseService.file.create).not.toHaveBeenCalled();
+    });
+
+    it('cleans up both the local tmp file AND the orphaned S3 object when the DB insert fails after a successful upload', async () => {
+      databaseService.file.create.mockRejectedValue(
+        new Error('Database error'),
+      );
+
+      await expect(
+        service.uploadFile(mockFile, createDto, mockUser),
+      ).rejects.toThrow('Database error');
+
+      expect(storageService.deleteFile).toHaveBeenCalledWith(
+        '/tmp/test-123.png',
+      );
+      expect(mockS3Provider.deleteFile).toHaveBeenCalledWith('test-123.png');
+    });
+
+    it('does not attempt to clean up a remote object when the DB fails for a LOCAL upload', async () => {
+      storageService.getDefaultStorageType.mockReturnValue(StorageType.LOCAL);
+      databaseService.file.create.mockRejectedValue(
+        new Error('Database error'),
+      );
+
+      await expect(
+        service.uploadFile(mockFile, createDto, mockUser),
+      ).rejects.toThrow('Database error');
+
+      expect(mockS3Provider.deleteFile).not.toHaveBeenCalled();
+    });
+
+    it('passes the S3 storageType through to thumbnail generation for video uploads', async () => {
+      const videoFile = {
+        ...mockFile,
+        originalname: 'clip.mp4',
+        mimetype: 'video/mp4',
+        filename: 'clip-123.mp4',
+        path: '/tmp/clip-123.mp4',
+      };
+      databaseService.file.create.mockResolvedValue({
+        id: 'file-video-s3',
+      } as any);
+      thumbnailService.generateVideoThumbnail.mockResolvedValue(
+        'thumbnails/file-video-s3.jpg',
+      );
+      databaseService.file.update.mockResolvedValue({} as any);
+
+      await service.uploadFile(videoFile, createDto, mockUser);
+
+      expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledWith(
+        '/tmp/clip-123.mp4',
+        'file-video-s3',
+        StorageType.S3,
+      );
+      // tmp cleanup happens only after thumbnail generation completes
+      expect(storageService.deleteFile).toHaveBeenCalledWith(
+        '/tmp/clip-123.mp4',
+      );
     });
   });
 

--- a/backend/src/file-upload/file-upload.service.ts
+++ b/backend/src/file-upload/file-upload.service.ts
@@ -33,6 +33,17 @@ export class FileUploadService {
     createFileUploadDto: CreateFileUploadDto,
     user: UserEntity,
   ) {
+    // The active default storage type decides where this NEW upload lands.
+    // Existing records keep whatever storageType they were created with —
+    // resolved per-record everywhere else (serve, delete, backfill).
+    const storageType = this.storageService.getDefaultStorageType();
+    // For LOCAL, multer already wrote the final storage location at
+    // file.path — the object key IS that path (zero-copy, unchanged
+    // behavior). For S3, multer's write is just local staging; the object
+    // key is the bare multer-generated filename and the bytes get streamed
+    // up below before the DB record is created.
+    let objectKey = file.path;
+
     try {
       // Check storage quota before processing
       const quotaCheck = await this.storageQuotaService.canUploadFile(
@@ -62,11 +73,31 @@ export class FileUploadService {
         );
       }
 
-      // Generate checksum
+      // Generate checksum (streamed — never buffers the whole file)
       const checksum = await this.generateChecksum(file.path);
 
       // Determine file type from MIME type
       const fileType = this.getFileTypeFromMimeType(file.mimetype);
+
+      // For S3, stream the staged tmp file up to the bucket now, before
+      // creating the DB record — a failed upload must never produce an
+      // orphan row. The local tmp file stays put: video thumbnailing (below)
+      // still needs a local path for ffmpeg, so it's cleaned up afterwards.
+      if (storageType === StorageType.S3) {
+        objectKey = file.filename;
+        try {
+          const provider = this.storageService.getProvider(StorageType.S3);
+          await provider.writeStream(
+            objectKey,
+            this.storageService.createReadStream(file.path),
+            { contentType: file.mimetype },
+          );
+        } catch (uploadError) {
+          await this.cleanupFile(file.path);
+          this.logger.error(`Failed to upload file to S3: ${uploadError}`);
+          throw uploadError;
+        }
+      }
 
       // Create database record
       try {
@@ -84,8 +115,8 @@ export class FileUploadService {
             size: file.size,
             checksum,
             uploadedById: user.id,
-            storageType: StorageType.LOCAL,
-            storagePath: file.path,
+            storageType,
+            storagePath: objectKey,
           },
         });
 
@@ -97,14 +128,29 @@ export class FileUploadService {
         // Failure is non-fatal — the upload succeeds without a thumbnail.
         const finalRecord =
           fileType === FileType.VIDEO
-            ? ((await this.generateThumbnail(file.path, fileRecord.id)) ??
-              fileRecord)
+            ? ((await this.generateThumbnail(
+                file.path,
+                fileRecord.id,
+                storageType,
+              )) ?? fileRecord)
             : fileRecord;
+
+        // The local tmp copy is only scratch space for S3 uploads (ffmpeg
+        // thumbnailing needed it above) — safe to remove now. For LOCAL,
+        // file.path IS the permanent storage location and must never be
+        // deleted here.
+        if (storageType === StorageType.S3) {
+          await this.cleanupFile(file.path);
+        }
 
         return new FileUploadResponseDto(finalRecord);
       } catch (dbError) {
-        // If DB insert fails, clean up the file
+        // If DB insert fails, clean up the local tmp file and, if the
+        // object was already uploaded to S3, the now-orphaned remote copy.
         await this.cleanupFile(file.path);
+        if (storageType === StorageType.S3) {
+          await this.cleanupRemoteObject(objectKey);
+        }
         this.logger.error(`Database error during file upload: ${dbError}`);
         throw dbError;
       }
@@ -129,11 +175,16 @@ export class FileUploadService {
    *
    * @returns The updated file record, or null if generation failed
    */
-  private async generateThumbnail(filePath: string, fileId: string) {
+  private async generateThumbnail(
+    filePath: string,
+    fileId: string,
+    storageType: StorageType,
+  ) {
     try {
       const thumbnailPath = await this.thumbnailService.generateVideoThumbnail(
         filePath,
         fileId,
+        storageType,
       );
       if (!thumbnailPath) {
         return null;
@@ -147,6 +198,24 @@ export class FileUploadService {
         `Failed to generate thumbnail for file ${fileId}: ${error instanceof Error ? error.message : String(error)}`,
       );
       return null;
+    }
+  }
+
+  /**
+   * Best-effort cleanup of an S3 object orphaned by a failed DB insert
+   * (upload succeeded, but the record that would reference it never
+   * committed). Logged, never thrown — mirrors cleanupFile's non-fatal
+   * cleanup semantics.
+   */
+  private async cleanupRemoteObject(key: string): Promise<void> {
+    try {
+      const provider = this.storageService.getProvider(StorageType.S3);
+      await provider.deleteFile(key);
+      this.logger.debug(`Cleaned up orphaned S3 object: ${key}`);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to clean up orphaned S3 object ${key}: ${error}`,
+      );
     }
   }
 
@@ -167,7 +236,9 @@ export class FileUploadService {
   }
 
   /**
-   * Delete a file from disk
+   * Delete the local tmp file staged by multer. Always local — this never
+   * needs per-record provider resolution (it runs before any DB record, or
+   * S3 upload, exists).
    */
   private async cleanupFile(filePath: string): Promise<void> {
     try {
@@ -179,11 +250,16 @@ export class FileUploadService {
   }
 
   /**
-   * Generate SHA-256 checksum for a file
+   * Generate a SHA-256 checksum for a file by streaming it through the
+   * hash — never buffers the whole file into memory.
    */
   private async generateChecksum(filePath: string): Promise<string> {
-    const fileBuffer = await this.storageService.readFile(filePath);
-    return createHash('sha256').update(fileBuffer).digest('hex');
+    const hash = createHash('sha256');
+    const stream = this.storageService.createReadStream(filePath);
+    for await (const chunk of stream) {
+      hash.update(chunk as Buffer);
+    }
+    return hash.digest('hex');
   }
 
   /**

--- a/backend/src/file/file.controller.spec.ts
+++ b/backend/src/file/file.controller.spec.ts
@@ -3,18 +3,20 @@ import type { Mocked } from '@suites/doubles.jest';
 import { FileController } from './file.controller';
 import { FileService } from './file.service';
 import { SignedUrlService } from './signed-url.service';
-import { NotFoundException, NotImplementedException } from '@nestjs/common';
+import { StorageService } from '@/storage/storage.service';
+import { NotFoundException } from '@nestjs/common';
 import { StorageType, FileType } from '@prisma/client';
 import { Request, Response } from 'express';
-import * as fs from 'fs';
+import { Readable } from 'stream';
+import type { IStorageProvider } from '@/storage/interfaces/storage-provider.interface';
 import { AuthenticatedRequest } from '@/types';
-
-jest.mock('fs');
 
 describe('FileController', () => {
   let controller: FileController;
   let service: Mocked<FileService>;
   let signedUrlService: Mocked<SignedUrlService>;
+  let storageService: Mocked<StorageService>;
+  let mockProvider: jest.Mocked<IStorageProvider>;
 
   const mockResponse = {
     set: jest.fn(),
@@ -32,16 +34,25 @@ describe('FileController', () => {
     controller = unit;
     service = unitRef.get(FileService);
     signedUrlService = unitRef.get(SignedUrlService);
+    storageService = unitRef.get(StorageService);
 
     // Reset mocks
     jest.clearAllMocks();
 
-    // Mock createReadStream
-    const mockStream = {
-      on: jest.fn(),
-      pipe: jest.fn(),
+    // Per-record provider resolution: the controller always resolves via
+    // storageService.getProvider(file.storageType) and reads through the
+    // returned provider — never a direct fs call.
+    mockProvider = {
+      writeStream: jest.fn(),
+      getReadStream: jest
+        .fn()
+        .mockResolvedValue(Readable.from([Buffer.from('data')])),
+      deleteFile: jest.fn(),
+      fileExists: jest.fn(),
+      getFileStats: jest.fn(),
+      getFileUrl: jest.fn(),
     };
-    (fs.createReadStream as jest.Mock).mockReturnValue(mockStream);
+    storageService.getProvider.mockReturnValue(mockProvider);
   });
 
   afterEach(() => {
@@ -123,7 +134,7 @@ describe('FileController', () => {
   });
 
   describe('getFileThumbnail', () => {
-    it('should stream thumbnail JPEG when available', async () => {
+    it('should stream thumbnail JPEG when available, via the LOCAL provider', async () => {
       const fileId = 'file-video';
       const mockFile = {
         id: fileId,
@@ -136,7 +147,10 @@ describe('FileController', () => {
 
       const result = await controller.getFileThumbnail(fileId, mockResponse);
 
-      expect(fs.createReadStream).toHaveBeenCalledWith(
+      expect(storageService.getProvider).toHaveBeenCalledWith(
+        StorageType.LOCAL,
+      );
+      expect(mockProvider.getReadStream).toHaveBeenCalledWith(
         '/uploads/thumbnails/file-video.jpg',
       );
       expect(mockResponse.set).toHaveBeenCalledWith({
@@ -145,6 +159,25 @@ describe('FileController', () => {
         'Cross-Origin-Resource-Policy': 'cross-origin',
       });
       expect(result).toBeDefined();
+    });
+
+    it('should stream an S3-backed thumbnail via the S3 provider (per-record resolution)', async () => {
+      const fileId = 'file-video-s3';
+      const mockFile = {
+        id: fileId,
+        thumbnailPath: 'thumbnails/file-video-s3.jpg',
+        storageType: StorageType.S3,
+        storagePath: 'video-key',
+      };
+
+      service.findOne.mockResolvedValue(mockFile as any);
+
+      await controller.getFileThumbnail(fileId, mockResponse);
+
+      expect(storageService.getProvider).toHaveBeenCalledWith(StorageType.S3);
+      expect(mockProvider.getReadStream).toHaveBeenCalledWith(
+        'thumbnails/file-video-s3.jpg',
+      );
     });
 
     it('should throw NotFoundException when no thumbnailPath', async () => {
@@ -170,7 +203,7 @@ describe('FileController', () => {
   });
 
   describe('getFile', () => {
-    it('should return file stream for local storage', async () => {
+    it('should return file stream for local storage via the LOCAL provider', async () => {
       const fileId = 'file-456';
       const mockFile = {
         id: fileId,
@@ -188,11 +221,42 @@ describe('FileController', () => {
       const result = await controller.getFile(fileId, req, mockResponse);
 
       expect(service.findOne).toHaveBeenCalledWith(fileId);
-      expect(fs.createReadStream).toHaveBeenCalledWith('/tmp/download.pdf');
+      expect(storageService.getProvider).toHaveBeenCalledWith(
+        StorageType.LOCAL,
+      );
+      expect(mockProvider.getReadStream).toHaveBeenCalledWith(
+        '/tmp/download.pdf',
+      );
       expect(mockResponse.set).toHaveBeenCalledWith(
         expect.objectContaining({
           'Accept-Ranges': 'bytes',
         }),
+      );
+      expect(result).toBeDefined();
+    });
+
+    it('should return file stream for S3 storage via the S3 provider (per-record resolution)', async () => {
+      const mockFile = {
+        id: 'file-s3',
+        filename: 'remote.png',
+        mimeType: 'image/png',
+        fileType: FileType.IMAGE,
+        size: 1024,
+        storageType: StorageType.S3,
+        storagePath: 'remote-object-key',
+      };
+
+      service.findOne.mockResolvedValue(mockFile as any);
+
+      const result = await controller.getFile(
+        'file-s3',
+        mockRequest(),
+        mockResponse,
+      );
+
+      expect(storageService.getProvider).toHaveBeenCalledWith(StorageType.S3);
+      expect(mockProvider.getReadStream).toHaveBeenCalledWith(
+        'remote-object-key',
       );
       expect(result).toBeDefined();
     });
@@ -239,10 +303,13 @@ describe('FileController', () => {
       await controller.getFile('file-range', req, mockResponse);
 
       expect(mockResponse.status).toHaveBeenCalledWith(206);
-      expect(fs.createReadStream).toHaveBeenCalledWith('/tmp/video.mp4', {
-        start: 0,
-        end: 999,
-      });
+      expect(mockProvider.getReadStream).toHaveBeenCalledWith(
+        '/tmp/video.mp4',
+        {
+          start: 0,
+          end: 999,
+        },
+      );
 
       const setCalls = (mockResponse.set as jest.Mock).mock.calls;
       const allHeaders = setCalls.reduce(
@@ -271,10 +338,13 @@ describe('FileController', () => {
       await controller.getFile('file-range-open', req, mockResponse);
 
       expect(mockResponse.status).toHaveBeenCalledWith(206);
-      expect(fs.createReadStream).toHaveBeenCalledWith('/tmp/video.mp4', {
-        start: 5000,
-        end: 9999,
-      });
+      expect(mockProvider.getReadStream).toHaveBeenCalledWith(
+        '/tmp/video.mp4',
+        {
+          start: 5000,
+          end: 9999,
+        },
+      );
     });
 
     it('should return 416 for out-of-range requests', async () => {
@@ -313,10 +383,13 @@ describe('FileController', () => {
       await controller.getFile('file-clamp', req, mockResponse);
 
       expect(mockResponse.status).toHaveBeenCalledWith(206);
-      expect(fs.createReadStream).toHaveBeenCalledWith('/tmp/video.mp4', {
-        start: 0,
-        end: 9999,
-      });
+      expect(mockProvider.getReadStream).toHaveBeenCalledWith(
+        '/tmp/video.mp4',
+        {
+          start: 0,
+          end: 9999,
+        },
+      );
 
       const setCalls = (mockResponse.set as jest.Mock).mock.calls;
       const allHeaders = setCalls.reduce(
@@ -345,10 +418,13 @@ describe('FileController', () => {
       await controller.getFile('file-1byte', req, mockResponse);
 
       expect(mockResponse.status).toHaveBeenCalledWith(206);
-      expect(fs.createReadStream).toHaveBeenCalledWith('/tmp/video.mp4', {
-        start: 100,
-        end: 100,
-      });
+      expect(mockProvider.getReadStream).toHaveBeenCalledWith(
+        '/tmp/video.mp4',
+        {
+          start: 100,
+          end: 100,
+        },
+      );
 
       const setCalls = (mockResponse.set as jest.Mock).mock.calls;
       const allHeaders = setCalls.reduce(
@@ -378,7 +454,7 @@ describe('FileController', () => {
 
       // Should serve full file (no 206, no Content-Range)
       expect(mockResponse.status).not.toHaveBeenCalled();
-      expect(fs.createReadStream).toHaveBeenCalledWith('/tmp/video.mp4');
+      expect(mockProvider.getReadStream).toHaveBeenCalledWith('/tmp/video.mp4');
     });
 
     it('should return 416 when start > end in Range', async () => {
@@ -422,22 +498,28 @@ describe('FileController', () => {
       );
     });
 
-    it('should throw NotImplementedException for non-local storage', async () => {
+    it('should support Range requests for S3-backed files too', async () => {
       const mockFile = {
-        id: 'file-s3',
-        filename: 'remote.png',
-        mimeType: 'image/png',
-        fileType: FileType.IMAGE,
-        size: 1024,
+        id: 'file-s3-range',
+        filename: 'video.mp4',
+        mimeType: 'video/mp4',
+        fileType: FileType.VIDEO,
+        size: 10000,
         storageType: StorageType.S3,
-        storagePath: 's3://bucket/remote.png',
+        storagePath: 's3-video-key',
       };
 
       service.findOne.mockResolvedValue(mockFile as any);
+      const req = mockRequest('bytes=0-999');
 
-      await expect(
-        controller.getFile('file-s3', mockRequest(), mockResponse),
-      ).rejects.toThrow(NotImplementedException);
+      await controller.getFile('file-s3-range', req, mockResponse);
+
+      expect(storageService.getProvider).toHaveBeenCalledWith(StorageType.S3);
+      expect(mockResponse.status).toHaveBeenCalledWith(206);
+      expect(mockProvider.getReadStream).toHaveBeenCalledWith('s3-video-key', {
+        start: 0,
+        end: 999,
+      });
     });
 
     it('should throw NotFoundException if file not found', async () => {

--- a/backend/src/file/file.controller.ts
+++ b/backend/src/file/file.controller.ts
@@ -2,7 +2,6 @@ import {
   Controller,
   Get,
   NotFoundException,
-  NotImplementedException,
   Param,
   Req,
   Res,
@@ -14,8 +13,7 @@ import { ApiOkResponse } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { FileService } from './file.service';
 import { SignedUrlService } from './signed-url.service';
-import { StorageType } from '@prisma/client';
-import { createReadStream } from 'fs';
+import { StorageService } from '@/storage/storage.service';
 
 import { FileAccessGuard } from '@/file/file-access/file-access.guard';
 import { FileAuthGuard } from '@/file/file-auth.guard';
@@ -30,6 +28,7 @@ export class FileController {
   constructor(
     private readonly fileService: FileService,
     private readonly signedUrlService: SignedUrlService,
+    private readonly storageService: StorageService,
   ) {}
 
   @Get(':id/signed-url')
@@ -90,7 +89,10 @@ export class FileController {
       throw new NotFoundException('No thumbnail available for this file');
     }
 
-    const stream = createReadStream(file.thumbnailPath);
+    // Per-record provider resolution: a mixed instance can have both
+    // LOCAL and S3 files, each served by its own storageType's provider.
+    const provider = this.storageService.getProvider(file.storageType);
+    const stream = await provider.getReadStream(file.thumbnailPath);
 
     res.set({
       'Content-Type': 'image/jpeg',
@@ -114,11 +116,13 @@ export class FileController {
       throw new NotFoundException('File not found');
     }
 
-    if (file.storageType !== StorageType.LOCAL) {
-      throw new NotImplementedException(
-        'Only local file storage is supported at this time',
-      );
-    }
+    // Per-record provider resolution: a mixed instance can have both
+    // LOCAL and S3 files, each served by its own storageType's provider.
+    // Access control (FileAuthGuard / FileAccessGuard) has already run by
+    // this point — the backend always streams object bytes through this
+    // route rather than redirecting to a presigned URL, so that guard
+    // chain stays the single source of truth for file access.
+    const provider = this.storageService.getProvider(file.storageType);
 
     // Sanitize filename for Content-Disposition header (RFC 5987)
     const sanitizedFilename = file.filename.replace(/["\\\n\r]/g, '_');
@@ -161,7 +165,7 @@ export class FileController {
         // Clamp end to file boundary (per RFC 7233 §2.1)
         const clampedEnd = Math.min(end, fileSize - 1);
         const chunkSize = clampedEnd - start + 1;
-        const stream = createReadStream(file.storagePath, {
+        const stream = await provider.getReadStream(file.storagePath, {
           start,
           end: clampedEnd,
         });
@@ -177,7 +181,7 @@ export class FileController {
     }
 
     // No Range header — serve full file
-    const stream = createReadStream(file.storagePath);
+    const stream = await provider.getReadStream(file.storagePath);
 
     res.set({
       'Content-Type': file.mimeType,

--- a/backend/src/file/file.service.spec.ts
+++ b/backend/src/file/file.service.spec.ts
@@ -3,11 +3,13 @@ import type { Mocked } from '@suites/doubles.jest';
 import { FileService } from './file.service';
 import { DatabaseService } from '@/database/database.service';
 import { StorageService } from '@/storage/storage.service';
+import type { IStorageProvider } from '@/storage/interfaces/storage-provider.interface';
 
 describe('FileService', () => {
   let service: FileService;
   let databaseService: Mocked<DatabaseService>;
   let storageService: Mocked<StorageService>;
+  let mockProvider: jest.Mocked<IStorageProvider>;
 
   beforeEach(async () => {
     const { unit, unitRef } = await TestBed.solitary(FileService).compile();
@@ -19,8 +21,18 @@ describe('FileService', () => {
     // Reset mocks
     jest.clearAllMocks();
 
-    // Default mock for deleteFile
-    storageService.deleteFile.mockResolvedValue(undefined);
+    // Per-record provider resolution: cleanupOldFiles calls
+    // storageService.getProvider(file.storageType) and operates on the
+    // returned provider directly (never the ambient/local-only wrappers).
+    mockProvider = {
+      writeStream: jest.fn(),
+      getReadStream: jest.fn(),
+      deleteFile: jest.fn().mockResolvedValue(undefined),
+      fileExists: jest.fn(),
+      getFileStats: jest.fn(),
+      getFileUrl: jest.fn(),
+    };
+    storageService.getProvider.mockReturnValue(mockProvider);
   });
 
   afterEach(() => {
@@ -135,18 +147,20 @@ describe('FileService', () => {
   });
 
   describe('cleanupOldFiles', () => {
-    it('should cleanup deleted files from local storage', async () => {
+    it('should cleanup deleted files from local storage via the LOCAL provider', async () => {
       const deletedFiles = [
         {
           id: 'file-1',
           storageType: 'LOCAL',
           storagePath: '/tmp/file1.png',
+          thumbnailPath: null,
           deletedAt: new Date(),
         },
         {
           id: 'file-2',
           storageType: 'LOCAL',
           storagePath: '/tmp/file2.png',
+          thumbnailPath: null,
           deletedAt: new Date(),
         },
       ];
@@ -162,9 +176,10 @@ describe('FileService', () => {
         },
       });
 
-      expect(storageService.deleteFile).toHaveBeenCalledWith('/tmp/file1.png');
-      expect(storageService.deleteFile).toHaveBeenCalledWith('/tmp/file2.png');
-      expect(storageService.deleteFile).toHaveBeenCalledTimes(2);
+      expect(storageService.getProvider).toHaveBeenCalledWith('LOCAL');
+      expect(mockProvider.deleteFile).toHaveBeenCalledWith('/tmp/file1.png');
+      expect(mockProvider.deleteFile).toHaveBeenCalledWith('/tmp/file2.png');
+      expect(mockProvider.deleteFile).toHaveBeenCalledTimes(2);
 
       expect(databaseService.file.delete).toHaveBeenCalledWith({
         where: { id: 'file-1' },
@@ -174,22 +189,78 @@ describe('FileService', () => {
       });
     });
 
-    it('should skip non-LOCAL storage files', async () => {
+    it('should clean up S3-backed files via the S3 provider (per-record resolution)', async () => {
       const deletedFiles = [
         {
           id: 'file-s3',
           storageType: 'S3',
-          storagePath: 's3://bucket/file.png',
+          storagePath: 'abc123def456',
+          thumbnailPath: null,
           deletedAt: new Date(),
         },
       ];
 
       databaseService.file.findMany.mockResolvedValue(deletedFiles as any);
+      databaseService.file.delete.mockResolvedValue({ id: 'file-s3' } as any);
 
       await service.cleanupOldFiles();
 
-      expect(storageService.deleteFile).not.toHaveBeenCalled();
-      expect(databaseService.file.delete).not.toHaveBeenCalled();
+      expect(storageService.getProvider).toHaveBeenCalledWith('S3');
+      expect(mockProvider.deleteFile).toHaveBeenCalledWith('abc123def456');
+      expect(databaseService.file.delete).toHaveBeenCalledWith({
+        where: { id: 'file-s3' },
+      });
+    });
+
+    it('should also clean up the thumbnail object when present, via the same provider', async () => {
+      const deletedFiles = [
+        {
+          id: 'file-video',
+          storageType: 'S3',
+          storagePath: 'video-key',
+          thumbnailPath: 'thumbnails/file-video.jpg',
+          deletedAt: new Date(),
+        },
+      ];
+
+      databaseService.file.findMany.mockResolvedValue(deletedFiles as any);
+      databaseService.file.delete.mockResolvedValue({} as any);
+
+      await service.cleanupOldFiles();
+
+      expect(mockProvider.deleteFile).toHaveBeenCalledWith('video-key');
+      expect(mockProvider.deleteFile).toHaveBeenCalledWith(
+        'thumbnails/file-video.jpg',
+      );
+      expect(databaseService.file.delete).toHaveBeenCalledWith({
+        where: { id: 'file-video' },
+      });
+    });
+
+    it('should still delete the DB row when thumbnail cleanup fails (non-fatal)', async () => {
+      const deletedFiles = [
+        {
+          id: 'file-video',
+          storageType: 'LOCAL',
+          storagePath: '/tmp/video.mp4',
+          thumbnailPath: '/tmp/thumbnails/file-video.jpg',
+          deletedAt: new Date(),
+        },
+      ];
+
+      databaseService.file.findMany.mockResolvedValue(deletedFiles as any);
+      databaseService.file.delete.mockResolvedValue({} as any);
+      mockProvider.deleteFile.mockImplementation((key: string) =>
+        key.includes('thumbnails')
+          ? Promise.reject(new Error('thumbnail already gone'))
+          : Promise.resolve(),
+      );
+
+      await expect(service.cleanupOldFiles()).resolves.toBeUndefined();
+
+      expect(databaseService.file.delete).toHaveBeenCalledWith({
+        where: { id: 'file-video' },
+      });
     });
 
     it('should skip files without storage path', async () => {
@@ -198,6 +269,7 @@ describe('FileService', () => {
           id: 'file-no-path',
           storageType: 'LOCAL',
           storagePath: null,
+          thumbnailPath: null,
           deletedAt: new Date(),
         },
       ];
@@ -206,7 +278,8 @@ describe('FileService', () => {
 
       await service.cleanupOldFiles();
 
-      expect(storageService.deleteFile).not.toHaveBeenCalled();
+      expect(storageService.getProvider).not.toHaveBeenCalled();
+      expect(mockProvider.deleteFile).not.toHaveBeenCalled();
       expect(databaseService.file.delete).not.toHaveBeenCalled();
     });
 
@@ -216,28 +289,28 @@ describe('FileService', () => {
           id: 'file-error',
           storageType: 'LOCAL',
           storagePath: '/tmp/error.png',
+          thumbnailPath: null,
           deletedAt: new Date(),
         },
         {
           id: 'file-success',
           storageType: 'LOCAL',
           storagePath: '/tmp/success.png',
+          thumbnailPath: null,
           deletedAt: new Date(),
         },
       ];
 
       databaseService.file.findMany.mockResolvedValue(deletedFiles as any);
-      storageService.deleteFile
+      mockProvider.deleteFile
         .mockRejectedValueOnce(new Error('File not found'))
         .mockResolvedValueOnce(undefined);
 
       await service.cleanupOldFiles();
 
       // Should have attempted both files
-      expect(storageService.deleteFile).toHaveBeenCalledWith('/tmp/error.png');
-      expect(storageService.deleteFile).toHaveBeenCalledWith(
-        '/tmp/success.png',
-      );
+      expect(mockProvider.deleteFile).toHaveBeenCalledWith('/tmp/error.png');
+      expect(mockProvider.deleteFile).toHaveBeenCalledWith('/tmp/success.png');
 
       // Only successful file should be deleted from DB
       expect(databaseService.file.delete).toHaveBeenCalledTimes(1);
@@ -251,7 +324,7 @@ describe('FileService', () => {
 
       await service.cleanupOldFiles();
 
-      expect(storageService.deleteFile).not.toHaveBeenCalled();
+      expect(mockProvider.deleteFile).not.toHaveBeenCalled();
       expect(databaseService.file.delete).not.toHaveBeenCalled();
     });
 
@@ -261,6 +334,7 @@ describe('FileService', () => {
           id: 'file-db-error',
           storageType: 'LOCAL',
           storagePath: '/tmp/file.png',
+          thumbnailPath: null,
           deletedAt: new Date(),
         },
       ];
@@ -273,7 +347,7 @@ describe('FileService', () => {
       // Should not throw - just logs error
       await expect(service.cleanupOldFiles()).resolves.toBeUndefined();
 
-      expect(storageService.deleteFile).toHaveBeenCalledWith('/tmp/file.png');
+      expect(mockProvider.deleteFile).toHaveBeenCalledWith('/tmp/file.png');
     });
   });
 });

--- a/backend/src/file/file.service.spec.ts
+++ b/backend/src/file/file.service.spec.ts
@@ -1,3 +1,4 @@
+import { NotFoundException } from '@nestjs/common';
 import { TestBed } from '@suites/unit';
 import type { Mocked } from '@suites/doubles.jest';
 import { FileService } from './file.service';
@@ -75,6 +76,31 @@ describe('FileService', () => {
       );
 
       await expect(service.findOne(fileId)).rejects.toThrow('File not found');
+    });
+
+    it('should map Prisma P2025 (missing or soft-deleted row) to NotFoundException', async () => {
+      const fileId = 'soft-deleted-file';
+
+      // findUniqueOrThrow's `deletedAt: null` filter means a soft-deleted
+      // row rejects with P2025, exactly like a genuinely-missing id.
+      databaseService.file.findUniqueOrThrow.mockRejectedValue({
+        code: 'P2025',
+      });
+
+      await expect(service.findOne(fileId)).rejects.toThrow(NotFoundException);
+      await expect(service.findOne(fileId)).rejects.toThrow('File not found');
+    });
+
+    it('should rethrow non-P2025 errors unchanged', async () => {
+      const fileId = 'file-123';
+      const dbError = new Error('connection lost');
+
+      databaseService.file.findUniqueOrThrow.mockRejectedValue(dbError);
+
+      await expect(service.findOne(fileId)).rejects.toThrow('connection lost');
+      await expect(service.findOne(fileId)).rejects.not.toThrow(
+        NotFoundException,
+      );
     });
   });
 

--- a/backend/src/file/file.service.ts
+++ b/backend/src/file/file.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { DatabaseService } from '@/database/database.service';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { StorageService } from '@/storage/storage.service';
+import { IStorageProvider } from '@/storage/interfaces/storage-provider.interface';
 import { Prisma } from '@prisma/client';
 
 @Injectable()
@@ -44,16 +45,31 @@ export class FileService {
     this.logger.debug(`Found ${deletedFiles.length} files to delete.`);
 
     for (const file of deletedFiles) {
-      try {
-        if (file.storageType === 'LOCAL' && file.storagePath) {
-          // Delete file from local storage
-          await this.cleanupFile(file.storagePath);
+      if (!file.storagePath) {
+        continue;
+      }
 
-          // Quota was already decremented at soft-delete time (in FileUploadService.remove)
-          await this.databaseService.file.delete({
-            where: { id: file.id },
+      try {
+        // Per-record provider resolution: a mixed instance may have both
+        // LOCAL and S3 rows awaiting physical deletion.
+        const provider = this.storageService.getProvider(file.storageType);
+        await this.cleanupObject(provider, file.storagePath);
+
+        // Video thumbnails live under the same storageType as their parent
+        // file. Best-effort: a missing/failed thumbnail delete must not
+        // block removing the DB row.
+        if (file.thumbnailPath) {
+          await provider.deleteFile(file.thumbnailPath).catch((error) => {
+            this.logger.warn(
+              `Failed to clean up thumbnail for file ${file.id}: ${error}`,
+            );
           });
         }
+
+        // Quota was already decremented at soft-delete time (in FileUploadService.remove)
+        await this.databaseService.file.delete({
+          where: { id: file.id },
+        });
       } catch (error) {
         // Log error but continue with next file
         this.logger.error(`Failed to delete file with ID ${file.id}:`, error);
@@ -61,12 +77,15 @@ export class FileService {
     }
   }
 
-  private async cleanupFile(filePath: string): Promise<void> {
+  private async cleanupObject(
+    provider: IStorageProvider,
+    key: string,
+  ): Promise<void> {
     try {
-      await this.storageService.deleteFile(filePath);
-      this.logger.debug(`Cleaned up file: ${filePath}`);
+      await provider.deleteFile(key);
+      this.logger.debug(`Cleaned up file: ${key}`);
     } catch (error) {
-      this.logger.warn(`Failed to clean up file ${filePath}: ${error}`);
+      this.logger.warn(`Failed to clean up file ${key}: ${error}`);
       throw error;
     }
   }

--- a/backend/src/file/file.service.ts
+++ b/backend/src/file/file.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { DatabaseService } from '@/database/database.service';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { StorageService } from '@/storage/storage.service';
 import { IStorageProvider } from '@/storage/interfaces/storage-provider.interface';
 import { Prisma } from '@prisma/client';
+import { isPrismaError } from '@/common/utils/prisma.utils';
 
 @Injectable()
 export class FileService {
@@ -13,10 +14,22 @@ export class FileService {
     private readonly storageService: StorageService,
   ) {}
 
-  findOne(id: string) {
-    return this.databaseService.file.findUniqueOrThrow({
-      where: { id, deletedAt: null },
-    });
+  async findOne(id: string) {
+    try {
+      return await this.databaseService.file.findUniqueOrThrow({
+        where: { id, deletedAt: null },
+      });
+    } catch (error) {
+      // findUniqueOrThrow rejects with P2025 (not `null`) for both a
+      // genuinely-missing id AND a soft-deleted row (excluded by the
+      // `deletedAt: null` filter above). Left unhandled, this was a raw
+      // Prisma error bubbling past every controller's dead `if (!file)`
+      // check — pre-existing bug, fixed here per repo testing policy.
+      if (isPrismaError(error, 'P2025')) {
+        throw new NotFoundException('File not found');
+      }
+      throw error;
+    }
   }
 
   async markForDeletion(fileId: string, tx?: Prisma.TransactionClient) {

--- a/backend/src/file/thumbnail-backfill.service.spec.ts
+++ b/backend/src/file/thumbnail-backfill.service.spec.ts
@@ -5,7 +5,28 @@ import { ThumbnailBackfillService } from './thumbnail-backfill.service';
 import { DatabaseService } from '@/database/database.service';
 import { StorageService } from '@/storage/storage.service';
 import { ThumbnailService } from './thumbnail.service';
-import { FileType } from '@prisma/client';
+import { FileType, StorageType } from '@prisma/client';
+import type { IStorageProvider } from '@/storage/interfaces/storage-provider.interface';
+import { Readable } from 'stream';
+
+// The S3 download-to-tmp branch pipes a real fs write stream; mocking just
+// createWriteStream/rm/pipeline keeps the S3 backfill tests fast/deterministic
+// and avoids interaction between jest fake timers (used throughout this
+// suite for the throttle sleep) and real filesystem I/O completion
+// callbacks. Everything else in 'fs' passes through unmocked — Prisma's
+// generated client uses fs.existsSync internally at import time.
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  promises: {
+    ...jest.requireActual('fs').promises,
+    rm: jest.fn().mockResolvedValue(undefined),
+  },
+  createWriteStream: jest.fn(() => ({})),
+}));
+jest.mock('stream/promises', () => ({
+  ...jest.requireActual('stream/promises'),
+  pipeline: jest.fn().mockResolvedValue(undefined),
+}));
 
 describe('ThumbnailBackfillService', () => {
   let service: ThumbnailBackfillService;
@@ -13,6 +34,7 @@ describe('ThumbnailBackfillService', () => {
   let storageService: Mocked<StorageService>;
   let thumbnailService: Mocked<ThumbnailService>;
   let configService: Mocked<ConfigService>;
+  let mockProvider: jest.Mocked<IStorageProvider>;
 
   beforeEach(async () => {
     const { unit, unitRef } = await TestBed.solitary(
@@ -31,6 +53,19 @@ describe('ThumbnailBackfillService', () => {
     // Default: no env vars set, so the service falls back to its defaults
     // (enabled, batch size 25, 60s startup delay, 1s throttle).
     configService.get.mockReturnValue(undefined);
+
+    // Per-record provider resolution: backfill() always calls
+    // storageService.getProvider(file.storageType) and operates on the
+    // returned provider directly (never the ambient/local-only wrappers).
+    mockProvider = {
+      writeStream: jest.fn(),
+      getReadStream: jest.fn(),
+      deleteFile: jest.fn(),
+      fileExists: jest.fn(),
+      getFileStats: jest.fn(),
+      getFileUrl: jest.fn(),
+    };
+    storageService.getProvider.mockReturnValue(mockProvider);
   });
 
   afterEach(() => {
@@ -144,7 +179,7 @@ describe('ThumbnailBackfillService', () => {
         },
         orderBy: { id: 'asc' },
         take: 25,
-        select: { id: true, storagePath: true },
+        select: { id: true, storagePath: true, storageType: true },
       });
     });
 
@@ -163,13 +198,25 @@ describe('ThumbnailBackfillService', () => {
       );
       databaseService.file.findMany
         .mockResolvedValueOnce([
-          { id: 'file-a', storagePath: '/clips/a.mp4' },
-          { id: 'file-b', storagePath: '/clips/b.mp4' },
+          {
+            id: 'file-a',
+            storagePath: '/clips/a.mp4',
+            storageType: StorageType.LOCAL,
+          },
+          {
+            id: 'file-b',
+            storagePath: '/clips/b.mp4',
+            storageType: StorageType.LOCAL,
+          },
         ] as any)
         .mockResolvedValueOnce([
-          { id: 'file-c', storagePath: '/clips/c.mp4' },
+          {
+            id: 'file-c',
+            storagePath: '/clips/c.mp4',
+            storageType: StorageType.LOCAL,
+          },
         ] as any);
-      storageService.fileExists.mockResolvedValue(true);
+      mockProvider.fileExists.mockResolvedValue(true);
       thumbnailService.generateVideoThumbnail
         .mockResolvedValueOnce('thumb-a.jpg')
         .mockResolvedValueOnce('thumb-b.jpg')
@@ -190,7 +237,7 @@ describe('ThumbnailBackfillService', () => {
         },
         orderBy: { id: 'asc' },
         take: 2,
-        select: { id: true, storagePath: true },
+        select: { id: true, storagePath: true, storageType: true },
       });
       expect(databaseService.file.findMany).toHaveBeenNthCalledWith(2, {
         where: {
@@ -201,7 +248,7 @@ describe('ThumbnailBackfillService', () => {
         },
         orderBy: { id: 'asc' },
         take: 2,
-        select: { id: true, storagePath: true },
+        select: { id: true, storagePath: true, storageType: true },
       });
       expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledTimes(3);
     });
@@ -306,11 +353,19 @@ describe('ThumbnailBackfillService', () => {
       );
       databaseService.file.findMany
         .mockResolvedValueOnce([
-          { id: 'file-1', storagePath: '/clips/a.mp4' },
-          { id: 'file-2', storagePath: '/clips/b.mp4' },
+          {
+            id: 'file-1',
+            storagePath: '/clips/a.mp4',
+            storageType: StorageType.LOCAL,
+          },
+          {
+            id: 'file-2',
+            storagePath: '/clips/b.mp4',
+            storageType: StorageType.LOCAL,
+          },
         ] as any)
         .mockResolvedValueOnce([]);
-      storageService.fileExists.mockResolvedValue(true);
+      mockProvider.fileExists.mockResolvedValue(true);
       thumbnailService.generateVideoThumbnail
         .mockResolvedValueOnce('thumb-1.jpg')
         .mockResolvedValueOnce('thumb-2.jpg');
@@ -330,11 +385,19 @@ describe('ThumbnailBackfillService', () => {
       );
       databaseService.file.findMany
         .mockResolvedValueOnce([
-          { id: 'file-1', storagePath: '/clips/a.mp4' },
-          { id: 'file-2', storagePath: '/clips/b.mp4' },
+          {
+            id: 'file-1',
+            storagePath: '/clips/a.mp4',
+            storageType: StorageType.LOCAL,
+          },
+          {
+            id: 'file-2',
+            storagePath: '/clips/b.mp4',
+            storageType: StorageType.LOCAL,
+          },
         ] as any)
         .mockResolvedValueOnce([]);
-      storageService.fileExists.mockResolvedValue(true);
+      mockProvider.fileExists.mockResolvedValue(true);
       thumbnailService.generateVideoThumbnail
         .mockResolvedValueOnce('thumb-1.jpg')
         .mockResolvedValueOnce('thumb-2.jpg');
@@ -366,11 +429,19 @@ describe('ThumbnailBackfillService', () => {
     it('should generate thumbnails and persist paths for backfillable files', async () => {
       databaseService.file.findMany
         .mockResolvedValueOnce([
-          { id: 'file-1', storagePath: '/clips/a.mp4' },
-          { id: 'file-2', storagePath: '/clips/b.mp4' },
+          {
+            id: 'file-1',
+            storagePath: '/clips/a.mp4',
+            storageType: StorageType.LOCAL,
+          },
+          {
+            id: 'file-2',
+            storagePath: '/clips/b.mp4',
+            storageType: StorageType.LOCAL,
+          },
         ] as any)
         .mockResolvedValueOnce([]);
-      storageService.fileExists.mockResolvedValue(true);
+      mockProvider.fileExists.mockResolvedValue(true);
       thumbnailService.generateVideoThumbnail
         .mockResolvedValueOnce('uploads/thumbnails/file-1.jpg')
         .mockResolvedValueOnce('uploads/thumbnails/file-2.jpg');
@@ -394,10 +465,14 @@ describe('ThumbnailBackfillService', () => {
     it('should skip files whose source no longer exists on disk', async () => {
       databaseService.file.findMany
         .mockResolvedValueOnce([
-          { id: 'file-gone', storagePath: '/clips/gone.mp4' },
+          {
+            id: 'file-gone',
+            storagePath: '/clips/gone.mp4',
+            storageType: StorageType.LOCAL,
+          },
         ] as any)
         .mockResolvedValueOnce([]);
-      storageService.fileExists.mockResolvedValue(false);
+      mockProvider.fileExists.mockResolvedValue(false);
 
       const resultPromise = service.backfill();
       await jest.runAllTimersAsync();
@@ -411,11 +486,19 @@ describe('ThumbnailBackfillService', () => {
     it('should skip files whose generation fails and continue with the rest', async () => {
       databaseService.file.findMany
         .mockResolvedValueOnce([
-          { id: 'file-bad', storagePath: '/clips/bad.mp4' },
-          { id: 'file-good', storagePath: '/clips/good.mp4' },
+          {
+            id: 'file-bad',
+            storagePath: '/clips/bad.mp4',
+            storageType: StorageType.LOCAL,
+          },
+          {
+            id: 'file-good',
+            storagePath: '/clips/good.mp4',
+            storageType: StorageType.LOCAL,
+          },
         ] as any)
         .mockResolvedValueOnce([]);
-      storageService.fileExists.mockResolvedValue(true);
+      mockProvider.fileExists.mockResolvedValue(true);
       thumbnailService.generateVideoThumbnail
         .mockResolvedValueOnce(null) // generateVideoThumbnail returns null on failure
         .mockResolvedValueOnce('uploads/thumbnails/file-good.jpg');
@@ -436,11 +519,19 @@ describe('ThumbnailBackfillService', () => {
     it('should continue with remaining files when one file errors mid-processing', async () => {
       databaseService.file.findMany
         .mockResolvedValueOnce([
-          { id: 'file-db-err', storagePath: '/clips/a.mp4' },
-          { id: 'file-ok', storagePath: '/clips/b.mp4' },
+          {
+            id: 'file-db-err',
+            storagePath: '/clips/a.mp4',
+            storageType: StorageType.LOCAL,
+          },
+          {
+            id: 'file-ok',
+            storagePath: '/clips/b.mp4',
+            storageType: StorageType.LOCAL,
+          },
         ] as any)
         .mockResolvedValueOnce([]);
-      storageService.fileExists.mockResolvedValue(true);
+      mockProvider.fileExists.mockResolvedValue(true);
       thumbnailService.generateVideoThumbnail
         .mockResolvedValueOnce('uploads/thumbnails/file-db-err.jpg')
         .mockResolvedValueOnce('uploads/thumbnails/file-ok.jpg');
@@ -456,6 +547,112 @@ describe('ThumbnailBackfillService', () => {
       expect(databaseService.file.update).toHaveBeenCalledWith({
         where: { id: 'file-ok' },
         data: { thumbnailPath: 'uploads/thumbnails/file-ok.jpg' },
+      });
+    });
+
+    describe('per-record provider resolution (mixed LOCAL/S3 instances)', () => {
+      it('resolves the LOCAL provider for a LOCAL-storageType file and feeds ffmpeg directly', async () => {
+        databaseService.file.findMany
+          .mockResolvedValueOnce([
+            {
+              id: 'file-local',
+              storagePath: '/clips/local.mp4',
+              storageType: StorageType.LOCAL,
+            },
+          ] as any)
+          .mockResolvedValueOnce([]);
+        mockProvider.fileExists.mockResolvedValue(true);
+        thumbnailService.generateVideoThumbnail.mockResolvedValue(
+          'uploads/thumbnails/file-local.jpg',
+        );
+        databaseService.file.update.mockResolvedValue({} as any);
+
+        const resultPromise = service.backfill();
+        await jest.runAllTimersAsync();
+        const result = await resultPromise;
+
+        expect(result).toEqual({ generated: 1, skipped: 0 });
+        expect(storageService.getProvider).toHaveBeenCalledWith(
+          StorageType.LOCAL,
+        );
+        // LOCAL source: ffmpeg reads the storagePath directly, no download step.
+        expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledWith(
+          '/clips/local.mp4',
+          'file-local',
+          StorageType.LOCAL,
+        );
+        expect(mockProvider.getReadStream).not.toHaveBeenCalled();
+      });
+
+      it('downloads an S3-storageType file to a local tmp path before generating, then cleans it up', async () => {
+        databaseService.file.findMany
+          .mockResolvedValueOnce([
+            {
+              id: 'file-s3',
+              storagePath: 's3-object-key.mp4',
+              storageType: StorageType.S3,
+            },
+          ] as any)
+          .mockResolvedValueOnce([]);
+        mockProvider.fileExists.mockResolvedValue(true);
+        mockProvider.getReadStream.mockResolvedValue(
+          Readable.from([Buffer.from('fake video bytes')]),
+        );
+
+        let capturedTmpPath: string | undefined;
+        thumbnailService.generateVideoThumbnail.mockImplementation(
+          (filePath: string) => {
+            capturedTmpPath = filePath;
+            return Promise.resolve('thumbnails/file-s3.jpg');
+          },
+        );
+        databaseService.file.update.mockResolvedValue({} as any);
+
+        const resultPromise = service.backfill();
+        await jest.runAllTimersAsync();
+        const result = await resultPromise;
+
+        expect(result).toEqual({ generated: 1, skipped: 0 });
+        expect(storageService.getProvider).toHaveBeenCalledWith(StorageType.S3);
+        expect(mockProvider.getReadStream).toHaveBeenCalledWith(
+          's3-object-key.mp4',
+        );
+        // ffmpeg was fed a LOCAL scratch path, not the S3 key.
+        expect(capturedTmpPath).toBeDefined();
+        expect(capturedTmpPath).not.toBe('s3-object-key.mp4');
+        expect(thumbnailService.generateVideoThumbnail).toHaveBeenCalledWith(
+          capturedTmpPath,
+          'file-s3',
+          StorageType.S3,
+        );
+        expect(databaseService.file.update).toHaveBeenCalledWith({
+          where: { id: 'file-s3' },
+          data: { thumbnailPath: 'thumbnails/file-s3.jpg' },
+        });
+      });
+
+      it('still cleans up the local tmp download when thumbnail generation fails for an S3 file', async () => {
+        databaseService.file.findMany
+          .mockResolvedValueOnce([
+            {
+              id: 'file-s3-fail',
+              storagePath: 's3-object-key.mp4',
+              storageType: StorageType.S3,
+            },
+          ] as any)
+          .mockResolvedValueOnce([]);
+        mockProvider.fileExists.mockResolvedValue(true);
+        mockProvider.getReadStream.mockResolvedValue(
+          Readable.from([Buffer.from('fake video bytes')]),
+        );
+        thumbnailService.generateVideoThumbnail.mockResolvedValue(null);
+
+        const resultPromise = service.backfill();
+        await jest.runAllTimersAsync();
+        const result = await resultPromise;
+
+        expect(result).toEqual({ generated: 0, skipped: 1 });
+        expect(databaseService.file.update).not.toHaveBeenCalled();
       });
     });
   });

--- a/backend/src/file/thumbnail-backfill.service.ts
+++ b/backend/src/file/thumbnail-backfill.service.ts
@@ -5,9 +5,15 @@ import {
   OnModuleDestroy,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { FileType } from '@prisma/client';
+import { FileType, StorageType } from '@prisma/client';
+import { promises as fs, createWriteStream } from 'fs';
+import { pipeline } from 'stream/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
 import { DatabaseService } from '@/database/database.service';
 import { StorageService } from '@/storage/storage.service';
+import { IStorageProvider } from '@/storage/interfaces/storage-provider.interface';
 import { ThumbnailService } from './thumbnail.service';
 
 /**
@@ -142,7 +148,7 @@ export class ThumbnailBackfillService
         },
         orderBy: { id: 'asc' },
         take: batchSize,
-        select: { id: true, storagePath: true },
+        select: { id: true, storagePath: true, storageType: true },
       });
 
       if (batch.length === 0) {
@@ -159,7 +165,11 @@ export class ThumbnailBackfillService
       // Best-effort per file: one failure must not abort the remaining candidates.
       for (const file of batch) {
         try {
-          if (!(await this.storageService.fileExists(file.storagePath))) {
+          // Per-record provider resolution: an instance may have files
+          // across both LOCAL and S3 storageType, especially mid-migration.
+          const provider = this.storageService.getProvider(file.storageType);
+
+          if (!(await provider.fileExists(file.storagePath))) {
             this.logger.warn(
               `Skipping thumbnail backfill for file ${file.id}: source ${file.storagePath} not found`,
             );
@@ -167,12 +177,11 @@ export class ThumbnailBackfillService
             continue;
           }
 
-          // generateVideoThumbnail logs and returns null on failure
-          const thumbnailPath =
-            await this.thumbnailService.generateVideoThumbnail(
-              file.storagePath,
-              file.id,
-            );
+          // generateThumbnailForFile logs and returns null on failure
+          const thumbnailPath = await this.generateThumbnailForFile(
+            file,
+            provider,
+          );
 
           if (!thumbnailPath) {
             skipped++;
@@ -214,5 +223,42 @@ export class ThumbnailBackfillService
     }
 
     return { generated, skipped };
+  }
+
+  /**
+   * Generates a thumbnail for a backfill candidate, resolving its source
+   * per-record. LOCAL files feed ffmpeg directly (it already reads from
+   * disk). Non-LOCAL (S3) files are downloaded to a local scratch file
+   * first — ffmpeg has no concept of reading from an object store — then
+   * cleaned up regardless of outcome.
+   */
+  private async generateThumbnailForFile(
+    file: { id: string; storagePath: string; storageType: StorageType },
+    provider: IStorageProvider,
+  ): Promise<string | null> {
+    if (file.storageType === StorageType.LOCAL) {
+      return this.thumbnailService.generateVideoThumbnail(
+        file.storagePath,
+        file.id,
+        file.storageType,
+      );
+    }
+
+    const tmpPath = path.join(
+      os.tmpdir(),
+      `thumbnail-backfill-${file.id}-${randomUUID()}`,
+    );
+
+    try {
+      const readStream = await provider.getReadStream(file.storagePath);
+      await pipeline(readStream, createWriteStream(tmpPath));
+      return await this.thumbnailService.generateVideoThumbnail(
+        tmpPath,
+        file.id,
+        file.storageType,
+      );
+    } finally {
+      await fs.rm(tmpPath, { force: true }).catch(() => undefined);
+    }
   }
 }

--- a/backend/src/file/thumbnail.service.ts
+++ b/backend/src/file/thumbnail.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as path from 'path';
-import { StorageService } from '@/storage/storage.service';
+import { StorageService, StorageType } from '@/storage/storage.service';
 import { FfmpegProvider } from '@/livekit/providers/ffmpeg.provider';
 
 @Injectable()
@@ -22,15 +22,33 @@ export class ThumbnailService {
    * Generate a JPEG thumbnail from a video file using FFmpeg.
    * Extracts a single frame at ~1 second, scaled to 480px wide.
    *
-   * @param filePath - Absolute path to the uploaded video file
+   * ffmpeg always needs a local filesystem path to write to. For LOCAL
+   * storage that's simply the final thumbnail location (unchanged, single
+   * write). For S3, extraction still lands in a local scratch file next to
+   * it, which is then streamed up to the object store and removed — the
+   * returned value is the S3 KEY, not a local path.
+   *
+   * @param filePath - Absolute path to the uploaded video file (always local — multer staging)
    * @param fileId - Database file ID (used for naming the thumbnail)
-   * @returns The thumbnail path on success, or null on failure (non-fatal)
+   * @param storageType - Where the parent `File` record lives; defaults to LOCAL
+   * @returns The thumbnail path/key on success, or null on failure (non-fatal)
    */
   async generateVideoThumbnail(
     filePath: string,
     fileId: string,
+    storageType: StorageType = StorageType.LOCAL,
   ): Promise<string | null> {
     const thumbnailDir = path.join(this.uploadsDir, 'thumbnails');
+
+    if (storageType !== StorageType.LOCAL) {
+      return this.generateAndUploadThumbnail(
+        filePath,
+        fileId,
+        storageType,
+        thumbnailDir,
+      );
+    }
+
     const thumbnailPath = path.join(thumbnailDir, `${fileId}.jpg`);
 
     try {
@@ -45,6 +63,44 @@ export class ThumbnailService {
         `Failed to generate thumbnail for file ${fileId}: ${error instanceof Error ? error.message : String(error)}`,
       );
       return null;
+    }
+  }
+
+  /**
+   * Non-LOCAL variant: extract to a local scratch file, upload it to the
+   * resolved provider, then remove the scratch copy regardless of outcome.
+   */
+  private async generateAndUploadThumbnail(
+    filePath: string,
+    fileId: string,
+    storageType: StorageType,
+    thumbnailDir: string,
+  ): Promise<string | null> {
+    const scratchPath = path.join(thumbnailDir, `${fileId}.jpg.tmp`);
+    const key = `thumbnails/${fileId}.jpg`;
+
+    try {
+      await this.storageService.ensureDirectory(thumbnailDir);
+      await this.runThumbnailExtraction(filePath, scratchPath);
+
+      const provider = this.storageService.getProvider(storageType);
+      await provider.writeStream(
+        key,
+        this.storageService.createReadStream(scratchPath),
+        { contentType: 'image/jpeg' },
+      );
+
+      this.logger.log(`Generated and uploaded thumbnail for file ${fileId}`);
+      return key;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to generate thumbnail for file ${fileId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    } finally {
+      // Best-effort scratch-file cleanup — non-fatal even if extraction
+      // never produced the file.
+      await this.storageService.deleteFile(scratchPath).catch(() => undefined);
     }
   }
 

--- a/backend/src/storage/interfaces/storage-provider.interface.ts
+++ b/backend/src/storage/interfaces/storage-provider.interface.ts
@@ -1,18 +1,106 @@
-import { ReadStream } from 'fs';
+import { Readable } from 'stream';
 
 /**
  * Storage Provider Interface
  *
- * Defines the contract for storage providers (filesystem, S3, Azure Blob, etc.)
- * This abstraction allows swapping storage backends without changing business logic.
+ * Object-store-shaped contract for storage backends (filesystem, S3, Azure
+ * Blob, etc.). Operates on opaque `key` strings rather than filesystem
+ * paths — for LocalStorageProvider a key happens to be a filesystem path
+ * (absolute or relative), for S3StorageProvider it is the S3 object key.
+ *
+ * This is deliberately narrow: it covers exactly what a `File` DB record
+ * needs (write once, read back — optionally ranged —, stat, delete, exists,
+ * URL). Directory-oriented filesystem operations (ensureDirectory,
+ * deleteDirectory, listFiles, deleteOldFiles, resolvePath, ...) are NOT part
+ * of this interface — S3 has no directory concept, and those operations are
+ * used exclusively by the LiveKit replay/egress pipeline and thumbnail
+ * generation, which inherently require a local scratch filesystem (ffmpeg
+ * reads/writes real files on disk). That surface stays local-only: see
+ * `LocalStorageProvider`'s additional public methods, which `StorageService`
+ * addresses directly (not through this interface).
  */
 
 export interface FileStats {
   size: number;
   mtime: Date;
   ctime: Date;
+  /** Populated by object-store providers (e.g. S3 HeadObject); undefined for local files. */
+  contentType?: string;
+  /** Populated by object-store providers; undefined for local files. */
+  etag?: string;
 }
 
+export interface WriteMeta {
+  contentType?: string;
+}
+
+export interface WriteResult {
+  size: number;
+  etag?: string;
+}
+
+export interface ReadRange {
+  /** Inclusive start byte offset. */
+  start: number;
+  /** Inclusive end byte offset. */
+  end: number;
+}
+
+export interface IStorageProvider {
+  /**
+   * Streams `source` to the object identified by `key`. Implementations
+   * MUST stream — never buffer the whole object in memory.
+   * @param key - Object key (local: filesystem path; S3: object key)
+   * @param source - Readable source (e.g. a local temp-file read stream)
+   * @param meta - Optional metadata (e.g. Content-Type)
+   * @returns The written object's size and, when available, its etag
+   */
+  writeStream(
+    key: string,
+    source: Readable,
+    meta?: WriteMeta,
+  ): Promise<WriteResult>;
+
+  /**
+   * Returns a readable stream for the object, optionally scoped to a byte
+   * range (used for HTTP Range request support in the file serve path).
+   * @param key - Object key
+   * @param range - Optional inclusive byte range
+   */
+  getReadStream(key: string, range?: ReadRange): Promise<Readable>;
+
+  /**
+   * Deletes the object identified by `key`.
+   */
+  deleteFile(key: string): Promise<void>;
+
+  /**
+   * Checks whether the object identified by `key` exists.
+   */
+  fileExists(key: string): Promise<boolean>;
+
+  /**
+   * Gets object metadata (HeadObject-style for S3).
+   */
+  getFileStats(key: string): Promise<FileStats>;
+
+  /**
+   * Gets a URL for accessing the object.
+   * For local storage: returns the key/path as-is.
+   * For S3: currently also returns the key as-is — presigned direct-to-S3
+   * URLs are a possible later optimization, not wired into any serve path
+   * in this task (the backend always streams object bytes through
+   * FileAuthGuard-protected routes).
+   */
+  getFileUrl(key: string): Promise<string>;
+}
+
+/**
+ * Local-filesystem-only types. Kept out of IStorageProvider (see module
+ * doc). Used by LocalStorageProvider's directory-oriented methods, which
+ * StorageService exposes as local-only convenience methods for the
+ * LiveKit replay/egress pipeline.
+ */
 export interface DeleteDirectoryOptions {
   recursive?: boolean;
   force?: boolean;
@@ -20,163 +108,4 @@ export interface DeleteDirectoryOptions {
 
 export interface ListFilesOptions {
   filter?: (filename: string) => boolean;
-}
-
-export interface IStorageProvider {
-  /**
-   * Ensures a directory exists, creating it if necessary
-   * @param path - Directory path
-   */
-  ensureDirectory(path: string): Promise<void>;
-
-  /**
-   * Checks if a directory exists
-   * @param path - Directory path
-   * @returns true if directory exists, false otherwise
-   */
-  directoryExists(path: string): Promise<boolean>;
-
-  /**
-   * Deletes a directory
-   * @param path - Directory path
-   * @param options - Deletion options (recursive, force)
-   */
-  deleteDirectory(
-    path: string,
-    options?: DeleteDirectoryOptions,
-  ): Promise<void>;
-
-  /**
-   * Deletes a file
-   * @param path - File path
-   */
-  deleteFile(path: string): Promise<void>;
-
-  /**
-   * Checks if a file exists
-   * @param path - File path
-   * @returns true if file exists, false otherwise
-   */
-  fileExists(path: string): Promise<boolean>;
-
-  /**
-   * Lists files in a directory
-   * @param dirPath - Directory path
-   * @param options - List options (filter function)
-   * @returns Array of filenames (not full paths)
-   */
-  listFiles(dirPath: string, options?: ListFilesOptions): Promise<string[]>;
-
-  /**
-   * Gets file metadata
-   * @param path - File path
-   * @returns File statistics
-   */
-  getFileStats(path: string): Promise<FileStats>;
-
-  /**
-   * Reads file contents
-   * @param path - File path
-   * @returns File contents as Buffer
-   */
-  readFile(path: string): Promise<Buffer>;
-
-  /**
-   * Writes file contents
-   * @param path - File path
-   * @param data - Data to write
-   */
-  writeFile(path: string, data: Buffer | string): Promise<void>;
-
-  /**
-   * Deletes files older than a specified date in a directory
-   * @param dirPath - Directory path
-   * @param olderThan - Delete files with mtime before this date
-   * @returns Number of files deleted
-   */
-  deleteOldFiles(dirPath: string, olderThan: Date): Promise<number>;
-
-  /**
-   * Creates a readable stream for a file
-   * Note: For local storage, this is a direct stream. For cloud storage,
-   * implementations may need to download to temp file first.
-   * @param path - File path
-   * @returns ReadStream for the file
-   */
-  createReadStream(path: string): ReadStream;
-
-  /**
-   * Gets a URL for accessing the file
-   * For local storage: returns the file path
-   * For S3: returns a signed URL
-   * For Azure Blob: returns a SAS URL
-   * @param path - File path or key
-   * @returns URL or path to access the file
-   */
-  getFileUrl(path: string): Promise<string>;
-
-  /**
-   * Resolves a relative path with a prefix
-   * For local storage: uses path.join(prefix, relativePath)
-   * For S3: concatenates bucket prefix and key
-   * @param relativePath - Relative path (e.g., "sessionId/")
-   * @param prefix - Base path prefix (e.g., "/app/storage/replay-segments")
-   * @returns Full resolved path
-   */
-  resolvePath(relativePath: string, prefix: string): string;
-
-  /**
-   * Lists files in a directory with prefix resolution
-   * @param relativeDir - Relative directory path
-   * @param prefix - Base path prefix
-   * @param options - List options (filter function)
-   * @returns Array of filenames (not full paths)
-   */
-  listFilesWithPrefix(
-    relativeDir: string,
-    prefix: string,
-    options?: ListFilesOptions,
-  ): Promise<string[]>;
-
-  /**
-   * Reads file contents with prefix resolution
-   * @param relativePath - Relative file path
-   * @param prefix - Base path prefix
-   * @returns File contents as Buffer
-   */
-  readFileWithPrefix(relativePath: string, prefix: string): Promise<Buffer>;
-
-  /**
-   * Deletes a directory with prefix resolution
-   * @param relativeDir - Relative directory path
-   * @param prefix - Base path prefix
-   * @param options - Deletion options (recursive, force)
-   */
-  deleteDirectoryWithPrefix(
-    relativeDir: string,
-    prefix: string,
-    options?: DeleteDirectoryOptions,
-  ): Promise<void>;
-
-  /**
-   * Gets file stats with prefix resolution
-   * @param relativePath - Relative file path
-   * @param prefix - Base path prefix
-   * @returns File statistics
-   */
-  getFileStatsWithPrefix(
-    relativePath: string,
-    prefix: string,
-  ): Promise<FileStats>;
-
-  /**
-   * Checks if directory exists with prefix resolution
-   * @param relativeDir - Relative directory path
-   * @param prefix - Base path prefix
-   * @returns true if directory exists, false otherwise
-   */
-  directoryExistsWithPrefix(
-    relativeDir: string,
-    prefix: string,
-  ): Promise<boolean>;
 }

--- a/backend/src/storage/providers/local-storage.provider.spec.ts
+++ b/backend/src/storage/providers/local-storage.provider.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed } from '@suites/unit';
 import { LocalStorageProvider } from './local-storage.provider';
-import { promises as fs, createReadStream } from 'fs';
+import { promises as fs, createReadStream, createWriteStream } from 'fs';
+import { pipeline } from 'stream/promises';
+import { Readable } from 'stream';
 
 // Mock fs module
 jest.mock('fs', () => ({
@@ -15,6 +17,13 @@ jest.mock('fs', () => ({
     writeFile: jest.fn(),
   },
   createReadStream: jest.fn(),
+  createWriteStream: jest.fn(),
+}));
+
+// Mock stream/promises' pipeline — writeStream pipes source -> destination
+// through it; tests only need to assert it was invoked with the right args.
+jest.mock('stream/promises', () => ({
+  pipeline: jest.fn(),
 }));
 
 describe('LocalStorageProvider', () => {
@@ -433,6 +442,71 @@ describe('LocalStorageProvider', () => {
       expect(await provider.getFileUrl('../parent/path')).toBe(
         '../parent/path',
       );
+    });
+  });
+
+  describe('writeStream', () => {
+    it('should ensure the parent directory exists, pipe source to disk, and return the written size', async () => {
+      (fs.mkdir as jest.Mock).mockResolvedValue(undefined);
+      (pipeline as unknown as jest.Mock).mockResolvedValue(undefined);
+      (fs.stat as jest.Mock).mockResolvedValue({ size: 2048 });
+      const mockWriteStream = {} as any;
+      (createWriteStream as jest.Mock).mockReturnValue(mockWriteStream);
+      const source = Readable.from([Buffer.from('data')]);
+
+      const result = await provider.writeStream(
+        '/test/nested/file.bin',
+        source,
+      );
+
+      expect(fs.mkdir).toHaveBeenCalledWith('/test/nested', {
+        recursive: true,
+      });
+      expect(createWriteStream).toHaveBeenCalledWith('/test/nested/file.bin');
+      expect(pipeline).toHaveBeenCalledWith(source, mockWriteStream);
+      expect(result).toEqual({ size: 2048 });
+    });
+
+    it('should propagate errors from the pipeline (e.g. disk full)', async () => {
+      (fs.mkdir as jest.Mock).mockResolvedValue(undefined);
+      (pipeline as unknown as jest.Mock).mockRejectedValue(new Error('ENOSPC'));
+      (createWriteStream as jest.Mock).mockReturnValue({} as any);
+      const source = Readable.from([Buffer.from('data')]);
+
+      await expect(
+        provider.writeStream('/test/file.bin', source),
+      ).rejects.toThrow('ENOSPC');
+    });
+  });
+
+  describe('getReadStream', () => {
+    it('should return a full-file read stream when no range is given', async () => {
+      const mockStream = {} as any;
+      (createReadStream as jest.Mock).mockReturnValue(mockStream);
+
+      const result = await provider.getReadStream('/test/file.txt');
+
+      expect(result).toBe(mockStream);
+      expect(createReadStream).toHaveBeenCalledWith(
+        '/test/file.txt',
+        undefined,
+      );
+    });
+
+    it('should pass start/end options through for ranged reads', async () => {
+      const mockStream = {} as any;
+      (createReadStream as jest.Mock).mockReturnValue(mockStream);
+
+      const result = await provider.getReadStream('/test/file.txt', {
+        start: 0,
+        end: 999,
+      });
+
+      expect(result).toBe(mockStream);
+      expect(createReadStream).toHaveBeenCalledWith('/test/file.txt', {
+        start: 0,
+        end: 999,
+      });
     });
   });
 });

--- a/backend/src/storage/providers/local-storage.provider.ts
+++ b/backend/src/storage/providers/local-storage.provider.ts
@@ -1,11 +1,20 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { promises as fs, createReadStream, ReadStream } from 'fs';
-import { join } from 'path';
+import {
+  promises as fs,
+  createReadStream,
+  createWriteStream,
+  ReadStream,
+} from 'fs';
+import { pipeline } from 'stream/promises';
+import { Readable } from 'stream';
+import { join, dirname } from 'path';
 import {
   IStorageProvider,
   FileStats,
   DeleteDirectoryOptions,
   ListFilesOptions,
+  WriteResult,
+  ReadRange,
 } from '../interfaces/storage-provider.interface';
 
 /**
@@ -13,6 +22,17 @@ import {
  *
  * Implements storage operations using Node.js filesystem (fs/promises).
  * This provider handles all direct disk operations.
+ *
+ * Implements `IStorageProvider` (the generic object-store contract used for
+ * `File` DB records) plus a local-only filesystem surface (ensureDirectory,
+ * directoryExists, deleteDirectory, listFiles, readFile, writeFile,
+ * deleteOldFiles, the synchronous createReadStream, resolvePath, and the
+ * *WithPrefix variants) that is NOT part of `IStorageProvider` — S3 has no
+ * directory concept. `StorageService` addresses that local-only surface
+ * directly (hard-pinned, independent of the configured default storage
+ * type) because it is used exclusively by the LiveKit replay/egress
+ * pipeline and thumbnail generation, both of which require a genuine local
+ * scratch filesystem regardless of where `File` records are stored.
  */
 @Injectable()
 export class LocalStorageProvider implements IStorageProvider {
@@ -225,6 +245,43 @@ export class LocalStorageProvider implements IStorageProvider {
   getFileUrl(path: string): Promise<string> {
     // For local storage, the path is the URL
     return Promise.resolve(path);
+  }
+
+  /**
+   * Streams `source` to `key` (a filesystem path for this provider).
+   * Ensures the parent directory exists, then pipes the stream directly to
+   * disk — never buffers the whole object in memory.
+   */
+  async writeStream(key: string, source: Readable): Promise<WriteResult> {
+    // `meta` (e.g. contentType) is part of the generic IStorageProvider
+    // contract for object-store backends but has no local-filesystem
+    // equivalent — content type is derived from the file at serve time,
+    // not stored alongside it. Callers may still pass it; it's ignored.
+    try {
+      await fs.mkdir(dirname(key), { recursive: true });
+      await pipeline(source, createWriteStream(key));
+      const stats = await fs.stat(key);
+      this.logger.debug(`Streamed write complete: ${key}`);
+      return { size: stats.size };
+    } catch (error) {
+      this.logger.error(`Failed to stream-write ${key}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Returns a readable stream for `key`, optionally scoped to a byte range.
+   * Part of the generic IStorageProvider contract (object-store semantics);
+   * distinct from the local-only synchronous `createReadStream` above,
+   * which the LiveKit replay pipeline uses directly.
+   */
+  getReadStream(key: string, range?: ReadRange): Promise<Readable> {
+    return Promise.resolve(
+      createReadStream(
+        key,
+        range ? { start: range.start, end: range.end } : undefined,
+      ),
+    );
   }
 
   /**

--- a/backend/src/storage/providers/s3-storage.provider.spec.ts
+++ b/backend/src/storage/providers/s3-storage.provider.spec.ts
@@ -27,11 +27,26 @@ jest.mock('@aws-sdk/client-s3', () => ({
 
 const mockUploadDone = jest.fn();
 const mockUploadCtor = jest.fn();
+let progressListener:
+  | ((progress: { loaded?: number; total?: number }) => void)
+  | undefined;
 
 jest.mock('@aws-sdk/lib-storage', () => ({
   Upload: jest.fn().mockImplementation((opts: unknown) => {
     mockUploadCtor(opts);
-    return { done: mockUploadDone };
+    return {
+      on: jest.fn(
+        (
+          event: string,
+          listener: (progress: { loaded?: number; total?: number }) => void,
+        ) => {
+          if (event === 'httpUploadProgress') {
+            progressListener = listener;
+          }
+        },
+      ),
+      done: mockUploadDone,
+    };
   }),
 }));
 
@@ -47,6 +62,7 @@ describe('S3StorageProvider', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    progressListener = undefined;
 
     const { unit } = await TestBed.solitary(S3StorageProvider)
       .mock(ConfigService)
@@ -64,12 +80,13 @@ describe('S3StorageProvider', () => {
 
   describe('writeStream', () => {
     it('streams via lib-storage Upload (never buffers the whole object)', async () => {
-      mockUploadDone.mockResolvedValue({ ETag: '"abc123"' });
-      mockSend.mockResolvedValue({
-        ContentLength: 4096,
-        LastModified: new Date('2026-01-01'),
-        ContentType: 'image/png',
-        ETag: '"abc123"',
+      // Simulate lib-storage's own httpUploadProgress accounting — the
+      // provider must derive `size` from this, never from a follow-up
+      // HeadObject call (mockSend is intentionally left unstubbed here to
+      // prove writeStream never calls `client.send` at all).
+      mockUploadDone.mockImplementation(() => {
+        progressListener?.({ loaded: 4096, total: 4096 });
+        return Promise.resolve({ ETag: '"abc123"' });
       });
       const source = Readable.from([Buffer.from('chunk')]);
 
@@ -88,7 +105,17 @@ describe('S3StorageProvider', () => {
         }),
       );
       expect(mockUploadDone).toHaveBeenCalledTimes(1);
+      expect(mockSend).not.toHaveBeenCalled();
       expect(result).toEqual({ size: 4096, etag: '"abc123"' });
+    });
+
+    it('defaults size to 0 when lib-storage never reports upload progress', async () => {
+      mockUploadDone.mockResolvedValue({ ETag: '"abc123"' });
+      const source = Readable.from([Buffer.from('chunk')]);
+
+      const result = await provider.writeStream('uploads/key.png', source);
+
+      expect(result).toEqual({ size: 0, etag: '"abc123"' });
     });
 
     it('propagates upload errors', async () => {

--- a/backend/src/storage/providers/s3-storage.provider.spec.ts
+++ b/backend/src/storage/providers/s3-storage.provider.spec.ts
@@ -1,0 +1,260 @@
+import { TestBed } from '@suites/unit';
+import { ConfigService } from '@nestjs/config';
+import { Readable } from 'stream';
+import { S3StorageProvider } from './s3-storage.provider';
+
+// Hand-mock the AWS SDK: no aws-sdk-client-mock dependency in this repo, and
+// the provider's whole contract with the SDK is "construct a client, call
+// .send(command)" — trivial to fake directly.
+const mockSend = jest.fn();
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn().mockImplementation((config: unknown) => ({
+    send: mockSend,
+    __config: config,
+  })),
+  GetObjectCommand: jest
+    .fn()
+    .mockImplementation((input: unknown) => ({ __type: 'GetObject', input })),
+  DeleteObjectCommand: jest.fn().mockImplementation((input: unknown) => ({
+    __type: 'DeleteObject',
+    input,
+  })),
+  HeadObjectCommand: jest
+    .fn()
+    .mockImplementation((input: unknown) => ({ __type: 'HeadObject', input })),
+}));
+
+const mockUploadDone = jest.fn();
+const mockUploadCtor = jest.fn();
+
+jest.mock('@aws-sdk/lib-storage', () => ({
+  Upload: jest.fn().mockImplementation((opts: unknown) => {
+    mockUploadCtor(opts);
+    return { done: mockUploadDone };
+  }),
+}));
+
+describe('S3StorageProvider', () => {
+  let provider: S3StorageProvider;
+
+  const envValues: Record<string, string | undefined> = {
+    S3_BUCKET: 'test-bucket',
+    S3_REGION: 'us-east-1',
+    S3_ACCESS_KEY_ID: 'AKIA_TEST',
+    S3_SECRET_ACCESS_KEY: 'secret',
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const { unit } = await TestBed.solitary(S3StorageProvider)
+      .mock(ConfigService)
+      .final({
+        get: jest.fn((key: string) => envValues[key]),
+      })
+      .compile();
+
+    provider = unit;
+  });
+
+  it('should be defined', () => {
+    expect(provider).toBeDefined();
+  });
+
+  describe('writeStream', () => {
+    it('streams via lib-storage Upload (never buffers the whole object)', async () => {
+      mockUploadDone.mockResolvedValue({ ETag: '"abc123"' });
+      mockSend.mockResolvedValue({
+        ContentLength: 4096,
+        LastModified: new Date('2026-01-01'),
+        ContentType: 'image/png',
+        ETag: '"abc123"',
+      });
+      const source = Readable.from([Buffer.from('chunk')]);
+
+      const result = await provider.writeStream('uploads/key.png', source, {
+        contentType: 'image/png',
+      });
+
+      expect(mockUploadCtor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            Bucket: 'test-bucket',
+            Key: 'uploads/key.png',
+            Body: source,
+            ContentType: 'image/png',
+          }),
+        }),
+      );
+      expect(mockUploadDone).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ size: 4096, etag: '"abc123"' });
+    });
+
+    it('propagates upload errors', async () => {
+      mockUploadDone.mockRejectedValue(new Error('network error'));
+      const source = Readable.from([Buffer.from('chunk')]);
+
+      await expect(
+        provider.writeStream('uploads/key.png', source),
+      ).rejects.toThrow('network error');
+    });
+  });
+
+  describe('getReadStream', () => {
+    it('returns the response Body for a full read (no Range)', async () => {
+      const body = Readable.from([Buffer.from('data')]);
+      mockSend.mockResolvedValue({ Body: body });
+
+      const result = await provider.getReadStream('uploads/key.png');
+
+      expect(result).toBe(body);
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          __type: 'GetObject',
+          input: { Bucket: 'test-bucket', Key: 'uploads/key.png' },
+        }),
+      );
+    });
+
+    it('passes a Range header for ranged reads (RFC 7233 bytes=start-end)', async () => {
+      const body = Readable.from([Buffer.from('data')]);
+      mockSend.mockResolvedValue({ Body: body });
+
+      await provider.getReadStream('uploads/key.png', { start: 0, end: 999 });
+
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({ Range: 'bytes=0-999' }),
+        }),
+      );
+    });
+
+    it('throws when the response has no readable Body', async () => {
+      mockSend.mockResolvedValue({ Body: undefined });
+
+      await expect(
+        provider.getReadStream('uploads/missing.png'),
+      ).rejects.toThrow(/no readable body/);
+    });
+
+    it('propagates errors from the SDK', async () => {
+      mockSend.mockRejectedValue(new Error('access denied'));
+
+      await expect(provider.getReadStream('uploads/key.png')).rejects.toThrow(
+        'access denied',
+      );
+    });
+  });
+
+  describe('deleteFile', () => {
+    it('sends a DeleteObjectCommand for the bucket/key', async () => {
+      mockSend.mockResolvedValue({});
+
+      await provider.deleteFile('uploads/key.png');
+
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          __type: 'DeleteObject',
+          input: { Bucket: 'test-bucket', Key: 'uploads/key.png' },
+        }),
+      );
+    });
+
+    it('propagates errors', async () => {
+      mockSend.mockRejectedValue(new Error('bucket unreachable'));
+
+      await expect(provider.deleteFile('uploads/key.png')).rejects.toThrow(
+        'bucket unreachable',
+      );
+    });
+  });
+
+  describe('fileExists', () => {
+    it('returns true when HeadObject succeeds', async () => {
+      mockSend.mockResolvedValue({ ContentLength: 10 });
+
+      await expect(provider.fileExists('uploads/key.png')).resolves.toBe(true);
+    });
+
+    it('returns false when HeadObject reports NotFound by name', async () => {
+      mockSend.mockRejectedValue(
+        Object.assign(new Error('not found'), {
+          name: 'NotFound',
+        }),
+      );
+
+      await expect(provider.fileExists('uploads/missing.png')).resolves.toBe(
+        false,
+      );
+    });
+
+    it('returns false when HeadObject reports a 404 status', async () => {
+      mockSend.mockRejectedValue(
+        Object.assign(new Error('not found'), {
+          $metadata: { httpStatusCode: 404 },
+        }),
+      );
+
+      await expect(provider.fileExists('uploads/missing.png')).resolves.toBe(
+        false,
+      );
+    });
+
+    it('re-throws non-NotFound errors', async () => {
+      mockSend.mockRejectedValue(new Error('access denied'));
+
+      await expect(provider.fileExists('uploads/key.png')).rejects.toThrow(
+        'access denied',
+      );
+    });
+  });
+
+  describe('getFileStats', () => {
+    it('maps HeadObject fields to FileStats', async () => {
+      const lastModified = new Date('2026-02-02T00:00:00Z');
+      mockSend.mockResolvedValue({
+        ContentLength: 12345,
+        LastModified: lastModified,
+        ContentType: 'video/mp4',
+        ETag: '"deadbeef"',
+      });
+
+      const result = await provider.getFileStats('uploads/video.mp4');
+
+      expect(result).toEqual({
+        size: 12345,
+        mtime: lastModified,
+        ctime: lastModified,
+        contentType: 'video/mp4',
+        etag: '"deadbeef"',
+      });
+    });
+
+    it('defaults size to 0 and dates to epoch when fields are missing', async () => {
+      mockSend.mockResolvedValue({});
+
+      const result = await provider.getFileStats('uploads/video.mp4');
+
+      expect(result.size).toBe(0);
+      expect(result.mtime).toEqual(new Date(0));
+      expect(result.ctime).toEqual(new Date(0));
+    });
+
+    it('propagates errors', async () => {
+      mockSend.mockRejectedValue(new Error('access denied'));
+
+      await expect(provider.getFileStats('uploads/key.png')).rejects.toThrow(
+        'access denied',
+      );
+    });
+  });
+
+  describe('getFileUrl', () => {
+    it('returns the key as-is (presigned URLs are not wired into any serve path in this task)', async () => {
+      await expect(provider.getFileUrl('uploads/key.png')).resolves.toBe(
+        'uploads/key.png',
+      );
+    });
+  });
+});

--- a/backend/src/storage/providers/s3-storage.provider.ts
+++ b/backend/src/storage/providers/s3-storage.provider.ts
@@ -77,6 +77,14 @@ export class S3StorageProvider implements IStorageProvider {
   /**
    * Streams `source` to the S3 object `key` via a multipart upload
    * (`@aws-sdk/lib-storage`'s `Upload`). Never buffers the whole object.
+   *
+   * Size is derived from `Upload`'s own `httpUploadProgress` accounting
+   * (cumulative bytes it has already streamed up) rather than a follow-up
+   * HeadObject call — the bytes were just sent, so re-fetching them costs a
+   * needless extra network round trip. `Upload` only emits progress events
+   * once something has subscribed via `.on(...)` (see its `on()` override),
+   * so the listener below is what turns that accounting on, for both the
+   * single-PutObject and true-multipart code paths.
    */
   async writeStream(
     key: string,
@@ -94,9 +102,15 @@ export class S3StorageProvider implements IStorageProvider {
         },
       });
 
+      let bytesUploaded = 0;
+      upload.on('httpUploadProgress', (progress) => {
+        if (typeof progress.loaded === 'number') {
+          bytesUploaded = progress.loaded;
+        }
+      });
+
       const result = await upload.done();
-      const stats = await this.getFileStats(key);
-      return { size: stats.size, etag: result.ETag ?? stats.etag };
+      return { size: bytesUploaded, etag: result.ETag };
     } catch (error) {
       this.logger.error(`Failed to upload object ${key}:`, error);
       throw error;

--- a/backend/src/storage/providers/s3-storage.provider.ts
+++ b/backend/src/storage/providers/s3-storage.provider.ts
@@ -1,0 +1,184 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Readable } from 'stream';
+import {
+  S3Client,
+  GetObjectCommand,
+  DeleteObjectCommand,
+  HeadObjectCommand,
+} from '@aws-sdk/client-s3';
+import { Upload } from '@aws-sdk/lib-storage';
+import {
+  IStorageProvider,
+  FileStats,
+  WriteMeta,
+  WriteResult,
+  ReadRange,
+} from '../interfaces/storage-provider.interface';
+
+/**
+ * S3-compatible Object Storage Provider
+ *
+ * Implements `IStorageProvider` against any S3-compatible API (AWS S3,
+ * MinIO, etc.) via `@aws-sdk/client-s3`. Writes always go through
+ * `@aws-sdk/lib-storage`'s `Upload` helper, which performs a streamed
+ * multipart upload — the object body is never buffered whole in memory,
+ * regardless of file size.
+ *
+ * Config is read directly from ConfigService (validated in
+ * env.validation.ts, required only when STORAGE_TYPE=S3):
+ *   S3_BUCKET, S3_REGION, S3_ENDPOINT (optional, e.g. MinIO),
+ *   S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY, S3_FORCE_PATH_STYLE (optional).
+ */
+@Injectable()
+export class S3StorageProvider implements IStorageProvider {
+  private readonly logger = new Logger(S3StorageProvider.name);
+  private readonly client: S3Client;
+  private readonly bucket: string;
+
+  constructor(configService: ConfigService) {
+    const region = configService.get<string>('S3_REGION') || 'us-east-1';
+    const endpoint = configService.get<string>('S3_ENDPOINT') || undefined;
+    const forcePathStyle = this.parseBool(
+      configService.get<string>('S3_FORCE_PATH_STYLE'),
+    );
+    const accessKeyId = configService.get<string>('S3_ACCESS_KEY_ID');
+    const secretAccessKey = configService.get<string>('S3_SECRET_ACCESS_KEY');
+    this.bucket = configService.get<string>('S3_BUCKET') || '';
+
+    this.client = new S3Client({
+      region,
+      ...(endpoint ? { endpoint, forcePathStyle } : {}),
+      ...(accessKeyId && secretAccessKey
+        ? { credentials: { accessKeyId, secretAccessKey } }
+        : {}),
+    });
+
+    this.logger.log(
+      `S3StorageProvider initialized (bucket=${this.bucket || '<unset>'}, region=${region}${
+        endpoint ? `, endpoint=${endpoint}` : ''
+      })`,
+    );
+  }
+
+  private parseBool(value?: string): boolean {
+    if (!value) return false;
+    return ['true', '1', 'yes'].includes(value.trim().toLowerCase());
+  }
+
+  private isNotFound(error: unknown): boolean {
+    const err = error as {
+      name?: string;
+      $metadata?: { httpStatusCode?: number };
+    };
+    return err?.name === 'NotFound' || err?.$metadata?.httpStatusCode === 404;
+  }
+
+  /**
+   * Streams `source` to the S3 object `key` via a multipart upload
+   * (`@aws-sdk/lib-storage`'s `Upload`). Never buffers the whole object.
+   */
+  async writeStream(
+    key: string,
+    source: Readable,
+    meta?: WriteMeta,
+  ): Promise<WriteResult> {
+    try {
+      const upload = new Upload({
+        client: this.client,
+        params: {
+          Bucket: this.bucket,
+          Key: key,
+          Body: source,
+          ContentType: meta?.contentType,
+        },
+      });
+
+      const result = await upload.done();
+      const stats = await this.getFileStats(key);
+      return { size: stats.size, etag: result.ETag ?? stats.etag };
+    } catch (error) {
+      this.logger.error(`Failed to upload object ${key}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Returns a readable stream for the S3 object `key`, optionally scoped to
+   * a byte range via the S3 GetObject `Range` parameter (RFC 7233 syntax).
+   */
+  async getReadStream(key: string, range?: ReadRange): Promise<Readable> {
+    try {
+      const command = new GetObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        ...(range ? { Range: `bytes=${range.start}-${range.end}` } : {}),
+      });
+      const response = await this.client.send(command);
+      const body = response.Body;
+      if (!(body instanceof Readable)) {
+        throw new Error(`S3 object ${key} returned no readable body`);
+      }
+      return body;
+    } catch (error) {
+      this.logger.error(`Failed to read object ${key}:`, error);
+      throw error;
+    }
+  }
+
+  async deleteFile(key: string): Promise<void> {
+    try {
+      await this.client.send(
+        new DeleteObjectCommand({ Bucket: this.bucket, Key: key }),
+      );
+      this.logger.debug(`Deleted object: ${key}`);
+    } catch (error) {
+      this.logger.error(`Failed to delete object ${key}:`, error);
+      throw error;
+    }
+  }
+
+  async fileExists(key: string): Promise<boolean> {
+    try {
+      await this.client.send(
+        new HeadObjectCommand({ Bucket: this.bucket, Key: key }),
+      );
+      return true;
+    } catch (error) {
+      if (this.isNotFound(error)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async getFileStats(key: string): Promise<FileStats> {
+    try {
+      const result = await this.client.send(
+        new HeadObjectCommand({ Bucket: this.bucket, Key: key }),
+      );
+      const lastModified = result.LastModified ?? new Date(0);
+      return {
+        size: result.ContentLength ?? 0,
+        mtime: lastModified,
+        ctime: lastModified,
+        contentType: result.ContentType,
+        etag: result.ETag,
+      };
+    } catch (error) {
+      this.logger.error(`Failed to stat object ${key}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Presigned direct-to-S3 URLs are a possible later optimization (bypasses
+   * backend streaming for read-heavy deployments) but are NOT wired into
+   * any serve path in this task — the backend always streams object bytes
+   * through the FileAuthGuard-protected `/api/file/:id` route so access
+   * control stays centralized. Kept for interface parity only.
+   */
+  getFileUrl(key: string): Promise<string> {
+    return Promise.resolve(key);
+  }
+}

--- a/backend/src/storage/storage.module.ts
+++ b/backend/src/storage/storage.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { StorageService } from './storage.service';
 import { LocalStorageProvider } from './providers/local-storage.provider';
+import { S3StorageProvider } from './providers/s3-storage.provider';
 
 /**
  * Storage Module
  *
  * Provides storage abstraction layer for filesystem, S3, Azure Blob, etc.
- * Currently supports LOCAL filesystem storage only.
+ * Supports LOCAL filesystem and S3-compatible object storage (AWS S3,
+ * MinIO). Azure Blob is not yet implemented.
  *
  * @example
  * ```typescript
@@ -29,8 +31,9 @@ import { LocalStorageProvider } from './providers/local-storage.provider';
   imports: [ConfigModule],
   providers: [
     LocalStorageProvider,
+    S3StorageProvider,
     StorageService,
-    // Future: S3Provider, AzureBlobProvider, etc.
+    // Future: AzureBlobProvider, etc.
   ],
   exports: [StorageService],
 })

--- a/backend/src/storage/storage.service.spec.ts
+++ b/backend/src/storage/storage.service.spec.ts
@@ -3,10 +3,12 @@ import type { Mocked } from '@suites/doubles.jest';
 import { ConfigService } from '@nestjs/config';
 import { StorageService, StorageType } from './storage.service';
 import { LocalStorageProvider } from './providers/local-storage.provider';
+import { S3StorageProvider } from './providers/s3-storage.provider';
 
 describe('StorageService', () => {
   let service: StorageService;
   let localProvider: Mocked<LocalStorageProvider>;
+  let s3Provider: Mocked<S3StorageProvider>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -20,6 +22,7 @@ describe('StorageService', () => {
 
     service = unit;
     localProvider = unitRef.get(LocalStorageProvider);
+    s3Provider = unitRef.get(S3StorageProvider);
   });
 
   afterEach(() => {
@@ -48,6 +51,25 @@ describe('StorageService', () => {
       const provider = svc.getProvider();
       expect(provider).toBe(mockLocalProvider);
     });
+
+    it('should resolve the default provider to S3 when STORAGE_TYPE=S3', async () => {
+      const { unit: svc, unitRef: ref } = await TestBed.solitary(StorageService)
+        .mock(ConfigService)
+        .final({
+          get: jest.fn().mockReturnValue(StorageType.S3),
+        })
+        .compile();
+
+      const mockS3Provider = ref.get(S3StorageProvider);
+      expect(svc.getProvider()).toBe(mockS3Provider);
+      expect(svc.getDefaultStorageType()).toBe(StorageType.S3);
+    });
+  });
+
+  describe('getDefaultStorageType', () => {
+    it('defaults to LOCAL when STORAGE_TYPE is unset', () => {
+      expect(service.getDefaultStorageType()).toBe(StorageType.LOCAL);
+    });
   });
 
   describe('getProvider', () => {
@@ -56,10 +78,9 @@ describe('StorageService', () => {
       expect(provider).toBe(localProvider);
     });
 
-    it('should throw error for S3 type (not implemented)', () => {
-      expect(() => service.getProvider(StorageType.S3)).toThrow(
-        'S3 storage provider not yet implemented',
-      );
+    it('should return S3 storage provider for S3 type', () => {
+      const provider = service.getProvider(StorageType.S3);
+      expect(provider).toBe(s3Provider);
     });
 
     it('should throw error for AZURE_BLOB type (not implemented)', () => {
@@ -74,7 +95,28 @@ describe('StorageService', () => {
     });
   });
 
-  describe('delegation methods', () => {
+  describe('local-only convenience methods (hard-pinned, independent of STORAGE_TYPE)', () => {
+    it('stays pinned to LocalStorageProvider even when the default type is S3', async () => {
+      const { unit: svc, unitRef: ref } = await TestBed.solitary(StorageService)
+        .mock(ConfigService)
+        .final({
+          get: jest.fn().mockReturnValue(StorageType.S3),
+        })
+        .compile();
+
+      const mockLocalProvider = ref.get(LocalStorageProvider);
+      const mockS3Provider = ref.get(S3StorageProvider);
+      mockLocalProvider.fileExists.mockResolvedValue(true);
+
+      const result = await svc.fileExists('/local/replay/segment.ts');
+
+      expect(result).toBe(true);
+      expect(mockLocalProvider.fileExists).toHaveBeenCalledWith(
+        '/local/replay/segment.ts',
+      );
+      expect(mockS3Provider.fileExists).not.toHaveBeenCalled();
+    });
+
     it('should delegate ensureDirectory to provider', async () => {
       localProvider.ensureDirectory.mockResolvedValue(undefined);
       await service.ensureDirectory('/test/path');

--- a/backend/src/storage/storage.service.ts
+++ b/backend/src/storage/storage.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, Logger, NotImplementedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ReadStream } from 'fs';
+import { StorageType } from '@prisma/client';
 import { LocalStorageProvider } from './providers/local-storage.provider';
+import { S3StorageProvider } from './providers/s3-storage.provider';
 import {
   IStorageProvider,
   FileStats,
@@ -10,36 +12,59 @@ import {
 } from './interfaces/storage-provider.interface';
 
 /**
- * Storage Type Enumeration
- * Matches the StorageType in Prisma schema
+ * Storage Type re-export.
+ *
+ * IMPORTANT: this MUST be the same `StorageType` as the Prisma `File` model's
+ * `storageType` column (re-exported here, not redeclared) — per-record
+ * provider resolution passes `file.storageType` straight into
+ * `getProvider()`. A locally-redeclared enum with identical string values
+ * would still be a structurally-identical-but-nominally-distinct TS type,
+ * breaking that call at every File-record call site.
  */
-export enum StorageType {
-  LOCAL = 'LOCAL',
-  S3 = 'S3',
-  AZURE_BLOB = 'AZURE_BLOB',
-}
+export { StorageType };
 
 /**
  * Storage Service
  *
- * Main service for storage operations. Uses provider pattern to support
- * multiple storage backends (filesystem, S3, Azure Blob, etc.).
+ * Resolves the `IStorageProvider` (LOCAL or S3) appropriate for a given
+ * `File` DB record, and additionally exposes a local-only filesystem
+ * convenience surface used exclusively by the LiveKit replay/egress
+ * pipeline and thumbnail generation.
  *
- * Currently implements LOCAL storage only. Future providers can be added
- * by implementing IStorageProvider interface and updating getProvider().
+ * Two distinct usage patterns:
  *
- * @example
- * ```typescript
- * // Use default provider (LOCAL)
- * await this.storageService.ensureDirectory('/path/to/dir');
+ * 1. Per-record object-store operations (file upload/serve/delete/backfill):
+ *    ALWAYS resolve the provider explicitly for the record in hand —
+ *    `getProvider(file.storageType)` — never rely on the default. A mixed
+ *    local/S3 instance must keep serving old LOCAL rows correctly even
+ *    after STORAGE_TYPE is switched to S3 for new uploads.
  *
- * // Specify provider type explicitly
- * const provider = this.storageService.getProvider(StorageType.LOCAL);
- * await provider.deleteOldFiles('/path/to/dir', new Date());
- * ```
+ *      const provider = this.storageService.getProvider(file.storageType);
+ *      const stream = await provider.getReadStream(file.storagePath);
+ *
+ *    `getProvider()` with no argument resolves the *configured default*
+ *    (STORAGE_TYPE), which is the right choice exactly once: deciding where
+ *    a brand-new upload should land.
+ *
+ * 2. Local-only filesystem convenience methods (ensureDirectory,
+ *    directoryExists, deleteDirectory, listFiles, readFile, writeFile,
+ *    deleteOldFiles, createReadStream, resolvePath, the *WithPrefix
+ *    variants, and the segment-* helpers): these hard-delegate to
+ *    `LocalStorageProvider` directly, independent of STORAGE_TYPE. They
+ *    exist for the LiveKit replay/egress pipeline and ffmpeg thumbnail
+ *    generation, which require a genuine local scratch filesystem
+ *    regardless of where `File` records themselves are stored — S3 has no
+ *    directory concept, so these are intentionally NOT part of
+ *    `IStorageProvider` and are not affected by the configured default
+ *    storage type. `deleteFile`, `fileExists`, `getFileStats`, and
+ *    `getFileUrl` also have ambient (no-arg-type) convenience wrappers here
+ *    for the same reason — their only current ambient call sites (LiveKit
+ *    clip cleanup, ffmpeg temp-file stats) are inherently local-disk
+ *    operations. Any File-record call site MUST use `getProvider(type)`
+ *    explicitly instead of these ambient wrappers.
  */
 @Injectable()
-export class StorageService implements IStorageProvider {
+export class StorageService {
   private readonly logger = new Logger(StorageService.name);
   private readonly defaultStorageType: StorageType;
   private readonly segmentsPrefix: string;
@@ -47,7 +72,8 @@ export class StorageService implements IStorageProvider {
   constructor(
     private readonly configService: ConfigService,
     private readonly localStorageProvider: LocalStorageProvider,
-    // Future: inject S3Provider, AzureBlobProvider, etc.
+    private readonly s3StorageProvider: S3StorageProvider,
+    // Future: inject AzureBlobProvider, etc.
   ) {
     // Default to LOCAL storage, configurable via environment
     this.defaultStorageType =
@@ -66,8 +92,11 @@ export class StorageService implements IStorageProvider {
   }
 
   /**
-   * Gets the appropriate storage provider based on type
-   * @param type - Storage type (defaults to configured default)
+   * Gets the appropriate storage provider based on type.
+   * @param type - Storage type. ALWAYS pass the specific `File` record's
+   *   `storageType` for read/delete/backfill operations. Omit only to
+   *   resolve the configured default (i.e. where a brand-new upload
+   *   should land).
    * @returns Storage provider instance
    */
   getProvider(type?: StorageType): IStorageProvider {
@@ -78,10 +107,7 @@ export class StorageService implements IStorageProvider {
         return this.localStorageProvider;
 
       case StorageType.S3:
-        // Future: return this.s3Provider;
-        throw new NotImplementedException(
-          'S3 storage provider not yet implemented',
-        );
+        return this.s3StorageProvider;
 
       case StorageType.AZURE_BLOB:
         // Future: return this.azureBlobProvider;
@@ -97,72 +123,80 @@ export class StorageService implements IStorageProvider {
     }
   }
 
+  /**
+   * The configured default storage type (STORAGE_TYPE env var). Used to
+   * decide where a brand-new upload should land.
+   */
+  getDefaultStorageType(): StorageType {
+    return this.defaultStorageType;
+  }
+
   // ==========================================
-  // Convenience methods that delegate to the default provider
-  // These allow services to inject StorageService and call methods directly
-  // without needing to call getProvider() explicitly
+  // Local-only filesystem convenience methods
+  // Hard-pinned to LocalStorageProvider — see class doc. NOT affected by
+  // the configured default storage type.
   // ==========================================
 
   async ensureDirectory(path: string): Promise<void> {
-    return this.getProvider().ensureDirectory(path);
+    return this.localStorageProvider.ensureDirectory(path);
   }
 
   async directoryExists(path: string): Promise<boolean> {
-    return this.getProvider().directoryExists(path);
+    return this.localStorageProvider.directoryExists(path);
   }
 
   async deleteDirectory(
     path: string,
     options?: DeleteDirectoryOptions,
   ): Promise<void> {
-    return this.getProvider().deleteDirectory(path, options);
+    return this.localStorageProvider.deleteDirectory(path, options);
   }
 
   async deleteFile(path: string): Promise<void> {
-    return this.getProvider().deleteFile(path);
+    return this.localStorageProvider.deleteFile(path);
   }
 
   async fileExists(path: string): Promise<boolean> {
-    return this.getProvider().fileExists(path);
+    return this.localStorageProvider.fileExists(path);
   }
 
   async listFiles(
     dirPath: string,
     options?: ListFilesOptions,
   ): Promise<string[]> {
-    return this.getProvider().listFiles(dirPath, options);
+    return this.localStorageProvider.listFiles(dirPath, options);
   }
 
   async getFileStats(path: string): Promise<FileStats> {
-    return this.getProvider().getFileStats(path);
+    return this.localStorageProvider.getFileStats(path);
   }
 
   async readFile(path: string): Promise<Buffer> {
-    return this.getProvider().readFile(path);
+    return this.localStorageProvider.readFile(path);
   }
 
   async writeFile(path: string, data: Buffer | string): Promise<void> {
-    return this.getProvider().writeFile(path, data);
+    return this.localStorageProvider.writeFile(path, data);
   }
 
   async deleteOldFiles(dirPath: string, olderThan: Date): Promise<number> {
-    return this.getProvider().deleteOldFiles(dirPath, olderThan);
+    return this.localStorageProvider.deleteOldFiles(dirPath, olderThan);
   }
 
   createReadStream(path: string): ReadStream {
-    return this.getProvider().createReadStream(path);
+    return this.localStorageProvider.createReadStream(path);
   }
 
   async getFileUrl(path: string): Promise<string> {
-    return this.getProvider().getFileUrl(path);
+    return this.localStorageProvider.getFileUrl(path);
   }
 
   // ==========================================
-  // Prefix-aware delegation methods
+  // Prefix-aware delegation methods (local-only, see above)
   // ==========================================
 
   resolvePath(relativePath: string, prefix: string): string {
-    return this.getProvider().resolvePath(relativePath, prefix);
+    return this.localStorageProvider.resolvePath(relativePath, prefix);
   }
 
   async listFilesWithPrefix(
@@ -170,14 +204,18 @@ export class StorageService implements IStorageProvider {
     prefix: string,
     options?: ListFilesOptions,
   ): Promise<string[]> {
-    return this.getProvider().listFilesWithPrefix(relativeDir, prefix, options);
+    return this.localStorageProvider.listFilesWithPrefix(
+      relativeDir,
+      prefix,
+      options,
+    );
   }
 
   async readFileWithPrefix(
     relativePath: string,
     prefix: string,
   ): Promise<Buffer> {
-    return this.getProvider().readFileWithPrefix(relativePath, prefix);
+    return this.localStorageProvider.readFileWithPrefix(relativePath, prefix);
   }
 
   async deleteDirectoryWithPrefix(
@@ -185,7 +223,7 @@ export class StorageService implements IStorageProvider {
     prefix: string,
     options?: DeleteDirectoryOptions,
   ): Promise<void> {
-    return this.getProvider().deleteDirectoryWithPrefix(
+    return this.localStorageProvider.deleteDirectoryWithPrefix(
       relativeDir,
       prefix,
       options,
@@ -196,18 +234,24 @@ export class StorageService implements IStorageProvider {
     relativePath: string,
     prefix: string,
   ): Promise<FileStats> {
-    return this.getProvider().getFileStatsWithPrefix(relativePath, prefix);
+    return this.localStorageProvider.getFileStatsWithPrefix(
+      relativePath,
+      prefix,
+    );
   }
 
   async directoryExistsWithPrefix(
     relativeDir: string,
     prefix: string,
   ): Promise<boolean> {
-    return this.getProvider().directoryExistsWithPrefix(relativeDir, prefix);
+    return this.localStorageProvider.directoryExistsWithPrefix(
+      relativeDir,
+      prefix,
+    );
   }
 
   // ==========================================
-  // Segment-specific convenience methods
+  // Segment-specific convenience methods (local-only, see above)
   // These auto-apply the REPLAY_SEGMENTS_PATH prefix
   // ==========================================
 

--- a/backend/test/helpers/e2e-app.ts
+++ b/backend/test/helpers/e2e-app.ts
@@ -63,10 +63,15 @@ export async function createE2eApp(): Promise<E2eApp> {
  * at boot, so the post-reset state matches a freshly-migrated instance.
  *
  * Destructive by design, so it refuses to run unless the database name in
- * DATABASE_URL contains "test" (CI provisions a dedicated `test` database)
- * or E2E_ALLOW_DB_RESET=1 is set explicitly. Local runs against the dev
- * compose database therefore need:
- *   docker compose run --rm -e E2E_ALLOW_DB_RESET=1 backend pnpm run test:e2e
+ * DATABASE_URL contains "test" (CI provisions a dedicated `test` database).
+ * There is deliberately NO override: an env-var escape hatch documented as
+ * the standard local command once wiped a developer's persistent dev
+ * database. Local runs must point DATABASE_URL at a dedicated test database
+ * instead, e.g.:
+ *   docker compose exec postgres createdb -U semaphore semaphore_e2e_local_test
+ *   docker compose run --rm \
+ *     -e DATABASE_URL=postgresql://semaphore:semaphore@postgres:5432/semaphore_e2e_local_test \
+ *     backend sh -c 'pnpm run prisma:migrate && pnpm run test:e2e'
  */
 export async function resetDatabase(app: E2eApp): Promise<void> {
   let dbName: string;
@@ -81,11 +86,12 @@ export async function resetDatabase(app: E2eApp): Promise<void> {
         'URL, so the target database cannot be identified.',
     );
   }
-  if (!/test/i.test(dbName) && process.env.E2E_ALLOW_DB_RESET !== '1') {
+  if (!/test/i.test(dbName)) {
     throw new Error(
       `resetDatabase() refused: DATABASE_URL points at "${dbName}", which ` +
-        'does not look like a test database. Set E2E_ALLOW_DB_RESET=1 to ' +
-        'wipe it anyway (this destroys all data).',
+        'does not look like a test database. There is no override — point ' +
+        'DATABASE_URL at a database whose name contains "test" (see the ' +
+        'resetDatabase doc comment for the local setup commands).',
     );
   }
 

--- a/backend/test/helpers/e2e-app.ts
+++ b/backend/test/helpers/e2e-app.ts
@@ -14,6 +14,7 @@
 import {
   ClassSerializerInterceptor,
   INestApplication,
+  LoggerService,
   ValidationPipe,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
@@ -31,14 +32,24 @@ export type E2eApp = INestApplication<App>;
 /** Instance invite code seeded for registration in e2e flows. */
 export const E2E_INVITE_CODE = 'e2e-test-invite';
 
-export async function createE2eApp(): Promise<E2eApp> {
+export async function createE2eApp(options?: {
+  /**
+   * Override the app's Nest logger. Defaults to `false` (silenced) to keep
+   * test output readable — Nest boot logs are noisy. Pass a `LoggerService`
+   * (e.g. a capturing logger) when a suite needs to inspect service-level
+   * `Logger.warn`/`.error` calls that are normally swallowed by `false`,
+   * such as diagnosing a non-fatal background failure (thumbnail
+   * generation, etc.) that otherwise surfaces only as an opaque assertion
+   * failure.
+   */
+  logger?: LoggerService | false;
+}): Promise<E2eApp> {
   const moduleFixture = await Test.createTestingModule({
     imports: [AppModule],
   }).compile();
 
   const app: E2eApp = moduleFixture.createNestApplication({
-    // Keep test output readable — Nest boot logs are noisy.
-    logger: false,
+    logger: options?.logger ?? false,
   });
 
   // Mirror src/main.ts request pipeline.
@@ -54,6 +65,66 @@ export async function createE2eApp(): Promise<E2eApp> {
 
   await app.init();
   return app;
+}
+
+/**
+ * `LoggerService` that buffers every call instead of writing to stdout, so a
+ * failing e2e assertion can dump exactly what the app's `Logger.log/warn/
+ * error/debug/verbose` calls said right before the failure — most useful for
+ * diagnosing non-fatal background failures (e.g. thumbnail generation
+ * catching and logging an ffmpeg error, then returning null) that otherwise
+ * surface only as an opaque assertion failure with no indication of *why*
+ * the backend didn't do what was expected.
+ *
+ * Pass an instance to `createE2eApp({ logger })` in place of the default
+ * `false`, call `logger.clear()` before each test, and on catch print
+ * `logger.dump()` before rethrowing.
+ */
+export class CapturingLogger implements LoggerService {
+  private entries: string[] = [];
+
+  log(message: unknown, ...optionalParams: unknown[]): void {
+    this.record('LOG', message, optionalParams);
+  }
+
+  error(message: unknown, ...optionalParams: unknown[]): void {
+    this.record('ERROR', message, optionalParams);
+  }
+
+  warn(message: unknown, ...optionalParams: unknown[]): void {
+    this.record('WARN', message, optionalParams);
+  }
+
+  debug(message: unknown, ...optionalParams: unknown[]): void {
+    this.record('DEBUG', message, optionalParams);
+  }
+
+  verbose(message: unknown, ...optionalParams: unknown[]): void {
+    this.record('VERBOSE', message, optionalParams);
+  }
+
+  clear(): void {
+    this.entries = [];
+  }
+
+  dump(): string {
+    return this.entries.length > 0
+      ? this.entries.join('\n')
+      : '(no backend log entries captured)';
+  }
+
+  private record(
+    level: string,
+    message: unknown,
+    optionalParams: unknown[],
+  ): void {
+    const rest = optionalParams
+      .map((p) => (typeof p === 'string' ? p : JSON.stringify(p)))
+      .join(' ');
+    const text =
+      typeof message === 'string' ? message : JSON.stringify(message);
+    this.entries.push(`[${level}] ${text}${rest ? ` ${rest}` : ''}`);
+  }
 }
 
 /**

--- a/backend/test/storage-s3.e2e-spec.ts
+++ b/backend/test/storage-s3.e2e-spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Integration test for the S3 storage provider against a REAL MinIO
+ * instance.
+ *
+ * Requires MinIO running and reachable (the dev Docker Compose stack ships
+ * a `minio` service behind an opt-in profile):
+ *
+ *   docker compose --profile s3 up -d minio minio-init
+ *   docker compose run --rm -e E2E_ALLOW_DB_RESET=1 backend pnpm run test:e2e -- storage-s3
+ *
+ * This spec overrides STORAGE_TYPE and the S3_* vars in `process.env` for
+ * its own AppModule instance only, restoring the previous values in
+ * `afterAll` — the e2e suite runs with `maxWorkers: 1` (see
+ * test/jest-e2e.json), so test FILES execute sequentially in one process
+ * and a leaked env var here would otherwise bleed into specs that assume
+ * the default LOCAL behavior.
+ *
+ * S3_ENDPOINT/S3_BUCKET can be overridden via S3_TEST_ENDPOINT /
+ * S3_TEST_BUCKET if your MinIO isn't reachable at the Compose defaults.
+ */
+import * as request from 'supertest';
+import {
+  createE2eApp,
+  resetDatabase,
+  seedInstanceInvite,
+  registerUser,
+  loginUser,
+  E2eApp,
+} from './helpers/e2e-app';
+
+const PREVIOUS_ENV: Record<string, string | undefined> = {};
+const S3_ENV: Record<string, string> = {
+  STORAGE_TYPE: 'S3',
+  S3_BUCKET: process.env.S3_TEST_BUCKET ?? 'semaphore-dev',
+  S3_REGION: 'us-east-1',
+  S3_ACCESS_KEY_ID: 'minioadmin',
+  S3_SECRET_ACCESS_KEY: 'minioadmin',
+  S3_ENDPOINT: process.env.S3_TEST_ENDPOINT ?? 'http://minio:9000',
+  S3_FORCE_PATH_STYLE: 'true',
+};
+
+// 1x1 transparent PNG — small, valid magic bytes (passes the image
+// content-sniffing check in ResourceTypeFileValidator).
+const PNG_FIXTURE = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+  'base64',
+);
+
+describe('Storage (S3/MinIO) e2e', () => {
+  let app: E2eApp;
+
+  beforeAll(async () => {
+    for (const key of Object.keys(S3_ENV)) {
+      PREVIOUS_ENV[key] = process.env[key];
+    }
+    Object.assign(process.env, S3_ENV);
+
+    app = await createE2eApp();
+    await resetDatabase(app);
+    await seedInstanceInvite(app);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    for (const [key, value] of Object.entries(PREVIOUS_ENV)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it('round-trips an image upload through S3 storage: upload -> serve (full + ranged) -> soft delete', async () => {
+    const username = 'e2e-s3-user';
+    const password = 'Password123!';
+
+    const user = await registerUser(app, { username, password });
+    const { accessToken } = await loginUser(app, username, password);
+
+    const uploadRes = await request(app.getHttpServer())
+      .post('/api/file-upload')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .field('resourceType', 'USER_AVATAR')
+      .field('resourceId', user.id)
+      .attach('file', PNG_FIXTURE, {
+        filename: 'avatar.png',
+        contentType: 'image/png',
+      })
+      .expect(201);
+
+    const uploadBody = uploadRes.body as { id: string; storageType: string };
+    const fileId = uploadBody.id;
+    expect(fileId).toBeDefined();
+    // Per-record resolution depends on this being persisted correctly.
+    expect(uploadBody.storageType).toBe('S3');
+    // storagePath (the S3 key) is excluded from the response DTO — only
+    // storageType is asserted here; the real key is verified indirectly
+    // by the serve requests below succeeding against the real bucket.
+
+    // Serve path: full object, streamed back from MinIO through the backend.
+    const getRes = await request(app.getHttpServer())
+      .get(`/api/file/${fileId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => callback(null, Buffer.concat(chunks)));
+      })
+      .expect(200);
+
+    expect(getRes.headers['content-type']).toBe('image/png');
+    expect(Buffer.compare(getRes.body as Buffer, PNG_FIXTURE)).toBe(0);
+
+    // Ranged read: S3 GetObject Range param must be honored end-to-end.
+    const rangeRes = await request(app.getHttpServer())
+      .get(`/api/file/${fileId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .set('Range', 'bytes=0-9')
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => callback(null, Buffer.concat(chunks)));
+      })
+      .expect(206);
+
+    expect(rangeRes.headers['content-range']).toBe(
+      `bytes 0-9/${PNG_FIXTURE.length}`,
+    );
+    expect((rangeRes.body as Buffer).length).toBe(10);
+    expect(
+      Buffer.compare(rangeRes.body as Buffer, PNG_FIXTURE.subarray(0, 10)),
+    ).toBe(0);
+
+    // Delete path: soft-delete via the API (physical S3 object cleanup runs
+    // on FileService's cron — covered by file.service.spec.ts unit tests).
+    await request(app.getHttpServer())
+      .delete(`/api/file-upload/${fileId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+  });
+});

--- a/backend/test/storage-s3.e2e-spec.ts
+++ b/backend/test/storage-s3.e2e-spec.ts
@@ -5,9 +5,14 @@
  * Requires MinIO running and reachable. Two ways to get that:
  *
  *   1. Local dev: the dev Docker Compose stack ships a `minio` service
- *      behind an opt-in profile —
+ *      behind an opt-in profile. E2e runs must target a dedicated
+ *      test-named database (resetDatabase() refuses anything else, with
+ *      no override — see test/helpers/e2e-app.ts):
  *        docker compose --profile s3 up -d minio minio-init
- *        docker compose run --rm -e E2E_ALLOW_DB_RESET=1 backend pnpm run test:e2e -- storage-s3
+ *        docker compose exec postgres createdb -U semaphore semaphore_e2e_local_test
+ *        docker compose run --rm \
+ *          -e DATABASE_URL=postgresql://semaphore:semaphore@postgres:5432/semaphore_e2e_local_test \
+ *          backend sh -c 'pnpm run prisma:migrate && pnpm run test:e2e -- storage-s3'
  *      S3_ENDPOINT defaults to the compose-network hostname (http://minio:9000).
  *
  *   2. CI: .github/workflows/backend-tests.yml's e2e job runs a `minio`

--- a/backend/test/storage-s3.e2e-spec.ts
+++ b/backend/test/storage-s3.e2e-spec.ts
@@ -48,6 +48,7 @@ import {
   seedInstanceInvite,
   registerUser,
   loginUser,
+  CapturingLogger,
   E2eApp,
 } from './helpers/e2e-app';
 
@@ -145,6 +146,14 @@ const MP4_FIXTURE = Buffer.from(
 describeS3('Storage (S3/MinIO) e2e', () => {
   let app: E2eApp;
   let s3Client: S3Client;
+  // Nest's built-in Logger is silenced app-wide by createE2eApp()'s default
+  // `logger: false` — which means ThumbnailService's `this.logger.warn(...)`
+  // on a caught ffmpeg failure (see file/thumbnail.service.ts) normally
+  // vanishes without a trace, so a failure of the video-thumbnail test below
+  // shows only "hasThumbnail expected true, got false" with no clue why
+  // generation didn't happen. Capture app logs instead so the real error
+  // (e.g. ffmpeg missing/failing on the CI runner) prints on failure.
+  const capturingLogger = new CapturingLogger();
 
   beforeAll(async () => {
     for (const key of Object.keys(S3_ENV)) {
@@ -178,7 +187,7 @@ describeS3('Storage (S3/MinIO) e2e', () => {
       }
     }
 
-    app = await createE2eApp();
+    app = await createE2eApp({ logger: capturingLogger });
     await resetDatabase(app);
     await seedInstanceInvite(app);
   });
@@ -196,6 +205,23 @@ describeS3('Storage (S3/MinIO) e2e', () => {
   });
 
   it('generates and serves a thumbnail for a video message attachment through S3 storage', async () => {
+    capturingLogger.clear();
+    try {
+      await runVideoThumbnailTest();
+    } catch (error) {
+      // Surface whatever the backend actually logged (e.g. a caught ffmpeg
+      // spawn/decode failure from ThumbnailService) alongside the assertion
+      // failure — without this, a `hasThumbnail` mismatch gives no clue
+      // whether generation threw, timed out, or never ran.
+
+      console.error(
+        `[storage-s3.e2e-spec] backend logs captured during failing test:\n${capturingLogger.dump()}`,
+      );
+      throw error;
+    }
+  });
+
+  async function runVideoThumbnailTest(): Promise<void> {
     const username = 'e2e-s3-video-user';
     const password = 'Password123!';
 
@@ -307,7 +333,7 @@ describeS3('Storage (S3/MinIO) e2e', () => {
     // image, not just that some bytes made it through the pipe.
     expect(bytes[0]).toBe(0xff);
     expect(bytes[1]).toBe(0xd8);
-  });
+  }
 
   it('round-trips an image upload through S3 storage: upload -> serve (full + ranged) -> soft delete -> 404', async () => {
     const username = 'e2e-s3-user';

--- a/backend/test/storage-s3.e2e-spec.ts
+++ b/backend/test/storage-s3.e2e-spec.ts
@@ -2,11 +2,23 @@
  * Integration test for the S3 storage provider against a REAL MinIO
  * instance.
  *
- * Requires MinIO running and reachable (the dev Docker Compose stack ships
- * a `minio` service behind an opt-in profile):
+ * Requires MinIO running and reachable. Two ways to get that:
  *
- *   docker compose --profile s3 up -d minio minio-init
- *   docker compose run --rm -e E2E_ALLOW_DB_RESET=1 backend pnpm run test:e2e -- storage-s3
+ *   1. Local dev: the dev Docker Compose stack ships a `minio` service
+ *      behind an opt-in profile —
+ *        docker compose --profile s3 up -d minio minio-init
+ *        docker compose run --rm -e E2E_ALLOW_DB_RESET=1 backend pnpm run test:e2e -- storage-s3
+ *      S3_ENDPOINT defaults to the compose-network hostname (http://minio:9000).
+ *
+ *   2. CI: .github/workflows/backend-tests.yml's e2e job runs a `minio`
+ *      service container reachable at http://localhost:9000 (GitHub Actions
+ *      service containers are only reachable via localhost:<port> from a
+ *      non-containerized job, never by hostname) — set via S3_TEST_ENDPOINT.
+ *
+ * If MinIO isn't reachable at the resolved endpoint (checked synchronously,
+ * before any test is registered — see `isMinioReachable` below), the whole
+ * suite is `describe.skip`-ped so Jest reports it as SKIPPED rather than
+ * silently passing or hard-failing every backend PR's CI.
  *
  * This spec overrides STORAGE_TYPE and the S3_* vars in `process.env` for
  * its own AppModule instance only, restoring the previous values in
@@ -19,6 +31,12 @@
  * S3_TEST_BUCKET if your MinIO isn't reachable at the Compose defaults.
  */
 import * as request from 'supertest';
+import { execFileSync } from 'child_process';
+import {
+  S3Client,
+  CreateBucketCommand,
+  HeadObjectCommand,
+} from '@aws-sdk/client-s3';
 import {
   createE2eApp,
   resetDatabase,
@@ -28,16 +46,77 @@ import {
   E2eApp,
 } from './helpers/e2e-app';
 
+const S3_ENDPOINT = process.env.S3_TEST_ENDPOINT ?? 'http://minio:9000';
+const S3_BUCKET = process.env.S3_TEST_BUCKET ?? 'semaphore-dev';
+
 const PREVIOUS_ENV: Record<string, string | undefined> = {};
 const S3_ENV: Record<string, string> = {
   STORAGE_TYPE: 'S3',
-  S3_BUCKET: process.env.S3_TEST_BUCKET ?? 'semaphore-dev',
+  S3_BUCKET,
   S3_REGION: 'us-east-1',
   S3_ACCESS_KEY_ID: 'minioadmin',
   S3_SECRET_ACCESS_KEY: 'minioadmin',
-  S3_ENDPOINT: process.env.S3_TEST_ENDPOINT ?? 'http://minio:9000',
+  S3_ENDPOINT,
   S3_FORCE_PATH_STYLE: 'true',
 };
+
+/**
+ * Synchronous TCP reachability probe for MinIO, run at module-load time —
+ * i.e. before any `describe`/`it` is registered, so the whole suite can be
+ * conditionally routed to `describe.skip` (Jest then reports it as
+ * genuinely SKIPPED, not a silently-green no-op).
+ *
+ * A raw TCP connect via a `node -e` child process is used instead of:
+ *   - `curl` — not guaranteed present in the backend's Docker image.
+ *   - an async check in `beforeAll` — by then `describe()` has already run
+ *     and registered real (non-skippable) tests; Jest offers no supported
+ *     way to `describe.skip` conditionally *after* collection.
+ * `execFileSync` blocks the parent (this file's module evaluation) until
+ * the child process exits, giving us a synchronous yes/no.
+ */
+function isMinioReachable(endpoint: string, timeoutMs = 2000): boolean {
+  let host: string;
+  let port: number;
+  try {
+    const url = new URL(endpoint);
+    host = url.hostname;
+    port = url.port ? Number(url.port) : 80;
+  } catch {
+    return false;
+  }
+
+  const probe = `
+    const net = require('net');
+    const socket = net.createConnection({ host: ${JSON.stringify(host)}, port: ${port} });
+    const fail = () => { try { socket.destroy(); } catch (e) {} process.exit(1); };
+    socket.setTimeout(${timeoutMs});
+    socket.once('connect', () => { socket.end(); process.exit(0); });
+    socket.once('timeout', fail);
+    socket.once('error', fail);
+  `;
+
+  try {
+    execFileSync(process.execPath, ['-e', probe], {
+      timeout: timeoutMs + 1000,
+      stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const minioAvailable = isMinioReachable(S3_ENDPOINT);
+const describeS3 = minioAvailable ? describe : describe.skip;
+
+if (!minioAvailable) {
+  console.warn(
+    `[storage-s3.e2e-spec] MinIO not reachable at ${S3_ENDPOINT} — SKIPPING ` +
+      'the S3/MinIO e2e suite. Start it locally via ' +
+      '`docker compose --profile s3 up -d minio minio-init`, or point at a ' +
+      'running instance via the S3_TEST_ENDPOINT env var.',
+  );
+}
 
 // 1x1 transparent PNG — small, valid magic bytes (passes the image
 // content-sniffing check in ResourceTypeFileValidator).
@@ -46,14 +125,53 @@ const PNG_FIXTURE = Buffer.from(
   'base64',
 );
 
-describe('Storage (S3/MinIO) e2e', () => {
+// Tiny (2s, 64x64, ~1.6KB) real H.264 MP4 generated via:
+//   ffmpeg -f lavfi -i "color=c=red:s=64x64:d=2:r=5" -c:v libx264 \
+//     -pix_fmt yuv420p -preset ultrafast -crf 30 -movflags +faststart tiny.mp4
+// Videos aren't magic-byte-sniffed by ResourceTypeFileValidator (only
+// image/* is), but thumbnail generation runs *real* ffmpeg against these
+// bytes (`ffmpeg -ss 1 -vframes 1 ...`), so it must be a genuinely decodable
+// video at least 1s long, not a placeholder blob.
+const MP4_FIXTURE = Buffer.from(
+  'AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAANKbW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAB9AAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAnR0cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAB9AAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAEAAAABAAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAfQAAAAAAABAAAAAAHsbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAAAoAAAAUABVxAAAAAAALWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABWaWRlb0hhbmRsZXIAAAABl21pbmYAAAAUdm1oZAAAAAEAAAAAAAAAAAAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAx1cmwgAAAAAQAAAVdzdGJsAAAAt3N0c2QAAAAAAAAAAQAAAKdhdmMxAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAEAAQABIAAAASAAAAAAAAAABFUxhdmM2MC4zMS4xMDIgbGlieDI2NAAAAAAAAAAAAAAAGP//AAAALWF2Y0MBQsAK/+EAFmdCwAraEJsBEAAAAwAQAAADAKDxImoBAARozgRyAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAAC1AAAAtQAAAAGHN0dHMAAAAAAAAAAQAAAAoAAAgAAAAAFHN0c3MAAAAAAAAAAQAAAAEAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAoAAAABAAAAPHN0c3oAAAAAAAAAAAAAAAoAAAJ6AAAACgAAAAoAAAAKAAAACgAAAAoAAAAKAAAACgAAAAoAAAAKAAAAFHN0Y28AAAAAAAAAAQAAA3oAAABidWR0YQAAAFptZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAAC1pbHN0AAAAJal0b28AAAAdZGF0YQAAAAEAAAAATGF2ZjYwLjE2LjEwMAAAAAhmcmVlAAAC3G1kYXQAAAJTBgX//0/cRem95tlIt5Ys2CDZI+7veDI2NCAtIGNvcmUgMTY0IHIzMTA4IDMxZTE5ZjkgLSBILjI2NC9NUEVHLTQgQVZDIGNvZGVjIC0gQ29weWxlZnQgMjAwMy0yMDIzIC0gaHR0cDovL3d3dy52aWRlb2xhbi5vcmcveDI2NC5odG1sIC0gb3B0aW9uczogY2FiYWM9MCByZWY9MSBkZWJsb2NrPTA6MDowIGFuYWx5c2U9MDowIG1lPWRpYSBzdWJtZT0wIHBzeT0xIHBzeV9yZD0xLjAwOjAuMDAgbWl4ZWRfcmVmPTAgbWVfcmFuZ2U9MTYgY2hyb21hX21lPTEgdHJlbGxpcz0wIDh4OGRjdD0wIGNxbT0wIGRlYWR6b25lPTIxLDExIGZhc3RfcHNraXA9MSBjaHJvbWFfcXBfb2Zmc2V0PTAgdGhyZWFkcz0yIGxvb2thaGVhZF90aHJlYWRzPTEgc2xpY2VkX3RocmVhZHM9MCBucj0wIGRlY2ltYXRlPTEgaW50ZXJsYWNlZD0wIGJsdXJheV9jb21wYXQ9MCBjb25zdHJhaW5lZF9pbnRyYT0wIGJmcmFtZXM9MCB3ZWlnaHRwPTAga2V5aW50PTI1MCBrZXlpbnRfbWluPTUgc2NlbmVjdXQ9MCBpbnRyYV9yZWZyZXNoPTAgcmM9Y3JmIG1idHJlZT0wIGNyZj0zMC4wIHFjb21wPTAuNjAgcXBtaW49MCBxcG1heD02OSBxcHN0ZXA9NCBpcF9yYXRpbz0xLjQwIGFxPTAAgAAAAB9liIQ6EYoAAglxwABALjgACC9JycnXXXXXXXXXXXXgAAAABkGaIBSgjAAAAAZBmkAUoIwAAAAGQZpgFKCMAAAABkGagBWgjAAAAAZBmqAVoIwAAAAGQZrAFaCMAAAABkGa4BWgjAAAAAZBmwAVoIwAAAAGQZsgFaCM',
+  'base64',
+);
+
+describeS3('Storage (S3/MinIO) e2e', () => {
   let app: E2eApp;
+  let s3Client: S3Client;
 
   beforeAll(async () => {
     for (const key of Object.keys(S3_ENV)) {
       PREVIOUS_ENV[key] = process.env[key];
     }
     Object.assign(process.env, S3_ENV);
+
+    s3Client = new S3Client({
+      region: S3_ENV.S3_REGION,
+      endpoint: S3_ENV.S3_ENDPOINT,
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: S3_ENV.S3_ACCESS_KEY_ID,
+        secretAccessKey: S3_ENV.S3_SECRET_ACCESS_KEY,
+      },
+    });
+
+    // Create the bucket ourselves via the SDK rather than depending on the
+    // compose-only `minio-init` sidecar — CI's bare `minio` service has no
+    // equivalent, and this is harmless to also run locally (MinIO returns
+    // BucketAlreadyOwnedByYou, ignored below).
+    try {
+      await s3Client.send(new CreateBucketCommand({ Bucket: S3_BUCKET }));
+    } catch (error) {
+      const name = (error as { name?: string } | undefined)?.name;
+      if (
+        name !== 'BucketAlreadyOwnedByYou' &&
+        name !== 'BucketAlreadyExists'
+      ) {
+        throw error;
+      }
+    }
 
     app = await createE2eApp();
     await resetDatabase(app);
@@ -62,6 +180,7 @@ describe('Storage (S3/MinIO) e2e', () => {
 
   afterAll(async () => {
     await app.close();
+    s3Client.destroy();
     for (const [key, value] of Object.entries(PREVIOUS_ENV)) {
       if (value === undefined) {
         delete process.env[key];
@@ -71,7 +190,121 @@ describe('Storage (S3/MinIO) e2e', () => {
     }
   });
 
-  it('round-trips an image upload through S3 storage: upload -> serve (full + ranged) -> soft delete', async () => {
+  it('generates and serves a thumbnail for a video message attachment through S3 storage', async () => {
+    const username = 'e2e-s3-video-user';
+    const password = 'Password123!';
+
+    // First user registered in this file's (freshly-reset) DB → OWNER,
+    // which bypasses RBAC — avoids depending on default non-owner role
+    // grants for CREATE_COMMUNITY/CREATE_CHANNEL/CREATE_MESSAGE, which
+    // aren't this suite's concern.
+    await registerUser(app, { username, password });
+    const { accessToken } = await loginUser(app, username, password);
+
+    const communityRes = await request(app.getHttpServer())
+      .post('/api/community')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ name: 'S3 e2e community' })
+      .expect(201);
+    const communityId = (communityRes.body as { id: string }).id;
+
+    const channelRes = await request(app.getHttpServer())
+      .post('/api/channels')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        name: 's3-e2e-channel',
+        communityId,
+        type: 'TEXT',
+        isPrivate: false,
+      })
+      .expect(201);
+    const channelId = (channelRes.body as { id: string }).id;
+
+    // Real message-attachment flow (mirrors useMessageFileUpload.ts): the
+    // message is created first (empty attachments) so a real messageId
+    // exists, then the file is uploaded with `resourceId: messageId` — the
+    // MessageAttachmentStrategy access-control check depends on
+    // File.fileMessageId pointing at a real, readable message.
+    const messageRes = await request(app.getHttpServer())
+      .post('/api/messages')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        channelId,
+        spans: [
+          {
+            type: 'PLAINTEXT',
+            text: 'video attachment coming up',
+            userId: null,
+            specialKind: null,
+            communityId: null,
+            aliasId: null,
+          },
+        ],
+        attachments: [],
+      })
+      .expect(201);
+    const messageId = (messageRes.body as { id: string }).id;
+
+    const uploadRes = await request(app.getHttpServer())
+      .post('/api/file-upload')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .field('resourceType', 'MESSAGE_ATTACHMENT')
+      .field('resourceId', messageId)
+      .attach('file', MP4_FIXTURE, {
+        filename: 'clip.mp4',
+        contentType: 'video/mp4',
+      })
+      .expect(201);
+
+    const uploadBody = uploadRes.body as { id: string; storageType: string };
+    const fileId = uploadBody.id;
+    expect(fileId).toBeDefined();
+    expect(uploadBody.storageType).toBe('S3');
+
+    // Thumbnail generation runs synchronously inside the upload request
+    // (FileUploadService.uploadFile awaits it before responding), so by now
+    // the DB row and the bucket object should both reflect it.
+    const metadataRes = await request(app.getHttpServer())
+      .get(`/api/file/${fileId}/metadata`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+    expect((metadataRes.body as { hasThumbnail: boolean }).hasThumbnail).toBe(
+      true,
+    );
+
+    // Confirm the thumbnail object actually landed in the bucket (not just
+    // that the DB row claims one exists) — thumbnail.service.ts's S3 path
+    // uploads to the fixed key `thumbnails/<fileId>.jpg`.
+    const thumbnailHead: { ContentLength?: number } = await s3Client.send(
+      new HeadObjectCommand({
+        Bucket: S3_BUCKET,
+        Key: `thumbnails/${fileId}.jpg`,
+      }),
+    );
+    expect(thumbnailHead.ContentLength).toEqual(expect.any(Number));
+
+    // Serve path: thumbnail bytes stream back from MinIO through the backend.
+    const thumbRes = await request(app.getHttpServer())
+      .get(`/api/file/${fileId}/thumbnail`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => callback(null, Buffer.concat(chunks)));
+      })
+      .expect(200);
+
+    expect(thumbRes.headers['content-type']).toBe('image/jpeg');
+    const bytes = thumbRes.body as Buffer;
+    expect(bytes.length).toBeGreaterThan(0);
+    // Real JPEG SOI marker — proves ffmpeg actually produced a decodable
+    // image, not just that some bytes made it through the pipe.
+    expect(bytes[0]).toBe(0xff);
+    expect(bytes[1]).toBe(0xd8);
+  });
+
+  it('round-trips an image upload through S3 storage: upload -> serve (full + ranged) -> soft delete -> 404', async () => {
     const username = 'e2e-s3-user';
     const password = 'Password123!';
 
@@ -140,5 +373,14 @@ describe('Storage (S3/MinIO) e2e', () => {
       .delete(`/api/file-upload/${fileId}`)
       .set('Authorization', `Bearer ${accessToken}`)
       .expect(200);
+
+    // Post-delete: fetching a soft-deleted file must 404, not 500.
+    // file.service.ts's findOne now maps the Prisma P2025 raised by
+    // findUniqueOrThrow's `deletedAt: null` filter to NotFoundException
+    // (see file.service.spec.ts for the unit-level regression test).
+    await request(app.getHttpServer())
+      .get(`/api/file/${fileId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(404);
   });
 });

--- a/backend/test/storage-s3.e2e-spec.ts
+++ b/backend/test/storage-s3.e2e-spec.ts
@@ -85,7 +85,7 @@ function isMinioReachable(endpoint: string, timeoutMs = 2000): boolean {
   try {
     const url = new URL(endpoint);
     host = url.hostname;
-    port = url.port ? Number(url.port) : 80;
+    port = Number(url.port || (url.protocol === 'https:' ? '443' : '80'));
   } catch {
     return false;
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,6 +128,47 @@ services:
       redis:
         condition: service_healthy
 
+  # S3-compatible object storage for local dev/testing of STORAGE_TYPE=S3.
+  # Opt-in via profile — doesn't start with a plain `docker compose up`:
+  #   docker compose --profile s3 up -d minio
+  # Then set in backend/.env: STORAGE_TYPE=S3, S3_BUCKET=semaphore-dev,
+  # S3_REGION=us-east-1, S3_ACCESS_KEY_ID=minioadmin,
+  # S3_SECRET_ACCESS_KEY=minioadmin, S3_ENDPOINT=http://minio:9000,
+  # S3_FORCE_PATH_STYLE=true. See docs-site/docs/installation/configuration.md.
+  minio:
+    image: minio/minio:latest
+    profiles: ["s3"]
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      # - "9001:9001" # Web console — uncomment to browse buckets at http://localhost:9001
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - miniodata:/data
+
+  # One-shot sidecar: creates the dev bucket so the backend doesn't have to.
+  # Equivalent manual command if you ever need to re-run it by hand:
+  #   docker compose --profile s3 run --rm minio-init
+  minio-init:
+    image: minio/mc:latest
+    profiles: ["s3"]
+    entrypoint: >
+      /bin/sh -c "
+        mc alias set local http://minio:9000 minioadmin minioadmin &&
+        mc mb --ignore-existing local/semaphore-dev
+      "
+    depends_on:
+      minio:
+        condition: service_healthy
+    restart: "no"
+
   egress-init:
     image: busybox
     volumes:
@@ -160,3 +201,4 @@ volumes:
   pgdata:
   redisdata:
   egress-data:
+  miniodata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,13 +130,20 @@ services:
 
   # S3-compatible object storage for local dev/testing of STORAGE_TYPE=S3.
   # Opt-in via profile — doesn't start with a plain `docker compose up`:
-  #   docker compose --profile s3 up -d minio
+  #   docker compose --profile s3 up -d minio minio-init
+  # (minio-init creates the dev bucket automatically — see that service below.)
   # Then set in backend/.env: STORAGE_TYPE=S3, S3_BUCKET=semaphore-dev,
   # S3_REGION=us-east-1, S3_ACCESS_KEY_ID=minioadmin,
   # S3_SECRET_ACCESS_KEY=minioadmin, S3_ENDPOINT=http://minio:9000,
   # S3_FORCE_PATH_STYLE=true. See docs-site/docs/installation/configuration.md.
+  #
+  # Image pinned to a specific release (not `:latest`) for reproducible dev
+  # behavior. CI intentionally uses `minio/minio:edge-cicd` instead — a
+  # separate constraint from a bare GitHub Actions service container boot
+  # (no compose profile, no healthcheck-gated init sidecar) — so the two are
+  # deliberately not kept identical.
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     profiles: ["s3"]
     command: server /data --console-address ":9001"
     environment:
@@ -157,7 +164,7 @@ services:
   # Equivalent manual command if you ever need to re-run it by hand:
   #   docker compose --profile s3 run --rm minio-init
   minio-init:
-    image: minio/mc:latest
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     profiles: ["s3"]
     entrypoint: >
       /bin/sh -c "

--- a/docs-site/docs/installation/configuration.md
+++ b/docs-site/docs/installation/configuration.md
@@ -21,6 +21,51 @@ Copy `backend/env.sample` to `backend/.env` to get started.
     openssl rand -base64 32
     ```
 
+### File storage
+
+File uploads (message attachments, avatars, banners, custom emoji, soundboard sounds) can be stored on the local filesystem or in an S3-compatible object store. Storage is resolved **per file record** — switching `STORAGE_TYPE` only affects where *new* uploads land; existing files keep working from wherever they were originally stored, so mixed-storage instances (e.g. after a mid-life migration to S3) work with zero migration.
+
+| Variable | Description | Default |
+|----------|------------|---------|
+| `STORAGE_TYPE` | `LOCAL` or `S3` | `LOCAL` |
+| `FILE_UPLOAD_DEST` | Local staging directory. For `STORAGE_TYPE=LOCAL` this is also the permanent storage location; for `STORAGE_TYPE=S3` it's scratch space only (files are uploaded to the bucket, then removed) | `./uploads` |
+
+The following are only required when `STORAGE_TYPE=S3` (validated at startup):
+
+| Variable | Description | Example |
+|----------|------------|---------|
+| `S3_BUCKET` | Target bucket name | `semaphore-chat-uploads` |
+| `S3_REGION` | AWS region (or an arbitrary value for MinIO) | `us-east-1` |
+| `S3_ACCESS_KEY_ID` | Access key | |
+| `S3_SECRET_ACCESS_KEY` | Secret key | |
+| `S3_ENDPOINT` | *(Optional)* Custom endpoint — set for S3-compatible services like MinIO | `http://minio:9000` |
+| `S3_FORCE_PATH_STYLE` | *(Optional)* Set `true` for MinIO and most self-hosted S3-compatible services (path-style addressing) | `true` |
+
+!!! note "The backend always streams file bytes, never redirects"
+    Uploads and downloads stream through the backend rather than presigning direct-to-S3 URLs, so the existing file access-control guards stay the single source of truth. Presigned URLs are a possible future optimization for read-heavy deployments, not implemented yet.
+
+#### Local development with MinIO
+
+The dev Docker Compose stack includes a MinIO service (S3-compatible, runs locally) behind an opt-in `s3` profile so it doesn't start by default:
+
+```bash
+docker compose --profile s3 up -d minio
+```
+
+Then set in `backend/.env`:
+
+```bash
+STORAGE_TYPE=S3
+S3_BUCKET=semaphore-dev
+S3_REGION=us-east-1
+S3_ACCESS_KEY_ID=minioadmin
+S3_SECRET_ACCESS_KEY=minioadmin
+S3_ENDPOINT=http://minio:9000
+S3_FORCE_PATH_STYLE=true
+```
+
+The `minio-init` sidecar creates the `semaphore-dev` bucket automatically on first start. MinIO's web console (if you enable the console port in `docker-compose.yml`) is available at `http://localhost:9001` with the same credentials.
+
 ### LiveKit (voice/video)
 
 These are optional — voice and video features are disabled if not configured.

--- a/docs-site/docs/installation/configuration.md
+++ b/docs-site/docs/installation/configuration.md
@@ -49,7 +49,7 @@ The following are only required when `STORAGE_TYPE=S3` (validated at startup):
 The dev Docker Compose stack includes a MinIO service (S3-compatible, runs locally) behind an opt-in `s3` profile so it doesn't start by default:
 
 ```bash
-docker compose --profile s3 up -d minio
+docker compose --profile s3 up -d minio minio-init
 ```
 
 Then set in `backend/.env`:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,12 @@ importers:
 
   backend:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.700.0
+        version: 3.1085.0
+      '@aws-sdk/lib-storage':
+        specifier: ^3.700.0
+        version: 3.1085.0(@aws-sdk/client-s3@3.1085.0)
       '@nest-lab/throttler-storage-redis':
         specifier: ^1.2.0
         version: 1.2.0(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(reflect-metadata@0.2.2))(ioredis@5.10.0)(reflect-metadata@0.2.2)
@@ -483,6 +489,84 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@aws-sdk/checksums@3.1000.16':
+    resolution: {integrity: sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1085.0':
+    resolution: {integrity: sha512-O0xe8sR50AYkwxlvRRsV0qytEO2dtXQTQ1CF3YBBdE5xtVkbu27H0vGa1mjQi1/+fbYM80AWEIPai5jZmXyubw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.975.1':
+    resolution: {integrity: sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.57':
+    resolution: {integrity: sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.59':
+    resolution: {integrity: sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.1':
+    resolution: {integrity: sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.63':
+    resolution: {integrity: sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.66':
+    resolution: {integrity: sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.57':
+    resolution: {integrity: sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.1':
+    resolution: {integrity: sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.63':
+    resolution: {integrity: sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/lib-storage@3.1085.0':
+    resolution: {integrity: sha512-S+yCGIMxQ5Zs2A5ZDdYfXwOxu5kKjBaCQVOxp6+mnwCQYXUNkBD/aKCnW1eniMTavzz3YidhD5eTFpDlcUv2gQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-s3': ^3.1085.0
+
+  '@aws-sdk/middleware-sdk-s3@3.972.62':
+    resolution: {integrity: sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.31':
+    resolution: {integrity: sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.39':
+    resolution: {integrity: sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1083.0':
+    resolution: {integrity: sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.0':
+    resolution: {integrity: sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.34':
+    resolution: {integrity: sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -2695,6 +2779,30 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@smithy/core@3.29.3':
+    resolution: {integrity: sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.8':
+    resolution: {integrity: sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.5':
+    resolution: {integrity: sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.5':
+    resolution: {integrity: sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.4':
+    resolution: {integrity: sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
@@ -3693,6 +3801,9 @@ packages:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   boxen@5.1.2:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
     engines: {node: '>=10'}
@@ -3735,6 +3846,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.6.0:
+    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -6804,6 +6918,9 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -7803,6 +7920,181 @@ snapshots:
       lru-cache: 11.2.6
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@aws-sdk/checksums@3.1000.16':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1085.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.16
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.66
+      '@aws-sdk/middleware-sdk-s3': 3.972.62
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.975.1':
+    dependencies:
+      '@aws-sdk/types': 3.974.0
+      '@aws-sdk/xml-builder': 3.972.34
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.3
+      '@smithy/signature-v4': 5.6.4
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.57':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.1':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-env': 3.972.57
+      '@aws-sdk/credential-provider-http': 3.972.59
+      '@aws-sdk/credential-provider-login': 3.972.63
+      '@aws-sdk/credential-provider-process': 3.972.57
+      '@aws-sdk/credential-provider-sso': 3.973.1
+      '@aws-sdk/credential-provider-web-identity': 3.972.63
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/credential-provider-imds': 4.4.8
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.63':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.66':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.57
+      '@aws-sdk/credential-provider-http': 3.972.59
+      '@aws-sdk/credential-provider-ini': 3.973.1
+      '@aws-sdk/credential-provider-process': 3.972.57
+      '@aws-sdk/credential-provider-sso': 3.973.1
+      '@aws-sdk/credential-provider-web-identity': 3.972.63
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/credential-provider-imds': 4.4.8
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.57':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.1':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/token-providers': 3.1083.0
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.63':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/lib-storage@3.1085.0(@aws-sdk/client-s3@3.1085.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1085.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      buffer: 5.6.0
+      events: 3.3.0
+      stream-browserify: 3.0.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.62':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.31':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.39':
+    dependencies:
+      '@aws-sdk/types': 3.974.0
+      '@smithy/signature-v4': 5.6.4
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1083.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.0':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.34':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -10076,6 +10368,39 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@smithy/core@3.29.3':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.8':
+    dependencies:
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.5':
+    dependencies:
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.5':
+    dependencies:
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.4':
+    dependencies:
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@socket.io/component-emitter@3.1.2': {}
 
   '@socket.io/redis-adapter@8.3.0(socket.io-adapter@2.5.6)':
@@ -11328,6 +11653,8 @@ snapshots:
   boolean@3.2.0:
     optional: true
 
+  bowser@2.14.1: {}
+
   boxen@5.1.2:
     dependencies:
       ansi-align: 3.0.1
@@ -11379,6 +11706,11 @@ snapshots:
   buffer-equal@1.0.1: {}
 
   buffer-from@1.1.2: {}
+
+  buffer@5.6.0:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   buffer@5.7.1:
     dependencies:
@@ -14904,6 +15236,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   streamsearch@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- Implements the S3 provider behind the existing `IStorageProvider` pattern (the enum stub previously threw NotImplemented), removing the local-disk-only scaling ceiling for uploads.
- Interface evolved to object-store semantics (keys + streams, ranged reads); `LocalStorageProvider` adapted with identical behavior — **default `STORAGE_TYPE=LOCAL` is a zero-behavior-change path**.
- **Mixed instances with zero migration**: providers resolve per file record (`storageType` column already existed), so old LOCAL files keep serving while new uploads go to S3. Serve path streams through the backend — FileAuthGuard strategies untouched (presigned redirects noted as a possible later optimization).
- Streaming discipline throughout: multipart uploads via `@aws-sdk/lib-storage`, streaming checksum (previously buffered whole files), Range pass-through on both providers.
- Dev: MinIO behind `docker compose --profile s3`; CI: MinIO service (first-party `minio/minio:edge-cicd`) in the backend e2e job, with the S3 spec skipping gracefully when MinIO is absent. E2e covers upload → serve (full + ranged) → video thumbnail (bucket object + served JPEG bytes) → delete → 404, verified against real MinIO.
- Rides along per repo testing policy: fixed the pre-existing bug where fetching a soft-deleted file returned 500 instead of 404 (P2025 → NotFoundException).
- **Hardening after an incident**: the e2e `E2E_ALLOW_DB_RESET` override (documented in spec headers as the standard local command) enabled wiping a non-test database. The override is removed — `resetDatabase()` now unconditionally refuses databases whose name lacks "test"; docs show the dedicated-test-DB flow.

## Env
`STORAGE_TYPE=S3` + `S3_BUCKET/REGION/ENDPOINT/ACCESS_KEY_ID/SECRET_ACCESS_KEY/FORCE_PATH_STYLE` (validated only when S3 is selected; typos in STORAGE_TYPE now fail fast at boot).

## Out of scope (logged follow-ups)
- Helm `fileStorage.s3` values + replica-guard relaxation — lands after #417 merges (same chart region).
- LiveKit replay/egress storage (LiveKit supports S3 natively via its own config).
- Pre-existing quota-increment/file-create non-atomicity (orphaned-row edge, both storage types).

## Test plan
- Backend suite 142 suites / 2403 tests, lint, build green (LOCAL default). E2e 6 suites / 40 tests green against real MinIO; skip path verified with MinIO stopped (reports SKIPPED, not silent pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sAJfCfBfMm8chbZMsh5Y5