### PR TITLE
feat(a11y): keyboard navigation and ARIA for mention dropdown, emoji picker, and menus

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -2,7 +2,24 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import jsxA11y from 'eslint-plugin-jsx-a11y'
 import tseslint from 'typescript-eslint'
+
+// jsx-a11y's own "recommended" preset ships most rules at 'error'. This repo
+// wants it advisory (warn) rather than build-breaking while the codebase
+// catches up — downgrade every enabled rule's severity to 'warn' but keep
+// each rule's own options (and leave anything explicitly 'off' alone).
+function toWarnOnly(rules) {
+  return Object.fromEntries(
+    Object.entries(rules).map(([ruleId, config]) => {
+      if (Array.isArray(config)) {
+        const [severity, ...options] = config
+        return [ruleId, severity === 'off' ? config : ['warn', ...options]]
+      }
+      return [ruleId, config === 'off' ? config : 'warn']
+    }),
+  )
+}
 
 export default tseslint.config(
   { ignores: ['dist', 'src/api-client', 'coverage'] },
@@ -39,5 +56,14 @@ export default tseslint.config(
     rules: {
       'no-console': 'off',
     },
+  },
+  // jsx-a11y recommended ruleset, downgraded to warnings (see toWarnOnly).
+  {
+    files: ['**/*.{ts,tsx}'],
+    plugins: { 'jsx-a11y': jsxA11y },
+    languageOptions: {
+      parserOptions: { ecmaFeatures: { jsx: true } },
+    },
+    rules: toWarnOnly(jsxA11y.flatConfigs.recommended.rules),
   },
 )

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -9,6 +9,14 @@ import tseslint from 'typescript-eslint'
 // wants it advisory (warn) rather than build-breaking while the codebase
 // catches up — downgrade every enabled rule's severity to 'warn' but keep
 // each rule's own options (and leave anything explicitly 'off' alone).
+//
+// NOTE on package.json's `lint`/`lint:fix` scripts (`--max-warnings 45`):
+// that ceiling was bumped 20 -> 45 to make room for ~41 pre-existing
+// warnings this ruleset surfaced across the app (mostly jsx-a11y/no-autofocus
+// and jsx-a11y/media-has-caption — real, easy a11y wins), none of which were
+// introduced or fixed by the PR that added jsx-a11y. Burning that count down
+// is tracked as a follow-up, not scoped into this PR — see
+// task-pr15-report.md's "Concerns"/follow-ups.
 function toWarnOnly(rules) {
   return Object.fromEntries(
     Object.entries(rules).map(([ruleId, config]) => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,8 +38,8 @@
     "start": "pnpm run build-electron && pnpm run build-preload && electron .",
     "electron-dev": "concurrently -k \"cross-env NODE_ENV=development vite\" \"wait-on http://localhost:5173 && pnpm run build-electron && pnpm run build-preload && electron .\"",
     "type-check": "tsc -b",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 20",
-    "lint:fix": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 20 --fix",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 45",
+    "lint:fix": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 45 --fix",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",
@@ -100,6 +100,7 @@
     "electron-builder": "^24.13.3",
     "electron-vite": "^5.0.0",
     "eslint": "^9.39.2",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.26",
     "globals": "^16.0.0",
@@ -114,6 +115,7 @@
     "vite-plugin-electron-renderer": "^0.14.6",
     "vite-plugin-pwa": "^1.2.0",
     "vitest": "^4.0.18",
+    "vitest-axe": "^0.1.0",
     "wait-on": "^8.0.3"
   }
 }

--- a/frontend/src/__tests__/components/EmojiPickerPopover.test.tsx
+++ b/frontend/src/__tests__/components/EmojiPickerPopover.test.tsx
@@ -1,10 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
-import { renderWithProviders } from '../test-utils';
+import { screen, within, act } from '@testing-library/react';
+import { renderWithProviders, runAxe, expectNoAxeViolations } from '../test-utils';
 import {
   EmojiPickerPopover,
   type EmojiPickerPopoverProps,
 } from '../../components/Message/EmojiPicker';
+
+// Focusing an element directly (vs. via userEvent) fires React's onFocus
+// synchronously outside of React's event batching, which triggers an "not
+// wrapped in act(...)" warning even though the assertions are still valid.
+// Wrap it so tests exercise the same roving-tabindex onFocus sync the app
+// relies on (e.g. tabbing in from the search field) without the noise.
+function focus(element: HTMLElement) {
+  act(() => {
+    element.focus();
+  });
+}
 
 function defaultProps(
   overrides: Partial<EmojiPickerPopoverProps> = {},
@@ -44,4 +55,125 @@ describe('EmojiPickerPopover', () => {
     ).not.toBeInTheDocument();
   });
 
+  describe('roving-tabindex grid navigation', () => {
+    // "Frequently Used" (the first, default-visible category) is:
+    // 👍 👎 ❤️ 😂 😮 😢 😡 👏 | 🎉 🔥 💯 ⭐ ✅ ❌ 🤔 😍  (8 columns × 2 rows)
+    //
+    // Several of these emoji (👍, 👎, 👏, 😂, 😮, 😢, 😡, 🎉…) also appear in
+    // OTHER categories further down the picker by design (recurring
+    // "reaction" emoji), so their aria-labels aren't page-unique — queries
+    // below are scoped with `within(...)` to the category's own group to
+    // disambiguate, rather than relying on global label lookups.
+    function frequentlyUsedGroup() {
+      return within(screen.getByRole('group', { name: 'Frequently Used' }));
+    }
+
+    it('only the active cell is in the tab order, defaulting to the first emoji', () => {
+      renderWithProviders(<EmojiPickerPopover {...defaultProps()} />);
+
+      const group = frequentlyUsedGroup();
+      expect(group.getByLabelText('thumbs up')).toHaveAttribute('tabindex', '0');
+      expect(group.getByLabelText('thumbs down')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('ArrowRight moves focus to the next cell and updates the roving tabindex', async () => {
+      const { user } = renderWithProviders(<EmojiPickerPopover {...defaultProps()} />);
+      const group = frequentlyUsedGroup();
+
+      const first = group.getByLabelText('thumbs up');
+      focus(first);
+      expect(first).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+
+      const second = group.getByLabelText('thumbs down');
+      expect(second).toHaveFocus();
+      expect(second).toHaveAttribute('tabindex', '0');
+      expect(first).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('ArrowLeft at the first cell of a row does nothing (no previous section)', async () => {
+      const { user } = renderWithProviders(<EmojiPickerPopover {...defaultProps()} />);
+      const group = frequentlyUsedGroup();
+
+      const first = group.getByLabelText('thumbs up');
+      focus(first);
+      await user.keyboard('{ArrowLeft}');
+
+      expect(first).toHaveFocus();
+    });
+
+    it('ArrowDown moves focus one row down (8 cells) within the category', async () => {
+      const { user } = renderWithProviders(<EmojiPickerPopover {...defaultProps()} />);
+      const group = frequentlyUsedGroup();
+
+      focus(group.getByLabelText('thumbs up'));
+      await user.keyboard('{ArrowDown}');
+
+      // Index 0 + 8 columns = index 8 = 🎉 ("party")
+      expect(group.getByLabelText('party')).toHaveFocus();
+    });
+
+    it('End moves to the last cell of the current row, Home moves back to the first', async () => {
+      const { user } = renderWithProviders(<EmojiPickerPopover {...defaultProps()} />);
+      const group = frequentlyUsedGroup();
+
+      focus(group.getByLabelText('thumbs down'));
+      await user.keyboard('{End}');
+      // Row 0 is indices 0-7; index 7 = 👏 ("clap")
+      expect(group.getByLabelText('clap')).toHaveFocus();
+
+      await user.keyboard('{Home}');
+      expect(group.getByLabelText('thumbs up')).toHaveFocus();
+    });
+
+    it('PageDown jumps to the first cell of the next category', async () => {
+      const { user } = renderWithProviders(<EmojiPickerPopover {...defaultProps()} />);
+
+      focus(frequentlyUsedGroup().getByLabelText('thumbs up'));
+      await user.keyboard('{PageDown}');
+
+      // First cell of "Smileys & People" (the next category) is 😀 ("grin")
+      const nextGroup = within(screen.getByRole('group', { name: 'Smileys & People' }));
+      expect(nextGroup.getByLabelText('grin')).toHaveFocus();
+    });
+
+    it('Enter selects the focused emoji and closes the popover', async () => {
+      const onEmojiSelect = vi.fn();
+      const onClose = vi.fn();
+      const { user } = renderWithProviders(
+        <EmojiPickerPopover {...defaultProps({ onEmojiSelect, onClose })} />,
+      );
+
+      focus(frequentlyUsedGroup().getByLabelText('thumbs up'));
+      await user.keyboard('{Enter}');
+
+      expect(onEmojiSelect).toHaveBeenCalledWith('👍');
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('Escape closes the popover', async () => {
+      const onClose = vi.fn();
+      const { user } = renderWithProviders(
+        <EmojiPickerPopover {...defaultProps({ onClose })} />,
+      );
+
+      focus(frequentlyUsedGroup().getByLabelText('thumbs up'));
+      await user.keyboard('{Escape}');
+
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has no axe violations while open', async () => {
+      renderWithProviders(<EmojiPickerPopover {...defaultProps()} />);
+      await screen.findByPlaceholderText('Search emojis...');
+
+      // MUI's Popover portals into document.body (outside RTL's render
+      // `container`), so scan the whole document to actually include it.
+      const results = await runAxe(document.body);
+      expectNoAxeViolations(results);
+    });
+  });
 });

--- a/frontend/src/__tests__/components/EmojiPickerPopover.test.tsx
+++ b/frontend/src/__tests__/components/EmojiPickerPopover.test.tsx
@@ -166,23 +166,38 @@ describe('EmojiPickerPopover', () => {
   });
 
   describe('accessibility', () => {
+    // axe's scan of the full emoji grid is legitimately slow (3s+ observed
+    // locally, more on a loaded CI runner) — give this one test more room
+    // than the file's default budget instead of letting it ride the shared
+    // 15s testTimeout.
     it('has no axe violations while open', async () => {
-      renderWithProviders(<EmojiPickerPopover {...defaultProps()} />);
-      await screen.findByPlaceholderText('Search emojis...');
+      // MUI's Grow transition (Popover's default `timeout="auto"`) settles
+      // its "entered" state via one or more internal timers (an
+      // auto-computed height-based duration, Popper repositioning, etc).
+      // None of these correspond to a real animation in jsdom (there's no
+      // layout engine), so there's nothing to wait for in real time — a
+      // previous fix drained them with a fixed real 300ms sleep inside
+      // act(), which is timing-coupled to nothing in particular and
+      // flaked/timed out on slow CI runners. Fake timers let us flush all
+      // of them deterministically in virtual time (no real wall-clock
+      // delay) before axe scans the DOM, with no risk of an "update not
+      // wrapped in act(...)" warning landing outside the flush.
+      vi.useFakeTimers();
+      try {
+        renderWithProviders(<EmojiPickerPopover {...defaultProps()} />);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1000);
+        });
+      } finally {
+        vi.useRealTimers();
+      }
 
-      // MUI's Grow transition finishes its enter animation via a real
-      // setTimeout. axe's scan is slow (multi-second in this environment),
-      // so without draining that timeout first, it can fire mid-scan and
-      // log a "not wrapped in act(...)" warning for the Transition's
-      // internal state update. Settle it here, inside act(), before axe runs.
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 300));
-      });
+      await screen.findByPlaceholderText('Search emojis...');
 
       // MUI's Popover portals into document.body (outside RTL's render
       // `container`), so scan the whole document to actually include it.
       const results = await runAxe(document.body);
       expectNoAxeViolations(results);
-    });
+    }, 20000);
   });
 });

--- a/frontend/src/__tests__/components/EmojiPickerPopover.test.tsx
+++ b/frontend/src/__tests__/components/EmojiPickerPopover.test.tsx
@@ -170,6 +170,15 @@ describe('EmojiPickerPopover', () => {
       renderWithProviders(<EmojiPickerPopover {...defaultProps()} />);
       await screen.findByPlaceholderText('Search emojis...');
 
+      // MUI's Grow transition finishes its enter animation via a real
+      // setTimeout. axe's scan is slow (multi-second in this environment),
+      // so without draining that timeout first, it can fire mid-scan and
+      // log a "not wrapped in act(...)" warning for the Transition's
+      // internal state update. Settle it here, inside act(), before axe runs.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 300));
+      });
+
       // MUI's Popover portals into document.body (outside RTL's render
       // `container`), so scan the whole document to actually include it.
       const results = await runAxe(document.body);

--- a/frontend/src/__tests__/components/MemberList.contextMenuFocusRestore.test.tsx
+++ b/frontend/src/__tests__/components/MemberList.contextMenuFocusRestore.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import MemberList, { type MemberData } from '../../components/Message/MemberList';
+
+/**
+ * Focus-restoration coverage for MemberList's right-click context menu
+ * (`UserModerationMenu`, opened via `useContextMenuFocusRestore`).
+ *
+ * Unlike MemberList.test.tsx (which stubs UserModerationMenu to `() => null`
+ * for rendering-only assertions), this file renders the real
+ * `UserModerationMenu` so Escape/onClose actually fires and the
+ * focus-restoration path can be exercised end-to-end. Covers both:
+ *  (a) the normal case — the row that opened the menu is still mounted, so
+ *      focus returns to it; and
+ *  (b) the presence-driven edge case — the row unmounts (e.g. the member
+ *      goes offline/leaves) while the menu is still open, so restoreFocus
+ *      falls back to the list's scroll container instead of no-oping on a
+ *      detached node.
+ */
+
+vi.mock('../../contexts/UserProfileContext', () => ({
+  useUserProfile: () => ({ openProfile: vi.fn() }),
+}));
+
+vi.mock('../../components/Common/UserAvatar', () => ({
+  default: () => <div data-testid="user-avatar" />,
+}));
+
+const mockCanPerformAction = vi.fn((..._args: unknown[]) => false);
+vi.mock('../../features/roles/useUserPermissions', () => ({
+  useCanPerformAction: (...args: unknown[]) => mockCanPerformAction(...args),
+}));
+
+vi.mock('../../components/Moderation/BanDialog', () => ({
+  default: () => null,
+}));
+vi.mock('../../components/Moderation/TimeoutDialog', () => ({
+  default: () => null,
+}));
+vi.mock('../../components/Moderation/KickConfirmDialog', () => ({
+  default: () => null,
+}));
+
+function createMember(overrides: Partial<MemberData> = {}): MemberData {
+  return {
+    id: overrides.id ?? `user-${Math.random().toString(36).slice(2)}`,
+    username: overrides.username ?? 'testuser',
+    displayName: overrides.displayName ?? null,
+    avatarUrl: overrides.avatarUrl ?? null,
+    isOnline: overrides.isOnline ?? true,
+    status: overrides.status ?? null,
+    displayRole: overrides.displayRole ?? undefined,
+  };
+}
+
+describe('MemberList context menu focus restoration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCanPerformAction.mockReturnValue(false);
+  });
+
+  it('restores focus to the member row on Escape when the row is still mounted', async () => {
+    const members: MemberData[] = [
+      createMember({ id: 'user-a', username: 'alice', displayName: 'Alice' }),
+      createMember({ id: 'user-b', username: 'bob', displayName: 'Bob' }),
+    ];
+
+    renderWithProviders(<MemberList members={members} communityId="community-1" />);
+
+    const aliceRow = screen.getByText('Alice').closest('div[role="button"]') as HTMLElement;
+    expect(aliceRow).not.toBeNull();
+
+    fireEvent.contextMenu(aliceRow, { clientX: 10, clientY: 10 });
+    const menu = await screen.findByRole('menu');
+
+    fireEvent.keyDown(menu, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(aliceRow);
+    });
+  });
+
+  it('falls back to the list container when the triggering row unmounts before the menu finishes closing', async () => {
+    const members: MemberData[] = [
+      createMember({ id: 'user-a', username: 'alice', displayName: 'Alice' }),
+      createMember({ id: 'user-b', username: 'bob', displayName: 'Bob' }),
+    ];
+
+    const { rerender } = renderWithProviders(
+      <MemberList members={members} communityId="community-1" />,
+    );
+
+    // Capture the scroll container reference before the menu opens — once
+    // open, MUI's Modal marks all other content `aria-hidden`, which would
+    // hide it from a `getByRole('list')` query.
+    const listContainer = screen.getByRole('list').parentElement as HTMLElement;
+
+    const aliceRow = screen.getByText('Alice').closest('div[role="button"]') as HTMLElement;
+    fireEvent.contextMenu(aliceRow, { clientX: 10, clientY: 10 });
+    const menu = await screen.findByRole('menu');
+
+    // Simulate Alice going offline/leaving while the menu is still open —
+    // her row unmounts, but the menu (keyed off contextMenu.member in
+    // component state, not the members array) stays open.
+    rerender(
+      <MemberList
+        members={[createMember({ id: 'user-b', username: 'bob', displayName: 'Bob' })]}
+        communityId="community-1"
+      />,
+    );
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(menu, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(listContainer);
+    });
+  });
+});

--- a/frontend/src/__tests__/components/MessageComponent.contextMenu.test.tsx
+++ b/frontend/src/__tests__/components/MessageComponent.contextMenu.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { renderWithProviders, runAxe, expectNoAxeViolations } from '../test-utils';
 import MessageComponent from '../../components/Message/MessageComponent';
 import { createMessage } from '../test-utils/factories';
@@ -142,13 +142,31 @@ describe('MessageComponent context menu (web)', () => {
   });
 
   it('has no axe violations while the context menu is open', async () => {
-    renderMessage();
-
-    fireEvent.contextMenu(screen.getByText('Right-click me'), {
-      clientX: 10,
-      clientY: 10,
-    });
-    await screen.findByRole('menu');
+    // MUI's Menu enters via a Grow transition whose "entered" state update
+    // lands on internal timers. axe's scan below is slow (multi-second under
+    // load) and is NOT act-wrapped, so any timer firing mid-scan logs an
+    // "update not wrapped in act(...)" warning. Flush all pending transition
+    // timers deterministically in virtual time first — fake timers must be
+    // installed BEFORE the contextmenu event (that's when the Menu mounts and
+    // schedules them; timers already sitting in the real queue can't be
+    // advanced virtually). Same pattern as EmojiPickerPopover.test.tsx's axe
+    // test. getByRole (not findByRole) because the act-wrapped fireEvent
+    // renders the menu synchronously, and RTL's waitFor shouldn't run under
+    // fake timers.
+    vi.useFakeTimers();
+    try {
+      renderMessage();
+      fireEvent.contextMenu(screen.getByText('Right-click me'), {
+        clientX: 10,
+        clientY: 10,
+      });
+      screen.getByRole('menu');
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
 
     // MUI's Menu portals into document.body (outside RTL's `container`), so
     // scan the whole document to actually include the open menu.

--- a/frontend/src/__tests__/components/MessageComponent.contextMenu.test.tsx
+++ b/frontend/src/__tests__/components/MessageComponent.contextMenu.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
-import { renderWithProviders } from '../test-utils';
+import { renderWithProviders, runAxe, expectNoAxeViolations } from '../test-utils';
 import MessageComponent from '../../components/Message/MessageComponent';
 import { createMessage } from '../test-utils/factories';
 import { SpanType } from '../../types/message.type';
@@ -116,5 +116,43 @@ describe('MessageComponent context menu (web)', () => {
 
     expect(mockActions.handleEditClick).toHaveBeenCalledOnce();
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('restores focus to the message row on Escape (anchorPosition menus have no anchorEl for MUI to auto-restore to)', async () => {
+    renderMessage();
+
+    const messageText = screen.getByText('Right-click me');
+    // The message row is the nearest ancestor with tabIndex=-1 — added
+    // specifically so it can receive focus programmatically after the
+    // context menu (opened via right-click, not a focusable button) closes.
+    const messageRow = messageText.closest('[tabindex="-1"]');
+    expect(messageRow).not.toBeNull();
+
+    fireEvent.contextMenu(messageText, { clientX: 10, clientY: 10 });
+    const menu = await screen.findByRole('menu');
+
+    fireEvent.keyDown(menu, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(messageRow);
+    });
+  });
+
+  it('has no axe violations while the context menu is open', async () => {
+    renderMessage();
+
+    fireEvent.contextMenu(screen.getByText('Right-click me'), {
+      clientX: 10,
+      clientY: 10,
+    });
+    await screen.findByRole('menu');
+
+    // MUI's Menu portals into document.body (outside RTL's `container`), so
+    // scan the whole document to actually include the open menu.
+    const results = await runAxe(document.body);
+    expectNoAxeViolations(results);
   });
 });

--- a/frontend/src/__tests__/components/MessageInput.emojiFocusRestore.test.tsx
+++ b/frontend/src/__tests__/components/MessageInput.emojiFocusRestore.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import MessageInput from '../../components/Message/MessageInput';
+import { VoiceSessionType } from '../../contexts/VoiceContext';
+
+/**
+ * Focused regression test for the composer's emoji-picker Escape/focus-
+ * restoration fix (see MessageInput.tsx `handleEmojiPickerClose`).
+ *
+ * The main MessageInput.test.tsx suite mocks EmojiPickerPopover entirely (to
+ * make emoji *selection* deterministic), so it never exercises the real
+ * Popover's `disableRestoreFocus` + manual restore-on-close path. This file
+ * renders the real EmojiPickerPopover to verify that path specifically.
+ */
+
+// Let MSW intercept API-client requests
+vi.mock('../../api-client/client.gen', async (importOriginal) => {
+  const { createClient, createConfig } = await import('../../api-client/client');
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    client: createClient(createConfig({ baseUrl: 'http://localhost:3000' })),
+  };
+});
+
+const mockResponsive = vi.fn(() => ({
+  isTouchDevice: false,
+  shouldUseTouchUI: false,
+  isMobile: false,
+  isTablet: false,
+  isDesktop: true,
+  deviceType: 'desktop' as string,
+}));
+
+vi.mock('../../hooks/useResponsive', () => ({
+  useResponsive: () => mockResponsive(),
+}));
+
+function setup() {
+  const utils = renderWithProviders(
+    <MessageInput
+      contextType={VoiceSessionType.Dm}
+      contextId="dm-1"
+      userMentions={[]}
+      onSendMessage={vi.fn()}
+    />,
+  );
+  const input = screen.getByPlaceholderText('Type a message...') as HTMLTextAreaElement;
+  return { ...utils, input };
+}
+
+describe('MessageInput emoji picker focus restoration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResponsive.mockReturnValue({
+      isTouchDevice: false,
+      shouldUseTouchUI: false,
+      isMobile: false,
+      isTablet: false,
+      isDesktop: true,
+      deviceType: 'desktop',
+    });
+  });
+
+  it('Escape closes the emoji popover and restores focus to the emoji button (Popover disables its own auto-restore here)', async () => {
+    const { user } = setup();
+
+    const emojiButton = screen.getByLabelText('add emoji');
+    await user.click(emojiButton);
+
+    await screen.findByPlaceholderText('Search emojis...');
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('Search emojis...')).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(emojiButton);
+    });
+  });
+
+  it('selecting an emoji still returns focus to the composer input, not the emoji button', async () => {
+    const { user, input } = setup();
+
+    await user.click(screen.getByLabelText('add emoji'));
+    await screen.findByPlaceholderText('Search emojis...');
+
+    // Pick the first "thumbs up" (it recurs across categories by design —
+    // see EmojiPickerPopover.test.tsx — so take the first, in "Frequently
+    // Used").
+    await user.click(screen.getAllByLabelText('thumbs up')[0]);
+
+    await waitFor(() => {
+      expect(input.value).toContain('👍');
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(input);
+    });
+  });
+});

--- a/frontend/src/__tests__/components/MessageInput.test.tsx
+++ b/frontend/src/__tests__/components/MessageInput.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
-import { renderWithProviders } from '../test-utils';
+import { renderWithProviders, runAxe, expectNoAxeViolations } from '../test-utils';
 import MessageInput from '../../components/Message/MessageInput';
 import { VoiceSessionType } from '../../contexts/VoiceContext';
+import type { UserMention } from '../../utils/mentionParser';
 
 // Let MSW intercept API-client requests
 vi.mock('../../api-client/client.gen', async (importOriginal) => {
@@ -12,6 +13,12 @@ vi.mock('../../api-client/client.gen', async (importOriginal) => {
     client: createClient(createConfig({ baseUrl: 'http://localhost:3000' })),
   };
 });
+
+// MentionDropdown renders UserAvatar for user-type suggestions, which needs
+// a FileCacheProvider renderWithProviders doesn't set up. Stub it out.
+vi.mock('../../components/Common/UserAvatar', () => ({
+  default: () => <div data-testid="avatar" />,
+}));
 
 // Mock the emoji picker so we can trigger a selection deterministically.
 // When open, it renders a button that inserts a fixed emoji.
@@ -98,12 +105,12 @@ vi.mock('../../hooks/useResponsive', () => ({
   useResponsive: () => mockResponsive(),
 }));
 
-function setup(onSendMessage = vi.fn()) {
+function setup(onSendMessage = vi.fn(), userMentions: UserMention[] = []) {
   const utils = renderWithProviders(
     <MessageInput
       contextType={VoiceSessionType.Dm}
       contextId="dm-1"
-      userMentions={[]}
+      userMentions={userMentions}
       onSendMessage={onSendMessage}
     />,
   );
@@ -112,6 +119,11 @@ function setup(onSendMessage = vi.fn()) {
   ) as HTMLTextAreaElement;
   return { ...utils, input, onSendMessage };
 }
+
+const MENTION_MEMBERS: UserMention[] = [
+  { id: 'u-alice', username: 'alice', displayName: 'Alice' },
+  { id: 'u-alan', username: 'alan', displayName: 'Alan' },
+];
 
 describe('MessageInput', () => {
   beforeEach(() => {
@@ -233,6 +245,82 @@ describe('MessageInput', () => {
       );
       // The composer's own draft text is untouched by the GIF send.
       expect(input.value).toBe('still typing');
+    });
+  });
+
+  describe('mention autocomplete (combobox pattern)', () => {
+    it('marks the input as a combobox wired to the listbox, with aria-activedescendant tracking the highlighted option', async () => {
+      const { user, input } = setup(vi.fn(), MENTION_MEMBERS);
+
+      expect(input).toHaveAttribute('aria-autocomplete', 'list');
+      expect(input).not.toHaveAttribute('aria-controls');
+      expect(input).not.toHaveAttribute('aria-activedescendant');
+
+      await user.type(input, '@a');
+
+      const listbox = await screen.findByRole('listbox', { name: /mention suggestions/i });
+      const options = screen.getAllByRole('option');
+      expect(options.length).toBeGreaterThanOrEqual(2);
+
+      expect(input).toHaveAttribute('aria-controls', listbox.id);
+      expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
+      expect(options[0]).toHaveAttribute('aria-selected', 'true');
+      expect(options[1]).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('ArrowDown moves the highlighted option and updates aria-activedescendant to match', async () => {
+      const { user, input } = setup(vi.fn(), MENTION_MEMBERS);
+
+      await user.type(input, '@a');
+      const options = await screen.findAllByRole('option');
+      expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
+
+      await user.keyboard('{ArrowDown}');
+
+      expect(input).toHaveAttribute('aria-activedescendant', options[1].id);
+      expect(options[1]).toHaveAttribute('aria-selected', 'true');
+      expect(options[0]).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('Enter selects the highlighted suggestion and closes the listbox, keeping focus on the input', async () => {
+      const { user, input } = setup(vi.fn(), MENTION_MEMBERS);
+
+      await user.type(input, '@a');
+      await screen.findAllByRole('option');
+      // Move to the second suggestion (alan) before committing.
+      await user.keyboard('{ArrowDown}{Enter}');
+
+      expect(input.value).toContain('@Alan');
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(input).not.toHaveAttribute('aria-controls');
+      expect(input).not.toHaveAttribute('aria-activedescendant');
+      // The combobox pattern keeps focus on the input throughout — there is
+      // no separate menu to invoke/restore focus from.
+      expect(document.activeElement).toBe(input);
+    });
+
+    it('Escape closes the listbox without inserting a mention, and focus stays on the input', async () => {
+      const { user, input } = setup(vi.fn(), MENTION_MEMBERS);
+
+      await user.type(input, '@a');
+      await screen.findAllByRole('option');
+
+      await user.keyboard('{Escape}');
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(input).not.toHaveAttribute('aria-controls');
+      expect(input.value).toBe('@a');
+      expect(document.activeElement).toBe(input);
+    });
+
+    it('has no axe violations while the mention dropdown is open', async () => {
+      const { user, input, container } = setup(vi.fn(), MENTION_MEMBERS);
+
+      await user.type(input, '@a');
+      await screen.findByRole('listbox');
+
+      const results = await runAxe(container);
+      expectNoAxeViolations(results);
     });
   });
 });

--- a/frontend/src/__tests__/components/ThreadMessageInput.emojiFocusRestore.test.tsx
+++ b/frontend/src/__tests__/components/ThreadMessageInput.emojiFocusRestore.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import { ThreadMessageInput } from '../../components/Thread/ThreadMessageInput';
+
+/**
+ * Focused regression test for the thread composer's emoji-picker
+ * Escape/focus-restoration fix (see ThreadMessageInput.tsx
+ * `handleEmojiPickerClose`), mirroring
+ * MessageInput.emojiFocusRestore.test.tsx.
+ *
+ * ThreadMessageInput uses the same EmojiPickerPopover `anchorEl` +
+ * `disableRestoreFocus` path as MessageInput, so it needs the same
+ * reason-aware close handler to restore focus to the invoking button on
+ * Escape/backdrop-close (rather than dropping focus to <body>).
+ */
+
+const mockResponsive = vi.fn(() => ({
+  isTouchDevice: false,
+  shouldUseTouchUI: false,
+  isMobile: false,
+  isTablet: false,
+  isDesktop: true,
+  deviceType: 'desktop' as string,
+}));
+
+vi.mock('../../hooks/useResponsive', () => ({
+  useResponsive: () => mockResponsive(),
+}));
+
+function setup() {
+  const utils = renderWithProviders(
+    <ThreadMessageInput parentMessageId="msg-1" />,
+  );
+  const input = screen.getByPlaceholderText('Reply...') as HTMLTextAreaElement;
+  return { ...utils, input };
+}
+
+describe('ThreadMessageInput emoji picker focus restoration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResponsive.mockReturnValue({
+      isTouchDevice: false,
+      shouldUseTouchUI: false,
+      isMobile: false,
+      isTablet: false,
+      isDesktop: true,
+      deviceType: 'desktop',
+    });
+  });
+
+  it('Escape closes the emoji popover and restores focus to the emoji button (Popover disables its own auto-restore here)', async () => {
+    const { user } = setup();
+
+    const emojiButton = screen.getByLabelText('add emoji');
+    await user.click(emojiButton);
+
+    await screen.findByPlaceholderText('Search emojis...');
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('Search emojis...')).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(emojiButton);
+    });
+  });
+
+  it('selecting an emoji still returns focus to the composer input, not the emoji button', async () => {
+    const { user, input } = setup();
+
+    await user.click(screen.getByLabelText('add emoji'));
+    await screen.findByPlaceholderText('Search emojis...');
+
+    // "thumbs up" recurs across categories by design (e.g. "Frequently
+    // Used" and "Smileys & People") — see EmojiPickerPopover.test.tsx.
+    await user.click(screen.getAllByLabelText('thumbs up')[0]);
+
+    await waitFor(() => {
+      expect(input.value).toContain('👍');
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(input);
+    });
+  });
+});

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -3,6 +3,14 @@ import { configure } from '@testing-library/react';
 import { beforeAll, afterEach, afterAll } from 'vitest';
 import { server } from './msw/server';
 
+// Note: axe-core a11y assertions use `expectNoAxeViolations()` from
+// `../test-utils/a11y`, not a `toHaveNoViolations` custom matcher.
+// vitest-axe@0.1.0's `toHaveNoViolations` is broken for this project's
+// vitest/TS versions two different ways (its `extend-expect` entrypoint
+// ships an empty dist file, and its `matchers` entrypoint re-exports the
+// function `export type`-only, so it can't be used as a value) — see
+// test-utils/a11y.ts for the full explanation.
+
 // RTL's default findBy*/waitFor timeout (1000ms) assumes a lightly-loaded
 // machine. Under v8 coverage instrumentation + constrained CI parallelism,
 // real timers (debounce, MSW round-trips) can occasionally take longer to

--- a/frontend/src/__tests__/test-utils/a11y.ts
+++ b/frontend/src/__tests__/test-utils/a11y.ts
@@ -1,0 +1,59 @@
+import { axe } from 'vitest-axe';
+import type { AxeResults, Result, RunOptions } from 'axe-core';
+import { expect } from 'vitest';
+
+/**
+ * axe-core wrapper for component-level a11y assertions.
+ *
+ * Two rules are disabled, both because these are component/fragment unit
+ * tests, not full-page checks:
+ * - `color-contrast`: jsdom performs no real layout/paint, so axe can't
+ *   compute an accurate contrast ratio there — any result would be noise
+ *   unrelated to the markup/ARIA semantics these tests actually care about.
+ *   Real contrast is out of scope for unit tests; it belongs in a
+ *   browser-based visual/e2e check if ever needed.
+ * - `region`: fires when scanning `document.body` (needed for components
+ *   that render via a portal, e.g. MUI Popover/Menu, since portaled content
+ *   lands outside RTL's `container`) and flags that the rendered fragment
+ *   isn't wrapped in a page landmark (header/nav/main) — true, but a
+ *   property of the (nonexistent, in a unit test) surrounding page chrome,
+ *   not of the component under test.
+ */
+export async function runAxe(
+  container: Element,
+  options?: RunOptions,
+): Promise<AxeResults> {
+  return axe(container, {
+    rules: {
+      'color-contrast': { enabled: false },
+      region: { enabled: false },
+    },
+    ...options,
+  });
+}
+
+function formatViolation(violation: Result): string {
+  const targets = violation.nodes.map((node) => node.target.join(' ')).join(', ');
+  return `${violation.id} (${violation.impact ?? 'unknown impact'}): ${violation.help}\n  targets: ${targets}\n  ${violation.helpUrl}`;
+}
+
+/**
+ * Asserts an axe run found zero violations, with a readable failure message.
+ *
+ * We don't use vitest-axe's own `toHaveNoViolations` matcher: that package
+ * (last published for vitest 0.x) is broken two different ways against this
+ * project's vitest/TypeScript versions — its `vitest-axe/extend-expect`
+ * entrypoint ships an empty `dist/extend-expect.js` (registers nothing at
+ * runtime), and its `vitest-axe/matchers` entrypoint's .d.ts re-exports the
+ * function via `export type *`, so TypeScript refuses to let it be used as a
+ * value (`cannot be used as a value because it was exported using 'export
+ * type'`). A plain assertion function sidesteps both issues.
+ */
+export function expectNoAxeViolations(results: AxeResults): void {
+  if (results.violations.length === 0) return;
+  const message = [
+    `Expected no axe violations, found ${results.violations.length}:`,
+    ...results.violations.map(formatViolation),
+  ].join('\n\n');
+  expect.fail(message);
+}

--- a/frontend/src/__tests__/test-utils/index.ts
+++ b/frontend/src/__tests__/test-utils/index.ts
@@ -21,3 +21,4 @@ export { createMockSocket } from './mockSocket';
 export type { MockSocket } from './mockSocket';
 export { createTestWrapper } from './wrappers';
 export { renderWithProviders } from './renderWithProviders';
+export { runAxe, expectNoAxeViolations } from './a11y';

--- a/frontend/src/components/Channel/ChannelNotificationMenu.tsx
+++ b/frontend/src/components/Channel/ChannelNotificationMenu.tsx
@@ -137,6 +137,9 @@ export const ChannelNotificationMenu: React.FC<ChannelNotificationMenuProps> = (
           onClick={handleClick}
           size="small"
           disabled={overrideLoading || isLoading}
+          aria-label={getTooltipText()}
+          aria-haspopup="menu"
+          aria-expanded={open}
         >
           {overrideLoading ? <CircularProgress size={20} /> : getIcon()}
         </IconButton>

--- a/frontend/src/components/Message/EmojiPicker.tsx
+++ b/frontend/src/components/Message/EmojiPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import { IconButton, Popover, Box, Typography, TextField, InputAdornment } from '@mui/material';
 import { AddReaction as AddReactionIcon, Search as SearchIcon, Clear as ClearIcon } from '@mui/icons-material';
 import { useResponsive } from '../../hooks/useResponsive';
@@ -6,6 +6,15 @@ import { MobileSheet } from '../Mobile/common/MobileSheet';
 import { useCommunityCustomEmojis } from '../../hooks/useCommunityCustomEmojis';
 import type { CustomEmojiDto } from '../../api-client/types.gen';
 import { getFileUrl } from '../../utils/fileHelpers';
+import {
+  computeNextEmojiGridPosition,
+  isEmojiGridNavKey,
+  type EmojiGridPosition,
+  type EmojiGridSection,
+} from '../../utils/emojiGridNavigation';
+
+/** Section key for the "Custom" emoji group in the roving-tabindex grid. */
+const CUSTOM_SECTION_KEY = '__custom__';
 
 // Emoji names for search functionality
 export const EMOJI_NAMES: Record<string, string[]> = {
@@ -201,6 +210,75 @@ const EmojiPickerContent: React.FC<{
     Object.keys(filteredCategories).length > 0 ||
     filteredCustomEmojis.length > 0;
 
+  // --- Roving-tabindex grid navigation ---
+  // The grid isn't a single native <table>/CSS-grid-with-role — categories
+  // are independent fixed-column (8) CSS grids stacked in one scrollable
+  // region, with no tab strip to jump between them (see file doc comment).
+  // We model that as an ordered list of "sections" (custom emojis, then each
+  // category) and let `computeNextEmojiGridPosition` do the row/column math;
+  // only one cell is in the tab order (tabIndex 0) at a time, and arrow keys
+  // move both the logical position and real DOM focus together.
+  const gridSections: EmojiGridSection[] = useMemo(() => {
+    const sections: EmojiGridSection[] = [];
+    if (filteredCustomEmojis.length > 0) {
+      sections.push({ key: CUSTOM_SECTION_KEY, count: filteredCustomEmojis.length });
+    }
+    Object.entries(filteredCategories).forEach(([name, emojis]) => {
+      sections.push({ key: name, count: emojis.length });
+    });
+    return sections;
+  }, [filteredCustomEmojis.length, filteredCategories]);
+
+  const [activeCell, setActiveCell] = useState<EmojiGridPosition>(() => ({
+    section: gridSections[0]?.key ?? '',
+    index: 0,
+  }));
+
+  // Keep the active cell valid as the result set changes (typing a search
+  // query can shrink/reorder sections out from under the current position).
+  useEffect(() => {
+    setActiveCell((prev) => {
+      const stillValid = gridSections.find((s) => s.key === prev.section);
+      if (stillValid && prev.index < stillValid.count) return prev;
+      return { section: gridSections[0]?.key ?? '', index: 0 };
+    });
+  }, [gridSections]);
+
+  const cellRefs = useRef<Record<string, (HTMLButtonElement | null)[]>>({});
+  const setCellRef = useCallback(
+    (sectionKey: string, index: number) => (el: HTMLButtonElement | null) => {
+      const arr = (cellRefs.current[sectionKey] ??= []);
+      arr[index] = el;
+    },
+    [],
+  );
+
+  const isActiveCell = useCallback(
+    (sectionKey: string, index: number) =>
+      activeCell.section === sectionKey && activeCell.index === index,
+    [activeCell],
+  );
+
+  const handleCellFocus = useCallback(
+    (sectionKey: string, index: number) => () => {
+      setActiveCell({ section: sectionKey, index });
+    },
+    [],
+  );
+
+  const handleGridKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (!isEmojiGridNavKey(event.key) || gridSections.length === 0) return;
+      event.preventDefault();
+      const next = computeNextEmojiGridPosition(event.key, activeCell, gridSections);
+      if (next.section !== activeCell.section || next.index !== activeCell.index) {
+        setActiveCell(next);
+        cellRefs.current[next.section]?.[next.index]?.focus();
+      }
+    },
+    [activeCell, gridSections],
+  );
+
   return (
     <Box sx={{
       width: touch ? '100%' : '300px',
@@ -223,6 +301,11 @@ const EmojiPickerContent: React.FC<{
           placeholder="Search emojis..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
+          // Intentional: this is the first focusable control inside a
+          // just-opened popover/sheet (not the page), matching the WAI-ARIA
+          // pattern of moving focus into a newly-opened dialog/menu and
+          // satisfying "search field first in tab order".
+          // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus
           fullWidth
           sx={{
@@ -268,6 +351,9 @@ const EmojiPickerContent: React.FC<{
 
       {/* Scrollable Content */}
       <Box
+        role="group"
+        aria-label="Emojis"
+        onKeyDown={handleGridKeyDown}
         sx={{
           flex: 1,
           overflowY: 'auto',
@@ -291,7 +377,7 @@ const EmojiPickerContent: React.FC<{
         }}
       >
         {filteredCustomEmojis.length > 0 && (
-          <Box sx={{ mb: 1.5 }}>
+          <Box role="group" aria-label="Custom" sx={{ mb: 1.5 }}>
             <Typography
               variant="caption"
               sx={{
@@ -314,9 +400,12 @@ const EmojiPickerContent: React.FC<{
                 width: '100%',
               }}
             >
-              {filteredCustomEmojis.map((emoji) => (
+              {filteredCustomEmojis.map((emoji, cellIndex) => (
                 <IconButton
                   key={emoji.id}
+                  ref={setCellRef(CUSTOM_SECTION_KEY, cellIndex)}
+                  tabIndex={isActiveCell(CUSTOM_SECTION_KEY, cellIndex) ? 0 : -1}
+                  onFocus={handleCellFocus(CUSTOM_SECTION_KEY, cellIndex)}
                   size="small"
                   title={`:${emoji.name}:`}
                   aria-label={`:${emoji.name}:`}
@@ -351,7 +440,7 @@ const EmojiPickerContent: React.FC<{
         )}
         {hasResults ? (
           Object.entries(filteredCategories).map(([categoryName, emojis], index) => (
-            <Box key={categoryName} sx={{ mb: 1.5 }}>
+            <Box key={categoryName} role="group" aria-label={categoryName} sx={{ mb: 1.5 }}>
               {/* Category Header */}
               <Typography
                 variant="caption"
@@ -378,10 +467,14 @@ const EmojiPickerContent: React.FC<{
                   width: '100%',
                 }}
               >
-                {emojis.map((emoji) => (
+                {emojis.map((emoji, cellIndex) => (
                   <IconButton
                     key={`${categoryName}-${emoji}`}
+                    ref={setCellRef(categoryName, cellIndex)}
+                    tabIndex={isActiveCell(categoryName, cellIndex) ? 0 : -1}
+                    onFocus={handleCellFocus(categoryName, cellIndex)}
                     size="small"
+                    aria-label={EMOJI_NAMES[emoji]?.[0] ?? emoji}
                     onClick={() => onEmojiClick(emoji)}
                     sx={{
                       fontSize: touch ? '24px' : '16px',
@@ -578,7 +671,13 @@ export const EmojiPicker: React.FC<EmojiPickerProps> = ({
 
   return (
     <>
-      <IconButton size="small" onClick={handleClick}>
+      <IconButton
+        size="small"
+        onClick={handleClick}
+        aria-label="Add reaction"
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
         <AddReactionIcon fontSize="small" />
       </IconButton>
       <Popover

--- a/frontend/src/components/Message/MemberList.tsx
+++ b/frontend/src/components/Message/MemberList.tsx
@@ -17,6 +17,7 @@ import { UserModerationMenu } from "../Moderation";
 import { useUserProfile } from "../../contexts/UserProfileContext";
 import { useResponsive } from "../../hooks/useResponsive";
 import { useLongPress } from "../../hooks/useSwipeGesture";
+import { useContextMenuFocusRestore } from "../../hooks/useContextMenuFocusRestore";
 
 export interface MemberData {
   id: string;
@@ -88,14 +89,15 @@ const SectionHeader: React.FC<{ label: string; count: number }> = ({ label, coun
 const MemberRow: React.FC<{
   member: MemberData;
   onOpenProfile: (userId: string) => void;
-  onOpenMenu: (position: { top: number; left: number }, member: MemberData) => void;
+  onOpenMenu: (position: { top: number; left: number }, member: MemberData, triggerEl: HTMLElement | null) => void;
 }> = React.memo(function MemberRow({ member, onOpenProfile, onOpenMenu }) {
   const theme = useTheme();
   const { shouldUseTouchUI } = useResponsive();
+  const rowRef = React.useRef<HTMLDivElement>(null);
 
   const longPress = useLongPress(
     (point) => {
-      if (point) onOpenMenu({ top: point.y, left: point.x }, member);
+      if (point) onOpenMenu({ top: point.y, left: point.x }, member, rowRef.current);
     },
     { enabled: shouldUseTouchUI },
   );
@@ -111,12 +113,13 @@ const MemberRow: React.FC<{
     : {
         onContextMenu: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
-          onOpenMenu({ top: e.clientY, left: e.clientX }, member);
+          onOpenMenu({ top: e.clientY, left: e.clientX }, member, e.currentTarget);
         },
       };
 
   return (
     <ListItemButton
+      ref={rowRef}
       onClick={() => {
         // Ignore the ghost click some browsers (iOS) fire after a long-press —
         // otherwise the profile opens on top of the moderation menu.
@@ -193,16 +196,21 @@ const MemberList: React.FC<MemberListProps> = ({
     position: null,
     member: null,
   });
+  const { captureTrigger, restoreFocus } = useContextMenuFocusRestore();
 
   const openMenu = React.useCallback(
-    (position: { top: number; left: number }, member: MemberData) => {
+    (position: { top: number; left: number }, member: MemberData, triggerEl: HTMLElement | null) => {
+      captureTrigger(triggerEl);
       setContextMenu({ position, member });
     },
-    [],
+    [captureTrigger],
   );
 
   const handleCloseContextMenu = () => {
     setContextMenu({ position: null, member: null });
+    // anchorPosition menus have no anchor element for MUI to auto-restore
+    // focus to on close — return it to the member row that opened this.
+    restoreFocus();
   };
 
   // Group members by display role

--- a/frontend/src/components/Message/MemberList.tsx
+++ b/frontend/src/components/Message/MemberList.tsx
@@ -197,6 +197,11 @@ const MemberList: React.FC<MemberListProps> = ({
     member: null,
   });
   const { captureTrigger, restoreFocus } = useContextMenuFocusRestore();
+  // Fallback restore target: the member row that opened the menu can
+  // unmount while the menu is closing (e.g. the member goes offline and is
+  // re-sorted/removed from view). The scroll container outlives any
+  // individual row, so it's a safe place to land focus in that case.
+  const listContainerRef = React.useRef<HTMLDivElement>(null);
 
   const openMenu = React.useCallback(
     (position: { top: number; left: number }, member: MemberData, triggerEl: HTMLElement | null) => {
@@ -209,8 +214,10 @@ const MemberList: React.FC<MemberListProps> = ({
   const handleCloseContextMenu = () => {
     setContextMenu({ position: null, member: null });
     // anchorPosition menus have no anchor element for MUI to auto-restore
-    // focus to on close — return it to the member row that opened this.
-    restoreFocus();
+    // focus to on close — return it to the member row that opened this,
+    // falling back to the scroll container if that row unmounted while
+    // the menu was closing.
+    restoreFocus(listContainerRef.current);
   };
 
   // Group members by display role
@@ -310,6 +317,8 @@ const MemberList: React.FC<MemberListProps> = ({
 
       {/* Member List */}
       <Box
+        ref={listContainerRef}
+        tabIndex={-1}
         sx={{
           flex: 1,
           overflowY: "auto",

--- a/frontend/src/components/Message/MentionDropdown.tsx
+++ b/frontend/src/components/Message/MentionDropdown.tsx
@@ -19,6 +19,7 @@ import {
 } from '@mui/icons-material';
 import { MentionSuggestion } from '../../hooks/useMentionAutocomplete';
 import UserAvatar from '../Common/UserAvatar';
+import { MENTION_LISTBOX_ID, mentionOptionId } from './mentionDropdownIds';
 
 const DropdownPaper = styled(Paper)(({ theme }) => ({
   position: 'absolute',
@@ -69,6 +70,7 @@ export const MentionDropdown: React.FC<MentionDropdownProps> = ({
     return (
       <DropdownPaper
         elevation={8}
+        role="status"
         sx={{
           ...position,
           p: 3,
@@ -134,6 +136,9 @@ export const MentionDropdown: React.FC<MentionDropdownProps> = ({
 
       {/* Suggestions List */}
       <List
+        id={MENTION_LISTBOX_ID}
+        role="listbox"
+        aria-label="Mention suggestions"
         sx={{
           p: 0.5,
           flex: 1,
@@ -155,6 +160,9 @@ export const MentionDropdown: React.FC<MentionDropdownProps> = ({
         {suggestions.map((suggestion, index) => (
           <ListItem
             key={suggestion.id}
+            id={mentionOptionId(index)}
+            role="option"
+            aria-selected={index === selectedIndex}
             onClick={() => onSelectSuggestion(index)}
             sx={{
               borderRadius: 2,

--- a/frontend/src/components/Message/MessageComponent.tsx
+++ b/frontend/src/components/Message/MessageComponent.tsx
@@ -35,6 +35,7 @@ import { EmojiPickerPopover } from "./EmojiPicker";
 import { useResponsive } from "../../hooks/useResponsive";
 import { useLongPress } from "../../hooks/useSwipeGesture";
 import { useCommunityCustomEmojis } from "../../hooks/useCommunityCustomEmojis";
+import { useContextMenuFocusRestore } from "../../hooks/useContextMenuFocusRestore";
 
 interface MessageProps {
   message: MessageType;
@@ -125,14 +126,21 @@ function MessageComponentInner({
   const [emojiPickerOpen, setEmojiPickerOpen] = useState(false);
   const [actionsSheetOpen, setActionsSheetOpen] = useState(false);
 
+  const { captureTrigger, restoreFocus } = useContextMenuFocusRestore();
+
   const handleContextMenu = useCallback((event: React.MouseEvent) => {
     event.preventDefault();
+    captureTrigger(event.currentTarget as HTMLElement);
     setContextMenuPosition({ top: event.clientY, left: event.clientX });
-  }, []);
+  }, [captureTrigger]);
 
   const handleCloseContextMenu = useCallback(() => {
     setContextMenuPosition(null);
-  }, []);
+    // Right-click (and long-press) open this menu with no keyboard-reachable
+    // invoker button, so — unlike an anchorEl Menu — MUI can't auto-restore
+    // focus. Return it to the message row itself.
+    restoreFocus();
+  }, [restoreFocus]);
 
   const handleAddReaction = useCallback(() => {
     // Save position for emoji picker, close context menu
@@ -157,7 +165,12 @@ function MessageComponentInner({
   const handleCloseEmojiPicker = useCallback(() => {
     setEmojiPickerPosition(null);
     setEmojiPickerOpen(false);
-  }, []);
+    // Reuses the same trigger captured on right-click: "Add Reaction" is
+    // reached via the context menu, so closing the emoji picker should
+    // return focus to the message row too (a no-op if it was opened via
+    // the touch sheet instead, since no trigger was captured for that path).
+    restoreFocus();
+  }, [restoreFocus]);
 
   // Under touch UI, wire long-press handlers and suppress native selection /
   // context menu; otherwise keep desktop right-click behavior untouched.
@@ -182,6 +195,9 @@ function MessageComponentInner({
       isDeleting={isDeleting}
       isHighlighted={isMentioned}
       isSearchHighlight={isSearchHighlight}
+      // Not in tab order (-1) — only focused programmatically, to restore
+      // focus here after the right-click/long-press context menu closes.
+      tabIndex={-1}
       {...containerInteractionProps}
     >
       <div style={{ marginRight: 12, marginTop: 4 }}>

--- a/frontend/src/components/Message/MessageInput.tsx
+++ b/frontend/src/components/Message/MessageInput.tsx
@@ -20,6 +20,7 @@ import GifBoxOutlinedIcon from "@mui/icons-material/GifBoxOutlined";
 import { useResponsive } from "../../hooks/useResponsive";
 import { FilePreview } from "./FilePreview";
 import { MentionDropdown } from "./MentionDropdown";
+import { MENTION_LISTBOX_ID, mentionOptionId } from "./mentionDropdownIds";
 import { useFileAttachments } from "./useFileAttachments";
 import { useDropZone } from "./useDropZone";
 import { DropZoneOverlay } from "./DropZoneOverlay";
@@ -88,6 +89,7 @@ export default function MessageInput({
   // Emoji picker state + last-known selection (captured before the picker steals focus)
   const [emojiAnchorEl, setEmojiAnchorEl] = useState<HTMLElement | null>(null);
   const emojiPickerOpen = Boolean(emojiAnchorEl);
+  const emojiButtonRef = useRef<HTMLButtonElement>(null);
   const lastSelectionRef = useRef<{ start: number; end: number }>({
     start: 0,
     end: 0,
@@ -418,8 +420,22 @@ export default function MessageInput({
     setEmojiAnchorEl(event.currentTarget);
   };
 
-  const handleEmojiPickerClose = () => {
+  // The Popover's `disableRestoreFocus` (see EmojiPickerPopover) intentionally
+  // stops MUI from refocusing the emoji button on close, since selecting an
+  // emoji instead refocuses the composer input (see handleEmojiSelect).
+  // But that means closing WITHOUT selecting (Escape/backdrop click) leaves
+  // focus nowhere — restore it to the invoking button in that case only, so
+  // it doesn't race the post-select refocus of the input.
+  const handleEmojiPickerClose = (
+    _event?: unknown,
+    reason?: "backdropClick" | "escapeKeyDown",
+  ) => {
     setEmojiAnchorEl(null);
+    if (reason === "escapeKeyDown" || reason === "backdropClick") {
+      requestAnimationFrame(() => {
+        emojiButtonRef.current?.focus();
+      });
+    }
   };
 
   // --- GIF picker handlers ---
@@ -592,11 +608,33 @@ export default function MessageInput({
             autoComplete="off"
             multiline
             maxRows={4}
+            slotProps={{
+              // Note: no `role="combobox"` and no `aria-expanded` here — this
+              // field is `multiline` (renders a <textarea>), and ARIA 1.2's
+              // `aria-allowed-role`/`aria-allowed-attr` restrict both to
+              // <input> hosts (or contenteditable), not <textarea> — axe
+              // flags either as a violation on this element. `aria-autocomplete`
+              // on the textarea's native textbox role, plus
+              // aria-controls/aria-activedescendant (present only while the
+              // dropdown is actually open), still fully conveys the
+              // combobox-listbox relationship to assistive tech.
+              htmlInput: {
+                "aria-autocomplete": "list",
+                "aria-controls": mentionIsOpen ? MENTION_LISTBOX_ID : undefined,
+                "aria-activedescendant":
+                  mentionIsOpen && mentionSuggestions.length > 0
+                    ? mentionOptionId(mentionSelectedIndex)
+                    : undefined,
+              },
+            }}
           />
           <IconButton
+            ref={emojiButtonRef}
             onClick={handleEmojiButtonClick}
             disabled={sending}
             aria-label="add emoji"
+            aria-haspopup="true"
+            aria-expanded={emojiPickerOpen}
           >
             <EmojiEmotionsOutlinedIcon />
           </IconButton>
@@ -605,6 +643,8 @@ export default function MessageInput({
               onClick={handleGifButtonClick}
               disabled={sending}
               aria-label="add gif"
+              aria-haspopup="true"
+              aria-expanded={gifPickerOpen}
             >
               <GifBoxOutlinedIcon />
             </IconButton>

--- a/frontend/src/components/Message/MessageToolbar.tsx
+++ b/frontend/src/components/Message/MessageToolbar.tsx
@@ -98,10 +98,11 @@ export const MessageToolbar: React.FC<MessageToolbarProps> = ({
             size="small"
             onClick={onConfirmDelete}
             color="error"
+            aria-label="Confirm delete"
           >
             <CheckIcon fontSize="small" />
           </IconButton>
-          <IconButton size="small" onClick={onCancelDelete}>
+          <IconButton size="small" onClick={onCancelDelete} aria-label="Cancel delete">
             <CancelIcon fontSize="small" />
           </IconButton>
         </>
@@ -114,14 +115,14 @@ export const MessageToolbar: React.FC<MessageToolbarProps> = ({
           />
           {onQuoteReply && (
             <Tooltip title="Quote reply">
-              <IconButton size="small" onClick={onQuoteReply}>
+              <IconButton size="small" onClick={onQuoteReply} aria-label="Quote reply">
                 <FormatQuoteIcon fontSize="small" />
               </IconButton>
             </Tooltip>
           )}
           {canThread && (
             <Tooltip title="Reply in thread">
-              <IconButton size="small" onClick={onReplyInThread}>
+              <IconButton size="small" onClick={onReplyInThread} aria-label="Reply in thread">
                 <ChatBubbleOutlineIcon fontSize="small" />
               </IconButton>
             </Tooltip>
@@ -132,13 +133,14 @@ export const MessageToolbar: React.FC<MessageToolbarProps> = ({
                 size="small"
                 onClick={isPinned ? onUnpin : onPin}
                 sx={{ color: isPinned ? "primary.main" : undefined }}
+                aria-label={isPinned ? "Unpin message" : "Pin message"}
               >
                 {isPinned ? <PushPinIcon fontSize="small" /> : <PushPinOutlinedIcon fontSize="small" />}
               </IconButton>
             </Tooltip>
           )}
           {canEdit && (
-            <IconButton size="small" onClick={onEdit}>
+            <IconButton size="small" onClick={onEdit} aria-label="Edit message">
               <EditIcon fontSize="small" />
             </IconButton>
           )}
@@ -147,6 +149,7 @@ export const MessageToolbar: React.FC<MessageToolbarProps> = ({
               size="small"
               onClick={onDelete}
               color="error"
+              aria-label="Delete message"
             >
               <DeleteIcon fontSize="small" />
             </IconButton>

--- a/frontend/src/components/Message/mentionDropdownIds.ts
+++ b/frontend/src/components/Message/mentionDropdownIds.ts
@@ -1,0 +1,15 @@
+/**
+ * DOM ids shared between MentionDropdown (the `role="listbox"`/`role="option"`
+ * markup) and MessageInput (the `role="combobox"` input's `aria-controls`/
+ * `aria-activedescendant`) — kept in their own module, rather than exported
+ * from MentionDropdown.tsx alongside the component, so the component file
+ * stays a fast-refresh-friendly single-export module.
+ */
+
+/** Stable id for the listbox — referenced by the input's `aria-controls`. */
+export const MENTION_LISTBOX_ID = 'mention-suggestions-listbox';
+
+/** Stable id for a given suggestion row — referenced by `aria-activedescendant`. */
+export function mentionOptionId(index: number): string {
+  return `mention-suggestion-option-${index}`;
+}

--- a/frontend/src/components/Message/mentionDropdownIds.ts
+++ b/frontend/src/components/Message/mentionDropdownIds.ts
@@ -1,9 +1,11 @@
 /**
  * DOM ids shared between MentionDropdown (the `role="listbox"`/`role="option"`
- * markup) and MessageInput (the `role="combobox"` input's `aria-controls`/
- * `aria-activedescendant`) — kept in their own module, rather than exported
- * from MentionDropdown.tsx alongside the component, so the component file
- * stays a fast-refresh-friendly single-export module.
+ * markup) and MessageInput (the textarea's `aria-controls`/
+ * `aria-activedescendant`; the textarea deliberately does NOT get
+ * `role="combobox"` — ARIA 1.2 disallows it on a multiline textbox host, see
+ * the note in MessageInput.tsx) — kept in their own module, rather than
+ * exported from MentionDropdown.tsx alongside the component, so the component
+ * file stays a fast-refresh-friendly single-export module.
  */
 
 /** Stable id for the listbox — referenced by the input's `aria-controls`. */

--- a/frontend/src/components/NavBar/ProfileIcon.tsx
+++ b/frontend/src/components/NavBar/ProfileIcon.tsx
@@ -37,7 +37,14 @@ const ProfileIcon: React.FC<ProfileIconProps> = ({
   return (
     <>
       <Tooltip title="Open settings">
-        <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
+        <IconButton
+          onClick={handleOpenUserMenu}
+          sx={{ p: 0 }}
+          aria-label="Open settings"
+          aria-haspopup="menu"
+          aria-controls={anchorElUser ? "menu-appbar" : undefined}
+          aria-expanded={Boolean(anchorElUser)}
+        >
           <UserAvatar userId={userData?.id} size="medium" />
         </IconButton>
       </Tooltip>

--- a/frontend/src/components/Thread/ThreadMessageInput.tsx
+++ b/frontend/src/components/Thread/ThreadMessageInput.tsx
@@ -51,6 +51,7 @@ export const ThreadMessageInput: React.FC<ThreadMessageInputProps> = ({
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const [emojiAnchorEl, setEmojiAnchorEl] = useState<HTMLElement | null>(null);
   const emojiPickerOpen = Boolean(emojiAnchorEl);
+  const emojiButtonRef = useRef<HTMLButtonElement>(null);
   const lastSelectionRef = useRef<{ start: number; end: number }>({
     start: 0,
     end: 0,
@@ -72,8 +73,22 @@ export const ThreadMessageInput: React.FC<ThreadMessageInputProps> = ({
     setEmojiAnchorEl(event.currentTarget);
   };
 
-  const handleEmojiPickerClose = () => {
+  // The Popover's `disableRestoreFocus` (see EmojiPickerPopover) intentionally
+  // stops MUI from refocusing the emoji button on close, since selecting an
+  // emoji instead refocuses the composer input (see handleEmojiSelect).
+  // But that means closing WITHOUT selecting (Escape/backdrop click) leaves
+  // focus nowhere — restore it to the invoking button in that case only, so
+  // it doesn't race the post-select refocus of the input.
+  const handleEmojiPickerClose = (
+    _event?: unknown,
+    reason?: "backdropClick" | "escapeKeyDown",
+  ) => {
     setEmojiAnchorEl(null);
+    if (reason === "escapeKeyDown" || reason === "backdropClick") {
+      requestAnimationFrame(() => {
+        emojiButtonRef.current?.focus();
+      });
+    }
   };
 
   const handleEmojiSelect = useCallback(
@@ -205,9 +220,12 @@ export const ThreadMessageInput: React.FC<ThreadMessageInputProps> = ({
           }}
         />
         <IconButton
+          ref={emojiButtonRef}
           onClick={handleEmojiButtonClick}
           disabled={isSending}
           aria-label="add emoji"
+          aria-haspopup="true"
+          aria-expanded={emojiPickerOpen}
           sx={{
             width: 40,
             height: 40,

--- a/frontend/src/components/Voice/VoiceChannelUserList.tsx
+++ b/frontend/src/components/Voice/VoiceChannelUserList.tsx
@@ -52,6 +52,11 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
   }>({ position: null, user: null });
 
   const { captureTrigger, restoreFocus } = useContextMenuFocusRestore();
+  // Fallback restore target: this list is presence-driven, so the row that
+  // opened the menu can unmount while the menu is closing (e.g. the
+  // participant disconnects). The list/row container outlives any
+  // individual row, so it's a safe place to land focus in that case.
+  const listContainerRef = useRef<HTMLDivElement>(null);
 
   const handleContextMenu = (event: React.MouseEvent<HTMLElement>, user: VoicePresenceUserDto) => {
     event.preventDefault();
@@ -62,8 +67,10 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
   const handleCloseContextMenu = () => {
     setContextMenu({ position: null, user: null });
     // anchorPosition menus have no anchor element for MUI to auto-restore
-    // focus to on close — return it to the user row that opened this.
-    restoreFocus();
+    // focus to on close — return it to the user row that opened this,
+    // falling back to the list container if that row unmounted while the
+    // menu was closing (e.g. the participant disconnected).
+    restoreFocus(listContainerRef.current);
   };
 
   // Check if we're connected to this specific channel
@@ -290,6 +297,8 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
     return (
       <>
         <Box
+          ref={listContainerRef}
+          tabIndex={-1}
           sx={{
             display: "flex",
             alignItems: "center",
@@ -321,7 +330,7 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
   if (showCompact) {
     return (
       <>
-        <Box>
+        <Box ref={listContainerRef} tabIndex={-1}>
           {presence.users.map((user) => (
             <CompactUserItem
               key={user.id}
@@ -349,6 +358,8 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
   return (
     <>
       <Paper
+        ref={listContainerRef}
+        tabIndex={-1}
         elevation={2}
         sx={{
           maxHeight: 300,

--- a/frontend/src/components/Voice/VoiceChannelUserList.tsx
+++ b/frontend/src/components/Voice/VoiceChannelUserList.tsx
@@ -22,6 +22,7 @@ import { ServerEvents } from "@semaphore-chat/shared";
 import { useSpeaking } from "../../hooks/useSpeaking";
 import { useVoice } from "../../contexts/VoiceContext";
 import { useTrackSubscriptionActions } from "../../hooks/useTrackSubscription";
+import { useContextMenuFocusRestore } from "../../hooks/useContextMenuFocusRestore";
 import CompactUserItem from "./components/CompactUserItem";
 import UserItem from "./components/UserItem";
 import InlineUserAvatar from "./components/InlineUserAvatar";
@@ -50,13 +51,19 @@ export const VoiceChannelUserList: React.FC<VoiceChannelUserListProps> = ({
     user: VoicePresenceUserDto | null;
   }>({ position: null, user: null });
 
+  const { captureTrigger, restoreFocus } = useContextMenuFocusRestore();
+
   const handleContextMenu = (event: React.MouseEvent<HTMLElement>, user: VoicePresenceUserDto) => {
     event.preventDefault();
+    captureTrigger(event.currentTarget);
     setContextMenu({ position: { top: event.clientY, left: event.clientX }, user });
   };
 
   const handleCloseContextMenu = () => {
     setContextMenu({ position: null, user: null });
+    // anchorPosition menus have no anchor element for MUI to auto-restore
+    // focus to on close — return it to the user row that opened this.
+    restoreFocus();
   };
 
   // Check if we're connected to this specific channel

--- a/frontend/src/components/Voice/components/CompactUserItem.tsx
+++ b/frontend/src/components/Voice/components/CompactUserItem.tsx
@@ -93,6 +93,9 @@ const CompactUserItem: React.FC<CompactUserItemProps> = React.memo(({
 
   return (
     <ListItem
+      // Not in tab order (-1) — only focused programmatically, to restore
+      // focus here after the right-click/long-press context menu closes.
+      tabIndex={-1}
       sx={{
         px: 1,
         py: 0.5,

--- a/frontend/src/components/Voice/components/InlineUserAvatar.tsx
+++ b/frontend/src/components/Voice/components/InlineUserAvatar.tsx
@@ -49,6 +49,9 @@ const InlineUserAvatar: React.FC<InlineUserAvatarProps> = ({
   return (
     <Tooltip key={user.id} title={user.displayName || user.username}>
       <Box
+        // Not in tab order (-1) — only focused programmatically, to restore
+        // focus here after the right-click/long-press context menu closes.
+        tabIndex={-1}
         sx={{
           width: 24,
           height: 24,

--- a/frontend/src/components/Voice/components/UserItem.tsx
+++ b/frontend/src/components/Voice/components/UserItem.tsx
@@ -84,6 +84,9 @@ const UserItem: React.FC<UserItemProps> = React.memo(({
   return (
     <React.Fragment key={user.id}>
       <ListItem
+        // Not in tab order (-1) — only focused programmatically, to restore
+        // focus here after the right-click/long-press context menu closes.
+        tabIndex={-1}
         sx={{
           px: showInline ? 1 : 2,
           py: 1,

--- a/frontend/src/hooks/useContextMenuFocusRestore.ts
+++ b/frontend/src/hooks/useContextMenuFocusRestore.ts
@@ -1,0 +1,48 @@
+import { useCallback, useRef } from 'react';
+
+/**
+ * WAI-ARIA menu-button pattern for context menus opened via right-click or
+ * long-press (`anchorPosition`-based MUI `Menu`/`Popover`s).
+ *
+ * Unlike anchorEl-based menus, MUI does not automatically know which
+ * element "invoked" an anchorPosition menu (there is no anchor element to
+ * return focus to), so focus is silently dropped when the menu closes.
+ * This hook lets the opener capture the triggering element and restore
+ * focus to it once the menu has finished closing.
+ *
+ * Usage:
+ *   const { captureTrigger, restoreFocus } = useContextMenuFocusRestore();
+ *   const handleContextMenu = (e) => {
+ *     e.preventDefault();
+ *     captureTrigger(e.currentTarget);
+ *     setPosition({ top: e.clientY, left: e.clientX });
+ *   };
+ *   const handleClose = () => {
+ *     setPosition(null);
+ *     restoreFocus();
+ *   };
+ *
+ * The triggering element must be focusable (a natively focusable element,
+ * or a plain element with `tabIndex={-1}`) for `restoreFocus` to have any
+ * effect.
+ */
+export function useContextMenuFocusRestore() {
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  const captureTrigger = useCallback((target: HTMLElement | null) => {
+    triggerRef.current = target;
+  }, []);
+
+  const restoreFocus = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    // Deferred a frame: the menu's exit transition / focus-trap teardown
+    // needs to finish first, otherwise MUI's Modal can steal focus back
+    // (or focus a mid-transition node that's about to unmount).
+    requestAnimationFrame(() => {
+      el.focus();
+    });
+  }, []);
+
+  return { captureTrigger, restoreFocus };
+}

--- a/frontend/src/hooks/useContextMenuFocusRestore.ts
+++ b/frontend/src/hooks/useContextMenuFocusRestore.ts
@@ -19,12 +19,16 @@ import { useCallback, useRef } from 'react';
  *   };
  *   const handleClose = () => {
  *     setPosition(null);
- *     restoreFocus();
+ *     // Pass a fallback (e.g. the list's scroll container) for
+ *     // presence-driven lists, where the triggering row can unmount
+ *     // (e.g. a voice participant disconnects) while the menu is still
+ *     // closing — see the `restoreFocus` fallback param below.
+ *     restoreFocus(listContainerRef.current);
  *   };
  *
  * The triggering element must be focusable (a natively focusable element,
  * or a plain element with `tabIndex={-1}`) for `restoreFocus` to have any
- * effect.
+ * effect. The same applies to the optional fallback element.
  */
 export function useContextMenuFocusRestore() {
   const triggerRef = useRef<HTMLElement | null>(null);
@@ -33,14 +37,28 @@ export function useContextMenuFocusRestore() {
     triggerRef.current = target;
   }, []);
 
-  const restoreFocus = useCallback(() => {
+  /**
+   * Restores focus to the captured trigger, deferred a frame so the menu's
+   * exit transition / focus-trap teardown finishes first (otherwise MUI's
+   * Modal can steal focus back, or focus a mid-transition node that's about
+   * to unmount).
+   *
+   * In presence-driven lists (e.g. voice participants, online members) the
+   * triggering row can unmount *during* that deferred frame — for example a
+   * participant disconnects while their row's context menu is closing.
+   * Calling `.focus()` on an already-detached node is a silent no-op, and
+   * focus would otherwise drop to `<body>`. If a `fallback` element is
+   * given (e.g. the list's scroll container — something stable that
+   * outlives any individual row), it receives focus instead whenever the
+   * trigger is no longer connected to the document by the time the frame
+   * runs. Without a fallback, this case is a documented no-op.
+   */
+  const restoreFocus = useCallback((fallback?: HTMLElement | null) => {
     const el = triggerRef.current;
-    if (!el) return;
-    // Deferred a frame: the menu's exit transition / focus-trap teardown
-    // needs to finish first, otherwise MUI's Modal can steal focus back
-    // (or focus a mid-transition node that's about to unmount).
+    if (!el && !fallback) return;
     requestAnimationFrame(() => {
-      el.focus();
+      const target = el?.isConnected ? el : fallback;
+      target?.focus();
     });
   }, []);
 

--- a/frontend/src/utils/emojiGridNavigation.ts
+++ b/frontend/src/utils/emojiGridNavigation.ts
@@ -1,0 +1,118 @@
+/**
+ * Pure keyboard-navigation math for the emoji picker's roving-tabindex grid.
+ *
+ * The picker renders each category (plus an optional "Custom" section) as
+ * its own independent CSS grid of fixed-width columns, one after another in
+ * a single scrollable region — there's no `role="tablist"` category switcher
+ * to jump between (see EmojiPicker.tsx doc comment for why we didn't add
+ * one). This module treats that layout as an ordered list of fixed-column
+ * "sections" and computes where focus should land for each arrow/paging key,
+ * including moving between sections when navigation runs off the top/bottom/
+ * start/end of one.
+ *
+ * Kept dependency-free (no DOM, no React) so the navigation logic can be
+ * unit-tested directly.
+ */
+
+export const EMOJI_GRID_COLUMNS = 8;
+
+export interface EmojiGridSection {
+  /** Unique key for the section (category name, or the custom-emoji sentinel). */
+  key: string;
+  /** Number of cells (emojis) in this section. */
+  count: number;
+}
+
+export interface EmojiGridPosition {
+  section: string;
+  index: number;
+}
+
+export const EMOJI_GRID_NAV_KEYS = [
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'Home',
+  'End',
+  'PageUp',
+  'PageDown',
+] as const;
+
+export type EmojiGridNavKey = (typeof EMOJI_GRID_NAV_KEYS)[number];
+
+export function isEmojiGridNavKey(key: string): key is EmojiGridNavKey {
+  return (EMOJI_GRID_NAV_KEYS as readonly string[]).includes(key);
+}
+
+function clampToSection(section: EmojiGridSection, index: number): number {
+  return Math.max(0, Math.min(index, section.count - 1));
+}
+
+/**
+ * Computes the next roving-tabindex position for a grid navigation key.
+ * Returns `current` unchanged if the key has no effect (e.g. ArrowLeft at
+ * the very first cell of the very first section).
+ */
+export function computeNextEmojiGridPosition(
+  key: EmojiGridNavKey,
+  current: EmojiGridPosition,
+  sections: EmojiGridSection[],
+  columns: number = EMOJI_GRID_COLUMNS,
+): EmojiGridPosition {
+  const sectionIdx = sections.findIndex((s) => s.key === current.section);
+  if (sectionIdx === -1 || sections.length === 0) return current;
+
+  const section = sections[sectionIdx];
+  const { index } = current;
+
+  switch (key) {
+    case 'ArrowRight': {
+      if (index + 1 < section.count) return { section: section.key, index: index + 1 };
+      const next = sections[sectionIdx + 1];
+      return next ? { section: next.key, index: 0 } : current;
+    }
+    case 'ArrowLeft': {
+      if (index - 1 >= 0) return { section: section.key, index: index - 1 };
+      const prev = sections[sectionIdx - 1];
+      return prev ? { section: prev.key, index: prev.count - 1 } : current;
+    }
+    case 'ArrowDown': {
+      const target = index + columns;
+      if (target < section.count) return { section: section.key, index: target };
+      const next = sections[sectionIdx + 1];
+      if (!next) return current;
+      const col = index % columns;
+      return { section: next.key, index: clampToSection(next, col) };
+    }
+    case 'ArrowUp': {
+      const target = index - columns;
+      if (target >= 0) return { section: section.key, index: target };
+      const prev = sections[sectionIdx - 1];
+      if (!prev) return current;
+      const col = index % columns;
+      const lastRowStart = Math.floor((prev.count - 1) / columns) * columns;
+      return { section: prev.key, index: clampToSection(prev, lastRowStart + col) };
+    }
+    case 'Home': {
+      const rowStart = Math.floor(index / columns) * columns;
+      return { section: section.key, index: rowStart };
+    }
+    case 'End': {
+      const rowStart = Math.floor(index / columns) * columns;
+      const rowEnd = Math.min(rowStart + columns - 1, section.count - 1);
+      return { section: section.key, index: rowEnd };
+    }
+    case 'PageDown': {
+      const next = sections[sectionIdx + 1];
+      return next ? { section: next.key, index: 0 } : current;
+    }
+    case 'PageUp': {
+      const prev = sections[sectionIdx - 1];
+      if (prev) return { section: prev.key, index: 0 };
+      return index === 0 ? current : { section: section.key, index: 0 };
+    }
+    default:
+      return current;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,6 +375,9 @@ importers:
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.2
+        version: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.39.2(jiti@2.6.1))
@@ -417,6 +420,9 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.7.3))(terser@5.46.0)
+      vitest-axe:
+        specifier: ^0.1.0
+        version: 0.1.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.7.3))(terser@5.46.0))
       wait-on:
         specifier: ^8.0.3
         version: 8.0.5
@@ -3491,8 +3497,20 @@ packages:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
 
+  array-includes@3.1.9:
+    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
+    engines: {node: '>= 0.4'}
+
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
+
+  array.prototype.flat@1.3.3:
+    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flatmap@1.3.3:
+    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
+    engines: {node: '>= 0.4'}
 
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
@@ -3511,6 +3529,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-types-flow@0.0.8:
+    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
   ast-v8-to-istanbul@0.3.11:
     resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
@@ -3544,8 +3565,16 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
+
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -3840,6 +3869,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -4138,6 +4171,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -4459,6 +4495,10 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es-shim-unscopables@1.1.0:
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
+
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
@@ -4491,6 +4531,12 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
+
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
   eslint-plugin-prettier@5.5.5:
     resolution: {integrity: sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==}
@@ -5565,6 +5611,10 @@ packages:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
 
+  jsx-ast-utils@3.3.5:
+    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
+    engines: {node: '>=4.0'}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -5581,6 +5631,13 @@ packages:
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+
+  language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
+
+  language-tags@1.0.9:
+    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
+    engines: {node: '>=0.10'}
 
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
@@ -5627,6 +5684,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -6012,6 +6072,14 @@ packages:
 
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  object.fromentries@2.0.8:
+    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.values@1.2.1:
+    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
   obug@2.1.1:
@@ -6826,6 +6894,10 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
+
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
     engines: {node: '>= 0.4'}
@@ -7424,6 +7496,11 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest-axe@0.1.0:
+    resolution: {integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==}
+    peerDependencies:
+      vitest: '>=0.16.0'
 
   vitest@4.0.18:
     resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
@@ -11083,7 +11160,32 @@ snapshots:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
 
+  array-includes@3.1.9:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.1
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      is-string: 1.1.1
+      math-intrinsics: 1.1.0
+
   array-timsort@1.0.3: {}
+
+  array.prototype.flat@1.3.3:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.1
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flatmap@1.3.3:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.1
+      es-shim-unscopables: 1.1.0
 
   arraybuffer.prototype.slice@1.0.4:
     dependencies:
@@ -11108,6 +11210,8 @@ snapshots:
     optional: true
 
   assertion-error@2.0.1: {}
+
+  ast-types-flow@0.0.8: {}
 
   ast-v8-to-istanbul@0.3.11:
     dependencies:
@@ -11134,6 +11238,8 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
+  axe-core@4.12.1: {}
+
   axios@1.13.5:
     dependencies:
       follow-redirects: 1.15.11
@@ -11141,6 +11247,8 @@ snapshots:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+
+  axobject-query@4.1.0: {}
 
   b4a@1.8.0: {}
 
@@ -11529,6 +11637,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   char-regex@1.0.2: {}
 
   chardet@2.1.1: {}
@@ -11800,6 +11910,8 @@ snapshots:
       lru-cache: 11.2.6
 
   csstype@3.2.3: {}
+
+  damerau-levenshtein@1.0.8: {}
 
   data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -12203,6 +12315,10 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
+  es-shim-unscopables@1.1.0:
+    dependencies:
+      hasown: 2.0.4
+
   es-to-primitive@1.3.0:
     dependencies:
       is-callable: 1.2.7
@@ -12252,6 +12368,25 @@ snapshots:
   eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.12.1
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.39.2(jiti@2.6.1)
+      hasown: 2.0.4
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
 
   eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))(prettier@3.8.1):
     dependencies:
@@ -13646,6 +13781,13 @@ snapshots:
       ms: 2.1.3
       semver: 7.7.4
 
+  jsx-ast-utils@3.3.5:
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.flat: 1.3.3
+      object.assign: 4.1.7
+      object.values: 1.2.1
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -13664,6 +13806,12 @@ snapshots:
   kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
+
+  language-subtag-registry@0.3.23: {}
+
+  language-tags@1.0.9:
+    dependencies:
+      language-subtag-registry: 0.3.23
 
   lazy-val@1.0.5: {}
 
@@ -13714,6 +13862,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.debounce@4.0.8: {}
 
@@ -14023,6 +14173,20 @@ snapshots:
       es-object-atoms: 1.1.1
       has-symbols: 1.1.0
       object-keys: 1.1.1
+
+  object.fromentries@2.0.8:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.1
+      es-object-atoms: 1.1.1
+
+  object.values@1.2.1:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
 
   obug@2.1.1: {}
 
@@ -14935,6 +15099,12 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.2
 
+  string.prototype.includes@2.0.1:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.1
+
   string.prototype.matchall@4.0.12:
     dependencies:
       call-bind: 1.0.8
@@ -15513,6 +15683,16 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.46.0
+
+  vitest-axe@0.1.0(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.7.3))(terser@5.46.0)):
+    dependencies:
+      aria-query: 5.3.2
+      axe-core: 4.12.1
+      chalk: 5.6.2
+      dom-accessibility-api: 0.5.16
+      lodash-es: 4.18.1
+      redent: 3.0.0
+      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.7.3))(terser@5.46.0)
 
   vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.7.3))(terser@5.46.0):
     dependencies:


### PR DESCRIPTION
## Summary
- **Mention dropdown** now implements the WAI-ARIA combobox pattern: the input keeps focus while `aria-activedescendant` tracks the highlighted option (listbox/option roles, stable ids); Arrow/Enter/Tab/Escape flows preserved from the existing hook logic. (`role="combobox"`/`aria-expanded` deliberately omitted — ARIA 1.2 disallows them on a textarea host; documented in-code.)
- **Emoji picker** gets a roving-tabindex grid: arrow keys move cell focus, Home/End row bounds, PageUp/Down switch categories, Escape returns focus to the invoker; per-emoji aria-labels; search first in tab order. Navigation math extracted to a pure, unit-tested module.
- **Menu/invoker audit**: aria-labels + `aria-haspopup` across message toolbar/context/user-moderation menus (including the thread composer's emoji invoker, which shared the same code path); right-click/long-press (`anchorPosition`) menus now restore focus on close via a shared `useContextMenuFocusRestore` hook — with an `isConnected` check and container fallback so presence-driven lists (a member disconnects while their row's menu is open) don't drop focus to `<body>`.
- **Tooling**: `eslint-plugin-jsx-a11y` (recommended, warn-level — 41 pre-existing warnings flagged for a tracked burn-down) and axe zero-violation tests for all three surfaces' open states (hand-rolled helper; `vitest-axe`'s matcher entry point is broken — two packaging bugs verified — but its `axe()` wrapper over real axe-core is used directly).

## Scope note
The message-list keyboard-nav/aria-live leg of the a11y plan is a follow-up after #426 (single virtualized renderer) merges — specced in the work report, including the deleted-message focus-fallback case.

## Test plan
- 165 files / 1721 tests (+18 for this work), type-check clean, lint 0 errors; keyboard flows asserted via userEvent + real `document.activeElement` targets; the unmount-race case simulated with a real rerender-while-menu-open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sAJfCfBfMm8chbZMsh5Y5