### PR TITLE
feat(messages): optimistic message sending with pending/failed states

### DIFF
--- a/frontend/src/__tests__/components/MessageComponent.optimistic.test.tsx
+++ b/frontend/src/__tests__/components/MessageComponent.optimistic.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, act } from '@testing-library/react';
 import { renderWithProviders } from '../test-utils';
 import MessageComponent from '../../components/Message/MessageComponent';
 import { createMessage } from '../test-utils/factories';
@@ -118,6 +118,45 @@ describe('MessageComponent optimistic states (PR-13)', () => {
 
     await user.click(deleteButton);
     expect(mockRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn about setting state on an unmounted component when unmounted mid-retry (Minor 4, fix round 1)', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let resolveRetry: (() => void) | undefined;
+    mockRetry.mockImplementation(
+      () => new Promise<void>((resolve) => {
+        resolveRetry = resolve;
+      }),
+    );
+
+    const message = createMessage({
+      id: 'pending-3',
+      clientId: 'pending-3',
+      sendStatus: 'failed',
+      authorId: 'user-1',
+      spans: [{ type: SpanType.PLAINTEXT, text: 'oops' }],
+    });
+
+    const { user, unmount } = renderWithProviders(<MessageComponent message={message} isAuthor />);
+    const retryButton = screen.getByRole('button', { name: 'Retry sending message' });
+
+    await user.click(retryButton);
+    expect(mockRetry).toHaveBeenCalledTimes(1);
+
+    // Unmount while the retry promise is still pending, then resolve it —
+    // the finally-block's setIsRetrying(false) must be skipped (guarded by
+    // the mounted ref), not fire on an unmounted component.
+    unmount();
+    await act(async () => {
+      resolveRetry!();
+      await Promise.resolve();
+    });
+
+    const unmountedStateWarning = consoleError.mock.calls.some(call =>
+      String(call[0]).includes("Can't perform a React state update on an unmounted component"),
+    );
+    expect(unmountedStateWarning).toBe(false);
+    consoleError.mockRestore();
   });
 
   it('renders a settled (real) message with no pending/failed chrome', () => {

--- a/frontend/src/__tests__/components/MessageComponent.optimistic.test.tsx
+++ b/frontend/src/__tests__/components/MessageComponent.optimistic.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import MessageComponent from '../../components/Message/MessageComponent';
+import { createMessage } from '../test-utils/factories';
+import { SpanType } from '../../types/message.type';
+
+vi.mock('../../hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: { id: 'user-1', username: 'alice' } }),
+}));
+
+vi.mock('../../contexts/UserProfileContext', () => ({
+  useUserProfile: () => ({ openProfile: vi.fn() }),
+}));
+
+vi.mock('../../components/Common/UserAvatar', () => ({
+  default: () => <div data-testid="user-avatar" />,
+}));
+
+// Real (own-message) permissions — proves the pending/failed gating inside
+// MessageComponent is what suppresses the toolbar, not the permission hook.
+const mockPermissions = {
+  canEdit: true,
+  canDelete: true,
+  canPin: true,
+  canReact: true,
+  isOwnMessage: true,
+};
+vi.mock('../../hooks/useMessagePermissions', () => ({
+  useMessagePermissions: () => mockPermissions,
+}));
+
+const mockActions = {
+  isEditing: false,
+  editText: '',
+  editAttachments: [],
+  stagedForDelete: false,
+  isDeleting: false,
+  setEditText: vi.fn(),
+  handleEditClick: vi.fn(),
+  handleEditSave: vi.fn(),
+  handleEditCancel: vi.fn(),
+  handleRemoveAttachment: vi.fn(),
+  handleDeleteClick: vi.fn(),
+  handleConfirmDelete: vi.fn(),
+  handleCancelDelete: vi.fn(),
+  handleConfirmThreadDelete: vi.fn(),
+  handleCancelThreadDelete: vi.fn(),
+  showThreadDeleteConfirm: false,
+  handleReactionClick: vi.fn(),
+  handleEmojiSelect: vi.fn(),
+  handlePin: vi.fn(),
+  handleUnpin: vi.fn(),
+};
+vi.mock('../../components/Message/useMessageActions', () => ({
+  useMessageActions: () => mockActions,
+}));
+
+const mockRetry = vi.fn();
+const mockRemove = vi.fn();
+vi.mock('../../hooks/useOptimisticSendMessage', () => ({
+  useOptimisticMessageRetry: () => ({ retry: mockRetry, remove: mockRemove }),
+}));
+
+describe('MessageComponent optimistic states (PR-13)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a pending message with a clock indicator and no action toolbar', () => {
+    const message = createMessage({
+      id: 'pending-1',
+      clientId: 'pending-1',
+      sendStatus: 'pending',
+      authorId: 'user-1',
+      spans: [{ type: SpanType.PLAINTEXT, text: 'sending soon' }],
+    });
+
+    renderWithProviders(<MessageComponent message={message} isAuthor onQuoteReply={vi.fn()} onOpenThread={vi.fn()} />);
+
+    expect(screen.getByText('sending soon')).toBeInTheDocument();
+    expect(screen.getByTestId('message-pending-icon')).toBeInTheDocument();
+    // Real API-backed actions must be unreachable for an unpersisted message.
+    expect(screen.queryByLabelText('Edit message')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Delete message')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Quote reply')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Reply in thread')).not.toBeInTheDocument();
+    expect(screen.queryByText('Failed to send')).not.toBeInTheDocument();
+  });
+
+  it('renders a failed message with always-visible, keyboard-reachable Retry/Delete actions', async () => {
+    const message = createMessage({
+      id: 'pending-2',
+      clientId: 'pending-2',
+      sendStatus: 'failed',
+      authorId: 'user-1',
+      spans: [{ type: SpanType.PLAINTEXT, text: 'oops' }],
+    });
+
+    const { user } = renderWithProviders(<MessageComponent message={message} isAuthor />);
+
+    expect(screen.getByText('Failed to send')).toBeInTheDocument();
+    // No pending clock on a failed row.
+    expect(screen.queryByTestId('message-pending-icon')).not.toBeInTheDocument();
+
+    const retryButton = screen.getByRole('button', { name: 'Retry sending message' });
+    const deleteButton = screen.getByRole('button', { name: 'Delete message' });
+
+    // Real <button> elements rendered unconditionally (not opacity-gated
+    // behind hover like MessageToolbar) — always in the tab order.
+    expect(retryButton).toBeVisible();
+    expect(deleteButton).toBeVisible();
+    expect(retryButton.tabIndex).not.toBe(-1);
+    expect(deleteButton.tabIndex).not.toBe(-1);
+
+    await user.click(retryButton);
+    expect(mockRetry).toHaveBeenCalledTimes(1);
+
+    await user.click(deleteButton);
+    expect(mockRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a settled (real) message with no pending/failed chrome', () => {
+    const message = createMessage({
+      authorId: 'user-1',
+      spans: [{ type: SpanType.PLAINTEXT, text: 'a normal message' }],
+    });
+
+    renderWithProviders(<MessageComponent message={message} isAuthor />);
+
+    expect(screen.getByText('a normal message')).toBeInTheDocument();
+    expect(screen.queryByTestId('message-pending-icon')).not.toBeInTheDocument();
+    expect(screen.queryByText('Failed to send')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/VirtualMessageList.test.tsx
+++ b/frontend/src/__tests__/components/VirtualMessageList.test.tsx
@@ -110,6 +110,27 @@ describe('VirtualMessageList', () => {
     expect(document.querySelector('[data-message-id="msg-2"]')).toBeTruthy();
   });
 
+  it('keeps the same DOM node across an optimistic id swap when clientId is stable (no remount, PR-13 fix round 1 Minor 6)', () => {
+    const pending = createMessage({ id: 'pending-1', clientId: 'pending-1', sendStatus: 'pending' });
+    const { rerender } = render(
+      <VirtualMessageList {...baseProps} orderedMessages={[pending]} />,
+    );
+    const beforeNode = document.querySelector('[data-message-id="pending-1"]');
+    expect(beforeNode).toBeTruthy();
+
+    // Reconciliation swaps id -> the real server id but retains clientId
+    // (see messageCacheUpdaters.ts) so the row's React key (clientId ?? id)
+    // stays stable across the swap.
+    const settled = createMessage({ id: 'real-1', clientId: 'pending-1' });
+    rerender(<VirtualMessageList {...baseProps} orderedMessages={[settled]} />);
+
+    const afterNode = document.querySelector('[data-message-id="real-1"]');
+    expect(afterNode).toBeTruthy();
+    // Same DOM node — proves React reconciled in place rather than
+    // unmounting the old row and mounting a new one (which would blink).
+    expect(afterNode).toBe(beforeNode);
+  });
+
   it('places the unread divider before the first unread message', () => {
     // lastReadIndex 1 → divider before index 2 (msg-2)
     render(

--- a/frontend/src/__tests__/hooks/useMessageFileUpload.optimistic.test.ts
+++ b/frontend/src/__tests__/hooks/useMessageFileUpload.optimistic.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClientProvider, type InfiniteData } from '@tanstack/react-query';
+
+// Mock the generated client (same pattern as useSendMessage.test.ts)
+vi.mock('../../api-client/client.gen', () => ({
+  client: {
+    getConfig: () => ({ baseUrl: 'http://localhost:3000' }),
+  },
+}));
+
+import { useMessageFileUpload } from '../../hooks/useMessageFileUpload';
+import { VoiceSessionType } from '../../contexts/VoiceContext';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import { channelMessagesQueryKey } from '../../utils/messageQueryKeys';
+import { userControllerGetProfileQueryKey } from '../../api-client/@tanstack/react-query.gen';
+import type { PaginatedMessagesResponseDto } from '../../api-client';
+import {
+  createTestQueryClient,
+  createMockSocket,
+  createInfiniteData,
+} from '../test-utils';
+import type { MockSocket } from '../test-utils';
+import type { Message } from '../../types/message.type';
+import { SocketContext } from '../../utils/SocketContext';
+
+let queryClient: ReturnType<typeof createTestQueryClient>;
+let mockSocket: MockSocket;
+
+const queryKey = channelMessagesQueryKey('ch-1');
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(
+    QueryClientProvider,
+    { client: queryClient },
+    React.createElement(
+      SocketContext.Provider,
+      { value: { socket: mockSocket as never, isConnected: true } },
+      React.createElement(NotificationProvider, null, children),
+    ),
+  );
+}
+
+function cacheMessages(): Message[] {
+  const data = queryClient.getQueryData<InfiniteData<PaginatedMessagesResponseDto>>(queryKey);
+  return (data?.pages.flatMap(p => p.messages) ?? []) as unknown as Message[];
+}
+
+beforeEach(() => {
+  queryClient = createTestQueryClient();
+  mockSocket = createMockSocket();
+  queryClient.setQueryData(userControllerGetProfileQueryKey(), { id: 'me', username: 'me' });
+  queryClient.setQueryData(queryKey, createInfiniteData([]));
+});
+
+describe('useMessageFileUpload — optimistic routing (PR-13 scope guard)', () => {
+  it('inserts an optimistic pending row for a plain (no-attachment) send', async () => {
+    mockSocket.emit.mockImplementation(() => {
+      /* never acks — just checking the synchronous insert */
+    });
+
+    const { result } = renderHook(
+      () => useMessageFileUpload({ contextType: VoiceSessionType.Channel, contextId: 'ch-1', authorId: 'me' }),
+      { wrapper },
+    );
+
+    act(() => {
+      void result.current.handleSendMessage('hello', [{ type: 'PLAINTEXT' as never, text: 'hello' }]);
+    });
+
+    const messages = cacheMessages();
+    expect(messages).toHaveLength(1);
+    expect(messages[0].sendStatus).toBe('pending');
+  });
+
+  it('does NOT insert an optimistic row for a send with attachments (v1 scope exclusion)', async () => {
+    mockSocket.emit.mockImplementation(() => {
+      /* never acks — checking that no pending row appears regardless */
+    });
+
+    const { result } = renderHook(
+      () => useMessageFileUpload({ contextType: VoiceSessionType.Channel, contextId: 'ch-1', authorId: 'me' }),
+      { wrapper },
+    );
+
+    const file = new File(['data'], 'photo.png', { type: 'image/png' });
+
+    act(() => {
+      void result.current.handleSendMessage('hello', [{ type: 'PLAINTEXT' as never, text: 'hello' }], [file]);
+    });
+
+    // The raw (non-optimistic) sender was used — no pending row in the cache.
+    expect(cacheMessages()).toHaveLength(0);
+    expect(mockSocket.emit).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/hooks/useOptimisticSendMessage.test.ts
+++ b/frontend/src/__tests__/hooks/useOptimisticSendMessage.test.ts
@@ -132,10 +132,18 @@ describe('useOptimisticSendMessage', () => {
       expect(messages[0].id).toBe('real-1');
       expect(messages[0].sendStatus).toBeUndefined();
 
-      // Step 3: WS echo arrives after — must be a no-op (dedupe by id), never a duplicate.
+      // Step 3: WS echo arrives after — id already present, so it MERGES into
+      // the promoted row (id match) rather than duplicating it.
       await act(async () => {
         await handleNewMessage(
-          { message: createMessage({ id: 'real-1', channelId: 'ch-1', authorId: 'me' }) as never },
+          {
+            message: createMessage({
+              id: 'real-1',
+              channelId: 'ch-1',
+              authorId: 'me',
+              spans: payload().spans,
+            }) as never,
+          },
           queryClient,
         );
       });
@@ -162,10 +170,18 @@ describe('useOptimisticSendMessage', () => {
       expect(cacheMessages()).toHaveLength(1);
       expect(cacheMessages()[0].sendStatus).toBe('pending');
 
-      // Step 2: WS echo arrives first — reconciles the optimistic row in place.
+      // Step 2: WS echo arrives first — reconciles the optimistic row in place
+      // (content-matches the pending row's spans, per the correlation rule).
       await act(async () => {
         await handleNewMessage(
-          { message: createMessage({ id: 'real-1', channelId: 'ch-1', authorId: 'me' }) as never },
+          {
+            message: createMessage({
+              id: 'real-1',
+              channelId: 'ch-1',
+              authorId: 'me',
+              spans: payload().spans,
+            }) as never,
+          },
           queryClient,
         );
       });
@@ -205,7 +221,14 @@ describe('useOptimisticSendMessage', () => {
 
         const echo = () =>
           handleNewMessage(
-            { message: createMessage({ id: 'real-1', channelId: 'ch-1', authorId: 'me' }) as never },
+            {
+              message: createMessage({
+                id: 'real-1',
+                channelId: 'ch-1',
+                authorId: 'me',
+                spans: payload().spans,
+              }) as never,
+            },
             qc,
           );
 
@@ -239,6 +262,98 @@ describe('useOptimisticSendMessage', () => {
       expect(ackFirstResult[0].id).toBe(echoFirstResult[0].id);
       expect(ackFirstResult[0].sendStatus).toBeUndefined();
       expect(echoFirstResult[0].sendStatus).toBeUndefined();
+    });
+
+    it('ack-first enrichment (fix round 1, Important 2): a later echo with resolved replyTo MERGES into the row instead of being dropped', async () => {
+      let ack: ((id: string) => void) | undefined;
+      mockSocket.emit.mockImplementation((_event, _p, ackFn) => {
+        ack = ackFn as (id: string) => void;
+      });
+      const { result } = renderHook(() => useOptimisticSendMessage(VoiceSessionType.Channel, 'ch-1'), {
+        wrapper: createTestWrapper({ queryClient, socket: mockSocket }),
+      });
+
+      let sendPromise!: Promise<SendMessageResult>;
+      act(() => {
+        sendPromise = result.current.sendMessage(payload());
+      });
+
+      // Ack-first: promotes the row to the real id using only locally-known content.
+      await act(async () => {
+        ack!('real-1');
+        await sendPromise;
+      });
+      let messages = cacheMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].id).toBe('real-1');
+      expect((messages[0] as unknown as { replyTo?: unknown }).replyTo).toBeUndefined();
+
+      // The echo arrives after, carrying richer, server-resolved content
+      // that the ack alone never had (e.g. a resolved replyTo object).
+      await act(async () => {
+        await handleNewMessage(
+          {
+            message: createMessage({
+              id: 'real-1',
+              channelId: 'ch-1',
+              authorId: 'me',
+              spans: payload().spans,
+              replyToId: 'parent-1',
+              replyTo: { id: 'parent-1', authorId: 'other', spans: [], deletedAt: null } as never,
+            }) as never,
+          },
+          queryClient,
+        );
+      });
+
+      messages = cacheMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].id).toBe('real-1');
+      // The enrichment landed — it's no longer discarded as a no-op dedupe.
+      expect((messages[0] as unknown as { replyTo?: { id: string } }).replyTo).toMatchObject({ id: 'parent-1' });
+    });
+  });
+
+  describe('concurrency guard (fix round 1, Important 3)', () => {
+    it('a second concurrent retry for the same clientId no-ops instead of firing a duplicate send', async () => {
+      const failed = createMessage({
+        id: 'pending-xyz',
+        clientId: 'pending-xyz',
+        sendStatus: 'failed',
+        channelId: 'ch-1',
+        authorId: 'me',
+      });
+      queryClient.setQueryData(queryKey, createInfiniteData([failed]));
+
+      let resolveAck: ((id: string) => void) | undefined;
+      const ackPromise = new Promise<string>((resolve) => {
+        resolveAck = resolve;
+      });
+      mockSocket.emit.mockImplementation((_event, _p, ackFn) => {
+        void ackPromise.then((id) => (ackFn as (id: string) => void)(id));
+      });
+
+      const { result } = renderHook(() => useOptimisticMessageRetry(failed), {
+        wrapper: createTestWrapper({ queryClient, socket: mockSocket }),
+      });
+
+      let firstRetry!: Promise<void>;
+      let secondRetry!: Promise<void>;
+      act(() => {
+        firstRetry = result.current.retry();
+        secondRetry = result.current.retry();
+      });
+
+      await act(async () => {
+        resolveAck!('real-1');
+        await Promise.all([firstRetry, secondRetry]);
+      });
+
+      // Only one socket.emit — the second concurrent retry() call was a no-op.
+      expect(mockSocket.emit).toHaveBeenCalledTimes(1);
+      const messages = cacheMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].id).toBe('real-1');
     });
   });
 

--- a/frontend/src/__tests__/hooks/useOptimisticSendMessage.test.ts
+++ b/frontend/src/__tests__/hooks/useOptimisticSendMessage.test.ts
@@ -1,0 +1,405 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { InfiniteData } from '@tanstack/react-query';
+
+// Mock the generated client (same pattern as useSendMessage.test.ts)
+vi.mock('../../api-client/client.gen', () => ({
+  client: {
+    getConfig: () => ({ baseUrl: 'http://localhost:3000' }),
+  },
+}));
+
+import {
+  useOptimisticSendMessage,
+  useOptimisticMessageRetry,
+} from '../../hooks/useOptimisticSendMessage';
+import { handleNewMessage } from '../../socket-hub/handlers/messageHandlers';
+import { VoiceSessionType } from '../../contexts/VoiceContext';
+import { channelMessagesQueryKey, channelAnchoredMessagesQueryKey } from '../../utils/messageQueryKeys';
+import { userControllerGetProfileQueryKey } from '../../api-client/@tanstack/react-query.gen';
+import type { PaginatedMessagesResponseDto } from '../../api-client';
+import {
+  createTestQueryClient,
+  createMockSocket,
+  createTestWrapper,
+  createMessage,
+  createInfiniteData,
+} from '../test-utils';
+import type { MockSocket } from '../test-utils';
+import type { Message } from '../../types/message.type';
+import type { NewMessagePayload, SendMessageResult } from '../../hooks/useSendMessage';
+
+let queryClient: ReturnType<typeof createTestQueryClient>;
+let mockSocket: MockSocket;
+
+const queryKey = channelMessagesQueryKey('ch-1');
+
+function seedCurrentUser() {
+  queryClient.setQueryData(userControllerGetProfileQueryKey(), { id: 'me', username: 'me' });
+}
+
+function cacheMessages(): Message[] {
+  const data = queryClient.getQueryData<InfiniteData<PaginatedMessagesResponseDto>>(queryKey);
+  return (data?.pages.flatMap(p => p.messages) ?? []) as unknown as Message[];
+}
+
+function payload(): NewMessagePayload {
+  return {
+    channelId: 'ch-1',
+    authorId: 'me',
+    spans: [{ type: 'PLAINTEXT' as never, text: 'hello' }],
+    attachments: [],
+    reactions: [],
+    sentAt: new Date().toISOString(),
+  };
+}
+
+beforeEach(() => {
+  queryClient = createTestQueryClient();
+  mockSocket = createMockSocket();
+  seedCurrentUser();
+  // Live-edge, empty channel cache (pageParams: [undefined] === live per isDetachedFromLiveEdge).
+  queryClient.setQueryData(queryKey, createInfiniteData([]));
+});
+
+describe('useOptimisticSendMessage', () => {
+  describe('optimistic insert', () => {
+    it('inserts a pending row immediately, before the send settles', () => {
+      mockSocket.emit.mockImplementation(() => {
+        /* never acks — just checking the synchronous insert */
+      });
+      const { result } = renderHook(() => useOptimisticSendMessage(VoiceSessionType.Channel, 'ch-1'), {
+        wrapper: createTestWrapper({ queryClient, socket: mockSocket }),
+      });
+
+      act(() => {
+        void result.current.sendMessage(payload());
+      });
+
+      const messages = cacheMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].sendStatus).toBe('pending');
+      expect(messages[0].id).toMatch(/^pending-/);
+      expect(messages[0].clientId).toBe(messages[0].id);
+    });
+
+    it('never includes sendStatus/clientId in the emitted socket payload', () => {
+      let emittedPayload: Record<string, unknown> | undefined;
+      mockSocket.emit.mockImplementation((_event, p) => {
+        emittedPayload = p as Record<string, unknown>;
+      });
+      const { result } = renderHook(() => useOptimisticSendMessage(VoiceSessionType.Channel, 'ch-1'), {
+        wrapper: createTestWrapper({ queryClient, socket: mockSocket }),
+      });
+
+      act(() => {
+        void result.current.sendMessage(payload());
+      });
+
+      expect(emittedPayload).toBeDefined();
+      expect(emittedPayload).not.toHaveProperty('sendStatus');
+      expect(emittedPayload).not.toHaveProperty('clientId');
+      expect(emittedPayload).not.toHaveProperty('id');
+    });
+  });
+
+  describe('reconciliation races (both orders)', () => {
+    it('ack-first: ack settles before the WS echo arrives', async () => {
+      let ack: ((id: string) => void) | undefined;
+      mockSocket.emit.mockImplementation((_event, _p, ackFn) => {
+        ack = ackFn as (id: string) => void;
+      });
+      const { result } = renderHook(() => useOptimisticSendMessage(VoiceSessionType.Channel, 'ch-1'), {
+        wrapper: createTestWrapper({ queryClient, socket: mockSocket }),
+      });
+
+      let sendPromise!: Promise<SendMessageResult>;
+      act(() => {
+        sendPromise = result.current.sendMessage(payload());
+      });
+
+      // Step 1: optimistic row present, exactly one instance.
+      expect(cacheMessages()).toHaveLength(1);
+      expect(cacheMessages()[0].sendStatus).toBe('pending');
+
+      // Step 2: ack arrives first — promotes the optimistic row in place.
+      await act(async () => {
+        ack!('real-1');
+        await sendPromise;
+      });
+      let messages = cacheMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].id).toBe('real-1');
+      expect(messages[0].sendStatus).toBeUndefined();
+
+      // Step 3: WS echo arrives after — must be a no-op (dedupe by id), never a duplicate.
+      await act(async () => {
+        await handleNewMessage(
+          { message: createMessage({ id: 'real-1', channelId: 'ch-1', authorId: 'me' }) as never },
+          queryClient,
+        );
+      });
+      messages = cacheMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].id).toBe('real-1');
+    });
+
+    it('echo-first: the WS echo arrives before the ack settles', async () => {
+      let ack: ((id: string) => void) | undefined;
+      mockSocket.emit.mockImplementation((_event, _p, ackFn) => {
+        ack = ackFn as (id: string) => void;
+      });
+      const { result } = renderHook(() => useOptimisticSendMessage(VoiceSessionType.Channel, 'ch-1'), {
+        wrapper: createTestWrapper({ queryClient, socket: mockSocket }),
+      });
+
+      let sendPromise!: Promise<SendMessageResult>;
+      act(() => {
+        sendPromise = result.current.sendMessage(payload());
+      });
+
+      // Step 1: optimistic row present, exactly one instance.
+      expect(cacheMessages()).toHaveLength(1);
+      expect(cacheMessages()[0].sendStatus).toBe('pending');
+
+      // Step 2: WS echo arrives first — reconciles the optimistic row in place.
+      await act(async () => {
+        await handleNewMessage(
+          { message: createMessage({ id: 'real-1', channelId: 'ch-1', authorId: 'me' }) as never },
+          queryClient,
+        );
+      });
+      let messages = cacheMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].id).toBe('real-1');
+      expect(messages[0].sendStatus).toBeUndefined();
+
+      // Step 3: ack arrives after — must be a no-op (its clientId is already gone).
+      await act(async () => {
+        ack!('real-1');
+        await sendPromise;
+      });
+      messages = cacheMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].id).toBe('real-1');
+    });
+
+    it('both orders converge to the identical final cache state', async () => {
+      const runOrder = async (order: 'ack-first' | 'echo-first') => {
+        const qc = createTestQueryClient();
+        qc.setQueryData(userControllerGetProfileQueryKey(), { id: 'me', username: 'me' });
+        qc.setQueryData(queryKey, createInfiniteData([]));
+        const socket = createMockSocket();
+        let ack: ((id: string) => void) | undefined;
+        socket.emit.mockImplementation((_event, _p, ackFn) => {
+          ack = ackFn as (id: string) => void;
+        });
+        const { result } = renderHook(() => useOptimisticSendMessage(VoiceSessionType.Channel, 'ch-1'), {
+          wrapper: createTestWrapper({ queryClient: qc, socket }),
+        });
+
+        let sendPromise!: Promise<SendMessageResult>;
+        act(() => {
+          sendPromise = result.current.sendMessage(payload());
+        });
+
+        const echo = () =>
+          handleNewMessage(
+            { message: createMessage({ id: 'real-1', channelId: 'ch-1', authorId: 'me' }) as never },
+            qc,
+          );
+
+        if (order === 'ack-first') {
+          await act(async () => {
+            ack!('real-1');
+            await sendPromise;
+          });
+          await act(async () => {
+            await echo();
+          });
+        } else {
+          await act(async () => {
+            await echo();
+          });
+          await act(async () => {
+            ack!('real-1');
+            await sendPromise;
+          });
+        }
+
+        const data = qc.getQueryData<InfiniteData<PaginatedMessagesResponseDto>>(queryKey);
+        return data?.pages.flatMap(p => p.messages) as unknown as Message[];
+      };
+
+      const ackFirstResult = await runOrder('ack-first');
+      const echoFirstResult = await runOrder('echo-first');
+
+      expect(ackFirstResult).toHaveLength(1);
+      expect(echoFirstResult).toHaveLength(1);
+      expect(ackFirstResult[0].id).toBe(echoFirstResult[0].id);
+      expect(ackFirstResult[0].sendStatus).toBeUndefined();
+      expect(echoFirstResult[0].sendStatus).toBeUndefined();
+    });
+  });
+
+  describe('timeout -> failed -> retry -> success', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('marks the row failed after the 10s send timeout, then retry (same clientId) succeeds', async () => {
+      mockSocket.emit.mockImplementation(() => {
+        /* never acks — triggers useSendMessage's 10s timeout */
+      });
+      const { result } = renderHook(() => useOptimisticSendMessage(VoiceSessionType.Channel, 'ch-1'), {
+        wrapper: createTestWrapper({ queryClient, socket: mockSocket }),
+      });
+
+      let sendPromise!: Promise<SendMessageResult>;
+      act(() => {
+        sendPromise = result.current.sendMessage(payload());
+      });
+
+      const clientId = cacheMessages()[0].clientId!;
+
+      await act(async () => {
+        vi.advanceTimersByTime(10000);
+        await sendPromise;
+      });
+
+      let messages = cacheMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].sendStatus).toBe('failed');
+      expect(messages[0].clientId).toBe(clientId);
+
+      // Retry — same clientId, no duplicate row, and this time it acks.
+      let retryAck: ((id: string) => void) | undefined;
+      mockSocket.emit.mockImplementation((_event, _p, ackFn) => {
+        retryAck = ackFn as (id: string) => void;
+      });
+
+      const failedMessage = messages[0];
+      const { result: retryResult } = renderHook(() => useOptimisticMessageRetry(failedMessage), {
+        wrapper: createTestWrapper({ queryClient, socket: mockSocket }),
+      });
+
+      let retryPromise!: Promise<void>;
+      act(() => {
+        retryPromise = retryResult.current.retry();
+      });
+
+      // Immediately reset to pending, same clientId, still one row.
+      messages = cacheMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].sendStatus).toBe('pending');
+      expect(messages[0].clientId).toBe(clientId);
+
+      await act(async () => {
+        retryAck!('real-1');
+        await retryPromise;
+      });
+
+      messages = cacheMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].id).toBe('real-1');
+      expect(messages[0].sendStatus).toBeUndefined();
+    });
+  });
+
+  describe('failed -> delete', () => {
+    it('removes the failed row entirely, no API call needed', () => {
+      const failed = createMessage({
+        id: 'pending-xyz',
+        clientId: 'pending-xyz',
+        sendStatus: 'failed',
+        channelId: 'ch-1',
+        authorId: 'me',
+      });
+      queryClient.setQueryData(queryKey, createInfiniteData([failed]));
+
+      const { result } = renderHook(() => useOptimisticMessageRetry(failed), {
+        wrapper: createTestWrapper({ queryClient, socket: mockSocket }),
+      });
+
+      act(() => {
+        result.current.remove();
+      });
+
+      expect(cacheMessages()).toHaveLength(0);
+      expect(mockSocket.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('scope guard: anchored mode', () => {
+    it('never writes to the anchored query key — it only ever targets the normal-mode key', async () => {
+      const anchorKey = channelAnchoredMessagesQueryKey('ch-1', 'anchor-msg-1');
+      const anchoredData = createInfiniteData([createMessage({ id: 'anchor-msg-1' })]);
+      queryClient.setQueryData(anchorKey, anchoredData);
+
+      let ack: ((id: string) => void) | undefined;
+      mockSocket.emit.mockImplementation((_event, _p, ackFn) => {
+        ack = ackFn as (id: string) => void;
+      });
+      const { result } = renderHook(() => useOptimisticSendMessage(VoiceSessionType.Channel, 'ch-1'), {
+        wrapper: createTestWrapper({ queryClient, socket: mockSocket }),
+      });
+
+      let sendPromise!: Promise<SendMessageResult>;
+      act(() => {
+        sendPromise = result.current.sendMessage(payload());
+      });
+
+      // The anchored cache (a completely separate query key while the UI is
+      // showing a jump-to-message view) is untouched by the optimistic
+      // insert — this hook only ever writes to the normal-mode key.
+      expect(queryClient.getQueryData(anchorKey)).toBe(anchoredData);
+      // The normal-mode window (still at the live edge underneath the
+      // anchored view) does get the optimistic row.
+      expect(cacheMessages()).toHaveLength(1);
+
+      await act(async () => {
+        ack!('real-1');
+        await sendPromise;
+      });
+      expect(queryClient.getQueryData(anchorKey)).toBe(anchoredData);
+    });
+  });
+
+  describe('scope guard: detached from the live edge', () => {
+    it('does not insert an optimistic row when the window is detached', async () => {
+      const existing = createMessage({ id: 'stale-1', channelId: 'ch-1' });
+      queryClient.setQueryData(queryKey, { ...createInfiniteData([existing]), pageParams: ['cursor-uuid'] });
+
+      let ack: ((id: string) => void) | undefined;
+      mockSocket.emit.mockImplementation((_event, _p, ackFn) => {
+        ack = ackFn as (id: string) => void;
+      });
+      const { result } = renderHook(() => useOptimisticSendMessage(VoiceSessionType.Channel, 'ch-1'), {
+        wrapper: createTestWrapper({ queryClient, socket: mockSocket }),
+      });
+
+      let sendPromise!: Promise<SendMessageResult>;
+      act(() => {
+        sendPromise = result.current.sendMessage(payload());
+      });
+
+      // No optimistic row was inserted — cache untouched by this hook.
+      expect(cacheMessages()).toHaveLength(1);
+      expect(cacheMessages()[0].id).toBe('stale-1');
+
+      // The underlying send still happens normally (just no optimistic UI).
+      await act(async () => {
+        ack!('real-1');
+        await sendPromise;
+      });
+      expect(mockSocket.emit).toHaveBeenCalled();
+      // Still untouched — this hook never wrote to a detached window at all;
+      // the real echo-driven reset (#416) is handled elsewhere.
+      expect(cacheMessages()).toHaveLength(1);
+      expect(cacheMessages()[0].id).toBe('stale-1');
+    });
+  });
+});

--- a/frontend/src/__tests__/socket-hub/handlers/messageHandlers.test.ts
+++ b/frontend/src/__tests__/socket-hub/handlers/messageHandlers.test.ts
@@ -95,6 +95,31 @@ describe('messageHandlers', () => {
       expect(unread![0].unreadCount).toBe(1); // still counted
     });
 
+    it('reconciles an own pending optimistic row in place instead of duplicating it (echo-first race)', async () => {
+      const queryClient = new QueryClient();
+      const queryKey = channelMessagesQueryKey('ch-1');
+      const optimistic = makeMessage({
+        id: 'pending-abc',
+        clientId: 'pending-abc',
+        sendStatus: 'pending',
+        authorId: 'me',
+      });
+
+      queryClient.setQueryData(queryKey, makeInfiniteData([optimistic]));
+      queryClient.setQueryData(userControllerGetProfileQueryKey(), { id: 'me' });
+      queryClient.setQueryData(readReceiptsControllerGetUnreadCountsQueryKey(), [
+        { channelId: 'ch-1', unreadCount: 0, mentionCount: 0 },
+      ]);
+
+      const realMsg = makeMessage({ id: 'real-1', channelId: 'ch-1', authorId: 'me' });
+      await handleNewMessage({ message: realMsg as never }, queryClient);
+
+      const data = queryClient.getQueryData<InfiniteData<PaginatedMessagesResponseDto>>(queryKey);
+      // Exactly one row for this message — the real one — never both.
+      expect(data!.pages[0].messages).toHaveLength(1);
+      expect(data!.pages[0].messages[0].id).toBe('real-1');
+    });
+
     it('resets the query to the live edge when the DETACHED user sends their own message', async () => {
       const queryClient = new QueryClient();
       const queryKey = channelMessagesQueryKey('ch-1');

--- a/frontend/src/__tests__/socket-hub/handlers/messageHandlers.test.ts
+++ b/frontend/src/__tests__/socket-hub/handlers/messageHandlers.test.ts
@@ -120,6 +120,50 @@ describe('messageHandlers', () => {
       expect(data!.pages[0].messages[0].id).toBe('real-1');
     });
 
+    it('multi-pending (fix round 1): failed-A + pending-B, echo for B reconciles B and leaves A untouched', async () => {
+      const queryClient = new QueryClient();
+      const queryKey = channelMessagesQueryKey('ch-1');
+      const failedA = makeMessage({
+        id: 'pending-a',
+        clientId: 'pending-a',
+        sendStatus: 'failed',
+        authorId: 'me',
+        spans: [{ type: 'PLAINTEXT', text: 'message A' }],
+      });
+      const pendingB = makeMessage({
+        id: 'pending-b',
+        clientId: 'pending-b',
+        sendStatus: 'pending',
+        authorId: 'me',
+        spans: [{ type: 'PLAINTEXT', text: 'message B' }],
+      });
+
+      queryClient.setQueryData(queryKey, makeInfiniteData([pendingB, failedA]));
+      queryClient.setQueryData(userControllerGetProfileQueryKey(), { id: 'me' });
+      queryClient.setQueryData(readReceiptsControllerGetUnreadCountsQueryKey(), [
+        { channelId: 'ch-1', unreadCount: 0, mentionCount: 0 },
+      ]);
+
+      const echoForB = makeMessage({
+        id: 'real-b',
+        channelId: 'ch-1',
+        authorId: 'me',
+        spans: [{ type: 'PLAINTEXT', text: 'message B' }],
+      });
+      await handleNewMessage({ message: echoForB as never }, queryClient);
+
+      const data = queryClient.getQueryData<InfiniteData<PaginatedMessagesResponseDto>>(queryKey);
+      const messages = data!.pages[0].messages as unknown as { id: string; clientId?: string; sendStatus?: string }[];
+      expect(messages).toHaveLength(2);
+      // B reconciled to the real message.
+      expect(messages.find((m) => m.id === 'real-b')).toMatchObject({ clientId: 'pending-b' });
+      // A's failed bubble is untouched — still present, still 'failed'.
+      expect(messages.find((m) => m.clientId === 'pending-a')).toMatchObject({
+        id: 'pending-a',
+        sendStatus: 'failed',
+      });
+    });
+
     it('resets the query to the live edge when the DETACHED user sends their own message', async () => {
       const queryClient = new QueryClient();
       const queryKey = channelMessagesQueryKey('ch-1');

--- a/frontend/src/__tests__/utils/messageCacheUpdaters.test.ts
+++ b/frontend/src/__tests__/utils/messageCacheUpdaters.test.ts
@@ -209,38 +209,42 @@ describe('findMessageInInfinite', () => {
 // --- Optimistic send (PR-13) ---
 
 describe('prependOrReconcileOptimistic', () => {
-  it('reconciles in place when a pending row from the same author exists (echo-first)', () => {
+  const plaintextSpans = (text: string) => [{ type: 'PLAINTEXT' as never, text }];
+
+  it('reconciles in place when a content-matching pending row from the same author exists (echo-first)', () => {
     const optimistic = createMessage({
       id: 'pending-abc',
       authorId: 'user-1',
       clientId: 'pending-abc',
       sendStatus: 'pending',
+      spans: plaintextSpans('hello'),
     });
     const other = createMessage({ id: 'other-1', authorId: 'user-2' });
     const data = createInfiniteData([optimistic, other]);
 
-    const real = createMessage({ id: 'real-1', authorId: 'user-1' });
+    const real = createMessage({ id: 'real-1', authorId: 'user-1', spans: plaintextSpans('hello') });
     const result = prependOrReconcileOptimistic(data, real);
 
     expect(result!.pages[0].messages).toHaveLength(2);
     // Real message swapped in at the SAME position the optimistic row held
     // (preserves chronological order relative to `other`).
-    expect(result!.pages[0].messages[0]).toMatchObject({ id: 'real-1' });
+    expect(result!.pages[0].messages[0]).toMatchObject({ id: 'real-1', clientId: 'pending-abc' });
     expect(result!.pages[0].messages[1]).toMatchObject({ id: 'other-1' });
     // No lingering optimistic row anywhere.
     expect(result!.pages[0].messages.some(m => m.id === 'pending-abc')).toBe(false);
   });
 
-  it('reconciles a failed row too (late echo after a timed-out ack)', () => {
+  it('reconciles a failed row too when content matches (late echo after a timed-out ack)', () => {
     const optimistic = createMessage({
       id: 'pending-abc',
       authorId: 'user-1',
       clientId: 'pending-abc',
       sendStatus: 'failed',
+      spans: plaintextSpans('hello'),
     });
     const data = createInfiniteData([optimistic]);
 
-    const real = createMessage({ id: 'real-1', authorId: 'user-1' });
+    const real = createMessage({ id: 'real-1', authorId: 'user-1', spans: plaintextSpans('hello') });
     const result = prependOrReconcileOptimistic(data, real);
 
     expect(result!.pages[0].messages).toHaveLength(1);
@@ -284,10 +288,149 @@ describe('prependOrReconcileOptimistic', () => {
     expect(result!.pages[0].messages).toHaveLength(1);
   });
 
+  it('MERGES the echo into an existing id-matched row instead of dropping it (ack-first enrichment)', () => {
+    // Simulates ack-first promotion: the optimistic row was already swapped
+    // to the real id (with locally-known content only) before the WS echo
+    // arrives carrying server-resolved enrichment (e.g. a resolved replyTo).
+    const promoted = createMessage({
+      id: 'real-1',
+      clientId: 'pending-abc',
+      authorId: 'user-1',
+      spans: plaintextSpans('hello'),
+      replyToId: 'parent-1',
+    });
+    const data = createInfiniteData([promoted]);
+
+    const echo = createMessage({
+      id: 'real-1',
+      authorId: 'user-1',
+      spans: plaintextSpans('hello'),
+      replyToId: 'parent-1',
+      replyTo: { id: 'parent-1', authorId: 'user-2', spans: [], deletedAt: null } as never,
+    });
+    const result = prependOrReconcileOptimistic(data, echo);
+
+    expect(result!.pages[0].messages).toHaveLength(1);
+    // Enrichment from the echo landed on the row...
+    expect(result!.pages[0].messages[0]).toMatchObject({ id: 'real-1', replyTo: { id: 'parent-1' } });
+    // ...and clientId (needed for stable row keying) survived the merge.
+    expect(result!.pages[0].messages[0]).toMatchObject({ clientId: 'pending-abc' });
+  });
+
   it('does not insert into a detached window', () => {
     const data = { ...createInfiniteData([createMessage({ id: 'old-1' })]), pageParams: ['cursor-uuid'] };
     const result = prependOrReconcileOptimistic(data, createMessage({ id: 'new-1' }));
     expect(result).toBe(data);
+  });
+
+  describe('multi-pending disambiguation (fix round 1, Critical 1)', () => {
+    it('failed-A + pending-B: an echo matching B\'s content reconciles B, leaves A (failed) UNTOUCHED', () => {
+      const failedA = createMessage({
+        id: 'pending-a',
+        authorId: 'user-1',
+        clientId: 'pending-a',
+        sendStatus: 'failed',
+        spans: plaintextSpans('message A'),
+      });
+      const pendingB = createMessage({
+        id: 'pending-b',
+        authorId: 'user-1',
+        clientId: 'pending-b',
+        sendStatus: 'pending',
+        spans: plaintextSpans('message B'),
+      });
+      const data = createInfiniteData([pendingB, failedA]);
+
+      const echoForB = createMessage({ id: 'real-b', authorId: 'user-1', spans: plaintextSpans('message B') });
+      const result = prependOrReconcileOptimistic(data, echoForB);
+
+      const messages = result!.pages[0].messages;
+      expect(messages).toHaveLength(2);
+      // B reconciled to the real message...
+      expect(messages.find(m => m.id === 'real-b')).toMatchObject({ clientId: 'pending-b' });
+      // ...A's failed bubble is completely untouched (still 'failed', still its own row, retry UI intact).
+      const stillFailedA = messages.find(m => (m as unknown as { clientId?: string }).clientId === 'pending-a');
+      expect(stillFailedA).toMatchObject({ id: 'pending-a', sendStatus: 'failed' });
+    });
+
+    it('failed-A + pending-B: a LATE echo matching A\'s content replaces the failed row (prevents double-post via retry) and does not touch B', () => {
+      const failedA = createMessage({
+        id: 'pending-a',
+        authorId: 'user-1',
+        clientId: 'pending-a',
+        sendStatus: 'failed',
+        spans: plaintextSpans('message A'),
+      });
+      const pendingB = createMessage({
+        id: 'pending-b',
+        authorId: 'user-1',
+        clientId: 'pending-b',
+        sendStatus: 'pending',
+        spans: plaintextSpans('message B'),
+      });
+      const data = createInfiniteData([pendingB, failedA]);
+
+      // The server actually received A before the client gave up and marked
+      // it 'failed' — its echo arrives late, after the timeout.
+      const echoForA = createMessage({ id: 'real-a', authorId: 'user-1', spans: plaintextSpans('message A') });
+      const result = prependOrReconcileOptimistic(data, echoForA);
+
+      const messages = result!.pages[0].messages;
+      expect(messages).toHaveLength(2);
+      // A's failed row is REPLACED by the real message — a subsequent Retry
+      // on A can no longer fire (the failed row, and its Retry affordance,
+      // are gone), so the user can't accidentally double-post it.
+      expect(messages.some(m => m.id === 'pending-a')).toBe(false);
+      expect(messages.find(m => m.id === 'real-a')).toMatchObject({ clientId: 'pending-a' });
+      // B (a different pending row, different content) is completely untouched.
+      const untouchedB = messages.find(m => (m as unknown as { clientId?: string }).clientId === 'pending-b');
+      expect(untouchedB).toMatchObject({ id: 'pending-b', sendStatus: 'pending' });
+    });
+
+    it('two PENDING rows, same author, different content: echo only reconciles the content match', () => {
+      const pendingA = createMessage({
+        id: 'pending-a',
+        authorId: 'user-1',
+        clientId: 'pending-a',
+        sendStatus: 'pending',
+        spans: plaintextSpans('first'),
+      });
+      const pendingB = createMessage({
+        id: 'pending-b',
+        authorId: 'user-1',
+        clientId: 'pending-b',
+        sendStatus: 'pending',
+        spans: plaintextSpans('second'),
+      });
+      const data = createInfiniteData([pendingA, pendingB]);
+
+      const echoForSecond = createMessage({ id: 'real-b', authorId: 'user-1', spans: plaintextSpans('second') });
+      const result = prependOrReconcileOptimistic(data, echoForSecond);
+
+      const messages = result!.pages[0].messages;
+      expect(messages).toHaveLength(2);
+      expect(messages.find(m => m.id === 'real-b')).toMatchObject({ clientId: 'pending-b' });
+      expect(messages.find(m => m.id === 'pending-a')).toMatchObject({ sendStatus: 'pending' });
+    });
+
+    it('same author, no content match at all: falls through to plain insert, both optimistic rows untouched', () => {
+      const pendingA = createMessage({
+        id: 'pending-a',
+        authorId: 'user-1',
+        clientId: 'pending-a',
+        sendStatus: 'pending',
+        spans: plaintextSpans('first'),
+      });
+      const data = createInfiniteData([pendingA]);
+
+      const unrelatedEcho = createMessage({ id: 'real-x', authorId: 'user-1', spans: plaintextSpans('totally different') });
+      const result = prependOrReconcileOptimistic(data, unrelatedEcho);
+
+      const messages = result!.pages[0].messages;
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({ id: 'real-x' });
+      expect(messages[1]).toMatchObject({ id: 'pending-a', sendStatus: 'pending' });
+    });
   });
 });
 
@@ -318,6 +461,15 @@ describe('replaceOptimisticMessage', () => {
   it('returns undefined when given undefined', () => {
     expect(replaceOptimisticMessage(undefined, 'pending-abc', createMessage())).toBeUndefined();
   });
+
+  it('is a no-op against an already-reconciled row (id changed, clientId retained) — does not overwrite it again', () => {
+    const reconciled = createMessage({ id: 'real-1', clientId: 'pending-abc' });
+    const data = createInfiniteData([reconciled]);
+
+    const result = replaceOptimisticMessage(data, 'pending-abc', createMessage({ id: 'real-1-different' }));
+    expect(result).toBe(data);
+    expect(result!.pages[0].messages[0]).toMatchObject({ id: 'real-1' });
+  });
 });
 
 describe('removeOptimisticMessage', () => {
@@ -339,6 +491,19 @@ describe('removeOptimisticMessage', () => {
 
   it('returns undefined when given undefined', () => {
     expect(removeOptimisticMessage(undefined, 'pending-abc')).toBeUndefined();
+  });
+
+  it('does NOT remove a row whose clientId is retained but whose id has already been reconciled (fix round 1 guard)', () => {
+    // Simulates an echo-first-reconciled row: id swapped to the real
+    // message id, but clientId intentionally kept for stable React keying.
+    // The ack-side cleanup call must treat this as already-handled, not as
+    // a redundant leftover placeholder to delete.
+    const reconciled = createMessage({ id: 'real-1', clientId: 'pending-abc' });
+    const data = createInfiniteData([reconciled]);
+
+    const result = removeOptimisticMessage(data, 'pending-abc');
+    expect(result!.pages[0].messages).toHaveLength(1);
+    expect(result!.pages[0].messages[0]).toMatchObject({ id: 'real-1', clientId: 'pending-abc' });
   });
 });
 
@@ -363,6 +528,18 @@ describe('markOptimisticFailed', () => {
 
   it('returns undefined when given undefined', () => {
     expect(markOptimisticFailed(undefined, 'pending-abc')).toBeUndefined();
+  });
+
+  it('does NOT flip an already-reconciled real message back to failed (lost-ack-after-echo guard, fix round 1)', () => {
+    // The echo already reconciled this row (id swapped to the real id,
+    // clientId retained for React key stability). If the ack itself is then
+    // lost/times out, reconcileAfterSend's failure branch must not touch it.
+    const reconciled = createMessage({ id: 'real-1', clientId: 'pending-abc' });
+    const data = createInfiniteData([reconciled]);
+
+    const result = markOptimisticFailed(data, 'pending-abc');
+    expect(result!.pages[0].messages[0]).toMatchObject({ id: 'real-1', clientId: 'pending-abc' });
+    expect((result!.pages[0].messages[0] as unknown as { sendStatus?: string }).sendStatus).toBeUndefined();
   });
 });
 

--- a/frontend/src/__tests__/utils/messageCacheUpdaters.test.ts
+++ b/frontend/src/__tests__/utils/messageCacheUpdaters.test.ts
@@ -5,6 +5,11 @@ import {
   deleteMessageFromInfinite,
   findMessageInInfinite,
   isDetachedFromLiveEdge,
+  prependOrReconcileOptimistic,
+  replaceOptimisticMessage,
+  removeOptimisticMessage,
+  markOptimisticFailed,
+  markOptimisticPending,
 } from '../../utils/messageCacheUpdaters';
 import {
   createMessage,
@@ -198,6 +203,180 @@ describe('findMessageInInfinite', () => {
   it('returns undefined when message not found', () => {
     const data = createInfiniteData([createMessage({ id: 'msg-1' })]);
     expect(findMessageInInfinite(data, 'nonexistent')).toBeUndefined();
+  });
+});
+
+// --- Optimistic send (PR-13) ---
+
+describe('prependOrReconcileOptimistic', () => {
+  it('reconciles in place when a pending row from the same author exists (echo-first)', () => {
+    const optimistic = createMessage({
+      id: 'pending-abc',
+      authorId: 'user-1',
+      clientId: 'pending-abc',
+      sendStatus: 'pending',
+    });
+    const other = createMessage({ id: 'other-1', authorId: 'user-2' });
+    const data = createInfiniteData([optimistic, other]);
+
+    const real = createMessage({ id: 'real-1', authorId: 'user-1' });
+    const result = prependOrReconcileOptimistic(data, real);
+
+    expect(result!.pages[0].messages).toHaveLength(2);
+    // Real message swapped in at the SAME position the optimistic row held
+    // (preserves chronological order relative to `other`).
+    expect(result!.pages[0].messages[0]).toMatchObject({ id: 'real-1' });
+    expect(result!.pages[0].messages[1]).toMatchObject({ id: 'other-1' });
+    // No lingering optimistic row anywhere.
+    expect(result!.pages[0].messages.some(m => m.id === 'pending-abc')).toBe(false);
+  });
+
+  it('reconciles a failed row too (late echo after a timed-out ack)', () => {
+    const optimistic = createMessage({
+      id: 'pending-abc',
+      authorId: 'user-1',
+      clientId: 'pending-abc',
+      sendStatus: 'failed',
+    });
+    const data = createInfiniteData([optimistic]);
+
+    const real = createMessage({ id: 'real-1', authorId: 'user-1' });
+    const result = prependOrReconcileOptimistic(data, real);
+
+    expect(result!.pages[0].messages).toHaveLength(1);
+    expect(result!.pages[0].messages[0]).toMatchObject({ id: 'real-1' });
+  });
+
+  it('falls back to a plain prepend when no matching optimistic row exists', () => {
+    const existing = createMessage({ id: 'existing-1', authorId: 'user-2' });
+    const data = createInfiniteData([existing]);
+
+    const real = createMessage({ id: 'real-1', authorId: 'user-1' });
+    const result = prependOrReconcileOptimistic(data, real);
+
+    expect(result!.pages[0].messages).toHaveLength(2);
+    expect(result!.pages[0].messages[0]).toMatchObject({ id: 'real-1' });
+    expect(result!.pages[0].messages[1]).toMatchObject({ id: 'existing-1' });
+  });
+
+  it('does not reconcile against a pending row from a DIFFERENT author', () => {
+    const optimistic = createMessage({
+      id: 'pending-abc',
+      authorId: 'user-2',
+      clientId: 'pending-abc',
+      sendStatus: 'pending',
+    });
+    const data = createInfiniteData([optimistic]);
+
+    const real = createMessage({ id: 'real-1', authorId: 'user-1' });
+    const result = prependOrReconcileOptimistic(data, real);
+
+    expect(result!.pages[0].messages).toHaveLength(2);
+    expect(result!.pages[0].messages[0]).toMatchObject({ id: 'real-1' });
+    expect(result!.pages[0].messages[1]).toMatchObject({ id: 'pending-abc' });
+  });
+
+  it('deduplicates when the real message id is already present', () => {
+    const real = createMessage({ id: 'real-1', authorId: 'user-1' });
+    const data = createInfiniteData([real]);
+
+    const result = prependOrReconcileOptimistic(data, createMessage({ id: 'real-1', authorId: 'user-1' }));
+    expect(result!.pages[0].messages).toHaveLength(1);
+  });
+
+  it('does not insert into a detached window', () => {
+    const data = { ...createInfiniteData([createMessage({ id: 'old-1' })]), pageParams: ['cursor-uuid'] };
+    const result = prependOrReconcileOptimistic(data, createMessage({ id: 'new-1' }));
+    expect(result).toBe(data);
+  });
+});
+
+describe('replaceOptimisticMessage', () => {
+  it('replaces the optimistic row matched by clientId with the real message', () => {
+    const optimistic = createMessage({
+      id: 'pending-abc',
+      clientId: 'pending-abc',
+      sendStatus: 'pending',
+    });
+    const data = createInfiniteData([optimistic]);
+
+    const real = createMessage({ id: 'real-1' });
+    const result = replaceOptimisticMessage(data, 'pending-abc', real);
+
+    expect(result!.pages[0].messages).toHaveLength(1);
+    expect(result!.pages[0].messages[0]).toMatchObject({ id: 'real-1' });
+  });
+
+  it('is a no-op when no row with that clientId is found (already reconciled by the echo)', () => {
+    const real = createMessage({ id: 'real-1' });
+    const data = createInfiniteData([real]);
+
+    const result = replaceOptimisticMessage(data, 'pending-abc', createMessage({ id: 'real-1' }));
+    expect(result).toBe(data);
+  });
+
+  it('returns undefined when given undefined', () => {
+    expect(replaceOptimisticMessage(undefined, 'pending-abc', createMessage())).toBeUndefined();
+  });
+});
+
+describe('removeOptimisticMessage', () => {
+  it('removes the row matched by clientId', () => {
+    const optimistic = createMessage({ id: 'pending-abc', clientId: 'pending-abc', sendStatus: 'failed' });
+    const keep = createMessage({ id: 'keep-1' });
+    const data = createInfiniteData([optimistic, keep]);
+
+    const result = removeOptimisticMessage(data, 'pending-abc');
+    expect(result!.pages[0].messages).toHaveLength(1);
+    expect(result!.pages[0].messages[0]).toMatchObject({ id: 'keep-1' });
+  });
+
+  it('leaves data unchanged when clientId not found', () => {
+    const data = createInfiniteData([createMessage({ id: 'keep-1' })]);
+    const result = removeOptimisticMessage(data, 'nonexistent');
+    expect(result!.pages[0].messages).toHaveLength(1);
+  });
+
+  it('returns undefined when given undefined', () => {
+    expect(removeOptimisticMessage(undefined, 'pending-abc')).toBeUndefined();
+  });
+});
+
+describe('markOptimisticFailed', () => {
+  it("sets sendStatus to 'failed' on the row matched by clientId", () => {
+    const optimistic = createMessage({ id: 'pending-abc', clientId: 'pending-abc', sendStatus: 'pending' });
+    const data = createInfiniteData([optimistic]);
+
+    const result = markOptimisticFailed(data, 'pending-abc');
+    expect(result!.pages[0].messages[0]).toMatchObject({ sendStatus: 'failed', id: 'pending-abc' });
+  });
+
+  it('leaves other rows untouched', () => {
+    const optimistic = createMessage({ id: 'pending-abc', clientId: 'pending-abc', sendStatus: 'pending' });
+    const other = createMessage({ id: 'other-1' });
+    const data = createInfiniteData([optimistic, other]);
+
+    const result = markOptimisticFailed(data, 'pending-abc');
+    expect(result!.pages[0].messages[1]).toMatchObject({ id: 'other-1' });
+    expect((result!.pages[0].messages[1] as { sendStatus?: string }).sendStatus).toBeUndefined();
+  });
+
+  it('returns undefined when given undefined', () => {
+    expect(markOptimisticFailed(undefined, 'pending-abc')).toBeUndefined();
+  });
+});
+
+describe('markOptimisticPending', () => {
+  it("resets a 'failed' row back to 'pending', keeping the same id", () => {
+    const optimistic = createMessage({ id: 'pending-abc', clientId: 'pending-abc', sendStatus: 'failed' });
+    const data = createInfiniteData([optimistic]);
+
+    const result = markOptimisticPending(data, 'pending-abc');
+    expect(result!.pages[0].messages[0]).toMatchObject({ sendStatus: 'pending', id: 'pending-abc' });
+  });
+
+  it('returns undefined when given undefined', () => {
+    expect(markOptimisticPending(undefined, 'pending-abc')).toBeUndefined();
   });
 });
 

--- a/frontend/src/components/Message/MessageComponent.tsx
+++ b/frontend/src/components/Message/MessageComponent.tsx
@@ -8,6 +8,7 @@
 import React, { useState, useCallback } from "react";
 import { Avatar, Typography, Tooltip, Box, Chip, Link } from "@mui/material";
 import PushPinIcon from "@mui/icons-material/PushPin";
+import ScheduleIcon from "@mui/icons-material/Schedule";
 import type { Message as MessageType } from "../../types/message.type";
 import { useQuery } from "@tanstack/react-query";
 import { userControllerGetUserByIdOptions } from "../../api-client/@tanstack/react-query.gen";
@@ -36,6 +37,7 @@ import { useResponsive } from "../../hooks/useResponsive";
 import { useLongPress } from "../../hooks/useSwipeGesture";
 import { useCommunityCustomEmojis } from "../../hooks/useCommunityCustomEmojis";
 import { useContextMenuFocusRestore } from "../../hooks/useContextMenuFocusRestore";
+import { OptimisticMessageActions } from "./OptimisticMessageActions";
 
 interface MessageProps {
   message: MessageType;
@@ -66,6 +68,13 @@ function MessageComponentInner({
   // Community custom emojis (for rendering EMOJI spans + custom reactions).
   const { byId: emojiById } = useCommunityCustomEmojis(communityId);
   const isWebhookMessage = !!message.webhook;
+  // Optimistic (not-yet-settled) send — see types/message.type.ts. Neither
+  // state has a real, persisted message id, so every action that would hit
+  // the API (edit/delete/pin/react/thread) is disabled below; retry/delete
+  // for the optimistic row itself is handled by OptimisticMessageActions.
+  const isPending = message.sendStatus === 'pending';
+  const isFailed = message.sendStatus === 'failed';
+  const isOptimistic = isPending || isFailed;
   const { data: author } = useQuery({
     ...userControllerGetUserByIdOptions({ path: { id: message.authorId ?? '' } }),
     // Webhook messages have no authorId — skip the user lookup entirely.
@@ -78,15 +87,19 @@ function MessageComponentInner({
   const isMentioned = isUserMentioned(message, currentUser?.id);
 
   // Use extracted hook for cleaner permission logic
-  const { canEdit, canDelete, canPin, canReact } = useMessagePermissions({
+  const messagePermissions = useMessagePermissions({
     message,
     currentUserId: currentUser?.id,
   });
+  const canEdit = messagePermissions.canEdit && !isOptimistic;
+  const canDelete = messagePermissions.canDelete && !isOptimistic;
+  const canPin = messagePermissions.canPin && !isOptimistic;
+  const canReact = messagePermissions.canReact && !isOptimistic;
 
   const isPinned = message.pinned === true;
 
   // Thread logic: Can start a thread if not already a thread reply and handler is provided
-  const canThread = !isThreadReply && !isThreadParent && !!onOpenThread;
+  const canThread = !isOptimistic && !isThreadReply && !isThreadParent && !!onOpenThread;
   const hasReplies = (message.replyCount ?? 0) > 0;
 
   const handleOpenThread = () => {
@@ -195,6 +208,8 @@ function MessageComponentInner({
       isDeleting={isDeleting}
       isHighlighted={isMentioned}
       isSearchHighlight={isSearchHighlight}
+      isPending={isPending}
+      isFailed={isFailed}
       // Not in tab order (-1) — only focused programmatically, to restore
       // focus here after the right-click/long-press context menu closes.
       tabIndex={-1}
@@ -266,6 +281,14 @@ function MessageComponentInner({
             {message.editedAt && (
               <span style={{ marginLeft: 4 }}>(edited)</span>
             )}
+            {isPending && (
+              <Tooltip title="Sending...">
+                <ScheduleIcon
+                  data-testid="message-pending-icon"
+                  sx={{ fontSize: 13, ml: 0.5, verticalAlign: "text-bottom" }}
+                />
+              </Tooltip>
+            )}
             {/* Show read status for own messages in DMs with "seen by" tooltip */}
             {contextType === VoiceSessionType.Dm && isAuthor && contextId && (
               <SeenByTooltip
@@ -325,6 +348,7 @@ function MessageComponentInner({
                 onClick={handleOpenThread}
               />
             )}
+            {isFailed && <OptimisticMessageActions message={message} />}
           </>
         )}
       </div>
@@ -344,7 +368,7 @@ function MessageComponentInner({
           onPin={handlePin}
           onUnpin={handleUnpin}
           onReplyInThread={handleOpenThread}
-          onQuoteReply={onQuoteReply && !message.deletedAt ? () => onQuoteReply(message) : undefined}
+          onQuoteReply={onQuoteReply && !message.deletedAt && !isOptimistic ? () => onQuoteReply(message) : undefined}
           communityId={communityId}
         />
       )}
@@ -373,7 +397,7 @@ function MessageComponentInner({
         onPin={handlePin}
         onUnpin={handleUnpin}
         onReplyInThread={handleOpenThread}
-        onQuoteReply={onQuoteReply && !message.deletedAt ? () => onQuoteReply(message) : undefined}
+        onQuoteReply={onQuoteReply && !message.deletedAt && !isOptimistic ? () => onQuoteReply(message) : undefined}
         onAddReaction={handleAddReaction}
       />
       {shouldUseTouchUI && (
@@ -393,7 +417,7 @@ function MessageComponentInner({
           onPin={handlePin}
           onUnpin={handleUnpin}
           onReplyInThread={handleOpenThread}
-          onQuoteReply={onQuoteReply && !message.deletedAt ? () => onQuoteReply(message) : undefined}
+          onQuoteReply={onQuoteReply && !message.deletedAt && !isOptimistic ? () => onQuoteReply(message) : undefined}
           onAddReaction={handleSheetAddReaction}
           onEmojiSelect={handleEmojiSelect}
         />
@@ -435,6 +459,7 @@ const MessageComponent = React.memo(MessageComponentInner, (prevProps, nextProps
     prevMsg.lastReplyAt === nextMsg.lastReplyAt &&
     prevMsg.replyToId === nextMsg.replyToId &&
     prevMsg.deletedAt === nextMsg.deletedAt &&
+    prevMsg.sendStatus === nextMsg.sendStatus &&
     prevProps.isSearchHighlight === nextProps.isSearchHighlight &&
     prevProps.isThreadParent === nextProps.isThreadParent &&
     prevProps.isThreadReply === nextProps.isThreadReply &&

--- a/frontend/src/components/Message/MessageComponentStyles.tsx
+++ b/frontend/src/components/Message/MessageComponentStyles.tsx
@@ -35,20 +35,28 @@ export const Container = styled("div", {
     prop !== "stagedForDelete" &&
     prop !== "isDeleting" &&
     prop !== "isHighlighted" &&
-    prop !== "isSearchHighlight",
+    prop !== "isSearchHighlight" &&
+    prop !== "isPending" &&
+    prop !== "isFailed",
 })<{
   stagedForDelete?: boolean;
   isDeleting?: boolean;
   isHighlighted?: boolean;
   isSearchHighlight?: boolean;
-}>(({ theme, stagedForDelete, isDeleting, isHighlighted, isSearchHighlight }) => ({
+  /** Optimistic send in flight — reduced opacity, no layout change (PR-13). */
+  isPending?: boolean;
+  /** Optimistic send failed — error tint (PR-13). */
+  isFailed?: boolean;
+}>(({ theme, stagedForDelete, isDeleting, isHighlighted, isSearchHighlight, isPending, isFailed }) => ({
   padding: theme.spacing(0.5, 2),
   display: "flex",
   alignItems: "flex-start",
   width: "100%",
   marginBottom: 0,
   position: "relative",
-  backgroundColor: isHighlighted
+  backgroundColor: isFailed
+    ? alpha(theme.palette.error.main, 0.06)
+    : isHighlighted
     ? alpha(theme.palette.primary.main, 0.08)
     : "transparent",
   border: stagedForDelete
@@ -58,7 +66,11 @@ export const Container = styled("div", {
     : "2px solid transparent",
   borderRadius: stagedForDelete || isSearchHighlight ? theme.spacing(1) : 0,
   transition: isDeleting ? "all 0.3s ease-out" : "all 0.2s ease-in-out",
-  opacity: isDeleting ? 0 : 1,
+  // Pending/failed opacity is independent of the delete-animation opacity —
+  // isDeleting (0) always wins since a row can't be mid-delete-animation
+  // while also optimistic. Kept at 1 for the real (settled) state so the
+  // pending -> real transition never shifts anything but this one value.
+  opacity: isDeleting ? 0 : isPending ? 0.6 : 1,
   transform: isDeleting
     ? "translateY(-10px) scale(0.98)"
     : "translateY(0) scale(1)",
@@ -71,6 +83,8 @@ export const Container = styled("div", {
   "&:hover": {
     backgroundColor: stagedForDelete
       ? theme.palette.error.light
+      : isFailed
+      ? alpha(theme.palette.error.main, 0.1)
       : isHighlighted
       ? alpha(theme.palette.primary.main, 0.12)
       : theme.palette.action.hover,

--- a/frontend/src/components/Message/MessageInput.tsx
+++ b/frontend/src/components/Message/MessageInput.tsx
@@ -80,6 +80,12 @@ export default function MessageInput({
   communityId,
 }: MessageInputProps) {
   const [text, setText] = useState("");
+  // LOAD-BEARING for optimistic-send correctness: `sending` serializes
+  // composer submits until the current send's ack/timeout settles, which is
+  // what makes two same-author PENDING rows with identical content
+  // unreachable from the composer alone (echo correlation is content-based —
+  // see messageCacheUpdaters.ts). If this ever becomes fire-and-forget, land
+  // the server-echoed client nonce follow-up first.
   const [sending, setSending] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/frontend/src/components/Message/OptimisticMessageActions.tsx
+++ b/frontend/src/components/Message/OptimisticMessageActions.tsx
@@ -1,0 +1,61 @@
+/**
+ * OptimisticMessageActions
+ *
+ * Retry / Delete affordance for a message whose optimistic send failed
+ * (`sendStatus === 'failed'`). Always rendered (not hover-gated like
+ * MessageToolbar) so the actions are visible and keyboard-reachable without
+ * discovery — matching the always-focusable button pattern from #428.
+ */
+
+import React from "react";
+import { Box, Button, Typography } from "@mui/material";
+import ReplayIcon from "@mui/icons-material/Replay";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import { useOptimisticMessageRetry } from "../../hooks/useOptimisticSendMessage";
+import type { Message } from "../../types/message.type";
+
+interface OptimisticMessageActionsProps {
+  message: Message;
+}
+
+export const OptimisticMessageActions: React.FC<OptimisticMessageActionsProps> = ({ message }) => {
+  const { retry, remove } = useOptimisticMessageRetry(message);
+  const [isRetrying, setIsRetrying] = React.useState(false);
+
+  const handleRetry = async () => {
+    setIsRetrying(true);
+    try {
+      await retry();
+    } finally {
+      setIsRetrying(false);
+    }
+  };
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 0.5 }}>
+      <Typography variant="caption" color="error.main">
+        Failed to send
+      </Typography>
+      <Button
+        size="small"
+        disabled={isRetrying}
+        startIcon={<ReplayIcon fontSize="small" />}
+        onClick={() => void handleRetry()}
+        aria-label="Retry sending message"
+      >
+        Retry
+      </Button>
+      <Button
+        size="small"
+        color="error"
+        startIcon={<DeleteOutlineIcon fontSize="small" />}
+        onClick={remove}
+        aria-label="Delete message"
+      >
+        Delete
+      </Button>
+    </Box>
+  );
+};
+
+export default OptimisticMessageActions;

--- a/frontend/src/components/Message/OptimisticMessageActions.tsx
+++ b/frontend/src/components/Message/OptimisticMessageActions.tsx
@@ -21,13 +21,25 @@ interface OptimisticMessageActionsProps {
 export const OptimisticMessageActions: React.FC<OptimisticMessageActionsProps> = ({ message }) => {
   const { retry, remove } = useOptimisticMessageRetry(message);
   const [isRetrying, setIsRetrying] = React.useState(false);
+  // Guards the finally-block setState below: `retry` awaits a socket
+  // round-trip (up to the 10s send timeout), and this row can unmount
+  // before that settles (e.g. the message list re-renders past it, or the
+  // whole view is torn down). Without this, React warns about a state
+  // update on an unmounted component.
+  const mountedRef = React.useRef(true);
+  React.useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const handleRetry = async () => {
     setIsRetrying(true);
     try {
       await retry();
     } finally {
-      setIsRetrying(false);
+      if (mountedRef.current) setIsRetrying(false);
     }
   };
 

--- a/frontend/src/components/Message/VirtualMessageList.tsx
+++ b/frontend/src/components/Message/VirtualMessageList.tsx
@@ -480,6 +480,10 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
             // echo-first reconcile paths (see messageCacheUpdaters.ts) for
             // exactly this reason. Falls back to message.id for every
             // ordinary (non-optimistic) row, unchanged from before.
+            // Known one-off: a full refetch rebuilds rows from server data,
+            // which never carries clientId, so a previously-optimistic row's
+            // key flips clientId → id once (remount) — invisible in practice
+            // since the refetch rebuilds the whole list anyway.
             const rowKey = message.clientId ?? message.id;
             // Composite key restarts the CSS flash on re-clicks (highlightSeq).
             const key = isHighlighted

--- a/frontend/src/components/Message/VirtualMessageList.tsx
+++ b/frontend/src/components/Message/VirtualMessageList.tsx
@@ -473,10 +473,18 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
             const isHighlighted = highlightMessageId === message.id;
             const showDividerBefore =
               unreadCount > 0 && lastReadIndex !== -1 && index === lastReadIndex + 1;
+            // Key by clientId when present so an optimistic message's row
+            // survives the id swap (pending-<uuid> -> real id) on
+            // reconciliation without remounting (PR-13 fix round 1, Minor
+            // 6) — clientId is preserved through both the ack-first and
+            // echo-first reconcile paths (see messageCacheUpdaters.ts) for
+            // exactly this reason. Falls back to message.id for every
+            // ordinary (non-optimistic) row, unchanged from before.
+            const rowKey = message.clientId ?? message.id;
             // Composite key restarts the CSS flash on re-clicks (highlightSeq).
             const key = isHighlighted
-              ? `${message.id}-hl-${highlightSeq}`
-              : message.id;
+              ? `${rowKey}-hl-${highlightSeq}`
+              : rowKey;
 
             return (
               <div key={key} data-message-id={message.id}>

--- a/frontend/src/hooks/useMessageFileUpload.ts
+++ b/frontend/src/hooks/useMessageFileUpload.ts
@@ -4,6 +4,7 @@ import { VoiceSessionType } from "../contexts/VoiceContext";
 import { messagesControllerAddAttachmentMutation } from "../api-client/@tanstack/react-query.gen";
 import { useFileUpload } from "./useFileUpload";
 import { useSendMessage } from "./useSendMessage";
+import { useOptimisticSendMessage } from "./useOptimisticSendMessage";
 import { useNotification } from "../contexts/NotificationContext";
 import { channelMessagesQueryKey, dmMessagesQueryKey } from "../utils/messageQueryKeys";
 import { updateMessageInInfinite } from "../utils/messageCacheUpdaters";
@@ -39,6 +40,9 @@ export const useMessageFileUpload = ({ contextType, contextId, authorId }: UseMe
     },
   });
 
+  // Attachment-bearing sends bypass the optimistic path entirely (v1 scope —
+  // see useOptimisticSendMessage's doc comment). This raw sender still owns
+  // the post-ack upload-then-attach continuation via its callback.
   const { sendMessage } = useSendMessage(contextType, async (messageId: string) => {
     const files = pendingFilesRef.current;
     if (!files || files.length === 0) return;
@@ -78,6 +82,8 @@ export const useMessageFileUpload = ({ contextType, contextId, authorId }: UseMe
     }
   });
 
+  const { sendMessage: sendOptimisticMessage } = useOptimisticSendMessage(contextType, contextId);
+
   const handleSendMessage = async (_messageContent: string, spans: Span[], files?: File[], replyToId?: string) => {
     const msg = {
       ...(contextType === VoiceSessionType.Channel
@@ -92,14 +98,26 @@ export const useMessageFileUpload = ({ contextType, contextId, authorId }: UseMe
       ...(replyToId ? { replyToId } : {}),
     };
 
-    pendingFilesRef.current = files || null;
+    // Messages with pending attachments are excluded from the optimistic
+    // path (v1 scope): they have their own upload-then-attach flow driven
+    // off the raw sender's ack callback above.
+    const hasAttachments = !!(files && files.length > 0);
 
-    const result = await sendMessage(msg);
-    if (!result.success) {
-      const errorMessage = result.error instanceof Error ? result.error.message : "Failed to send message";
-      showNotification(errorMessage, "error");
+    if (hasAttachments) {
+      pendingFilesRef.current = files || null;
+      const result = await sendMessage(msg);
+      if (!result.success) {
+        const errorMessage = result.error instanceof Error ? result.error.message : "Failed to send message";
+        showNotification(errorMessage, "error");
+      }
       return;
     }
+
+    pendingFilesRef.current = null;
+    // Failures surface inline via the message's 'failed' sendStatus
+    // (retry/delete UI in MessageComponent) instead of a toast — the
+    // optimistic bubble IS the error affordance here.
+    await sendOptimisticMessage(msg);
   };
 
   return { handleSendMessage };

--- a/frontend/src/hooks/useOptimisticSendMessage.ts
+++ b/frontend/src/hooks/useOptimisticSendMessage.ts
@@ -1,0 +1,196 @@
+import { useCallback } from "react";
+import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
+import { useCurrentUser } from "./useCurrentUser";
+import {
+  useSendMessage,
+  type NewMessagePayload,
+  type SendMessageResult,
+  type MessageContext,
+} from "./useSendMessage";
+import { VoiceSessionType } from "../contexts/VoiceContext";
+import { channelMessagesQueryKey, dmMessagesQueryKey } from "../utils/messageQueryKeys";
+import {
+  prependMessageToInfinite,
+  replaceOptimisticMessage,
+  removeOptimisticMessage,
+  markOptimisticFailed,
+  markOptimisticPending,
+  findMessageInInfinite,
+  isDetachedFromLiveEdge,
+} from "../utils/messageCacheUpdaters";
+import type { Message } from "../types/message.type";
+import type { PaginatedMessagesResponseDto } from "../api-client";
+
+type MessagesInfiniteData = InfiniteData<PaginatedMessagesResponseDto>;
+type MessageQueryKey = ReturnType<typeof channelMessagesQueryKey> | ReturnType<typeof dmMessagesQueryKey>;
+
+function queryKeyFor(contextType: MessageContext, contextId: string): MessageQueryKey {
+  return contextType === VoiceSessionType.Channel
+    ? channelMessagesQueryKey(contextId)
+    : dmMessagesQueryKey(contextId);
+}
+
+/**
+ * Applies the outcome of a (re)send to the cache.
+ *
+ * Ack always wins cleanup — this runs regardless of WS-echo timing:
+ * - success + the real id is already in the cache (the echo beat the ack):
+ *   the optimistic row is now redundant, just remove it.
+ * - success + the real id is NOT in the cache yet (ack beat the echo):
+ *   promote the optimistic row in place to the real id (best-effort — we
+ *   only have `messageId` from the ack, not the full enriched message, so
+ *   this keeps our own locally-known content). When the echo arrives after,
+ *   `prependMessageToInfinite`'s dedupe-by-id sees the id already present
+ *   and no-ops — a documented v1 tradeoff: any content the echo would have
+ *   added (e.g. resolved link previews) won't retroactively populate this
+ *   row until the next update.
+ * - failure: mark 'failed' for the retry/delete UI.
+ *
+ * This is a no-op against a clientId that's already gone (the echo-first
+ * case above already reconciled it via `prependOrReconcileOptimistic`).
+ */
+function reconcileAfterSend(
+  queryClient: ReturnType<typeof useQueryClient>,
+  queryKey: MessageQueryKey,
+  clientId: string,
+  optimisticMessage: Message,
+  result: SendMessageResult,
+) {
+  queryClient.setQueryData(queryKey, (old: unknown) => {
+    const typedOld = old as MessagesInfiniteData | undefined;
+    if (result.success && result.messageId) {
+      const echoAlreadyInserted = !!findMessageInInfinite(typedOld, result.messageId);
+      if (echoAlreadyInserted) {
+        return removeOptimisticMessage(typedOld, clientId);
+      }
+      const promoted: Message = {
+        ...optimisticMessage,
+        id: result.messageId,
+        sendStatus: undefined,
+        clientId: undefined,
+      };
+      return replaceOptimisticMessage(typedOld, clientId, promoted);
+    }
+    return markOptimisticFailed(typedOld, clientId);
+  });
+}
+
+export interface UseOptimisticSendMessageResult {
+  sendMessage: (payload: NewMessagePayload) => Promise<SendMessageResult>;
+  canSend: boolean;
+}
+
+/**
+ * Wraps useSendMessage with an optimistic pending bubble: the message
+ * appears immediately (before the server round-trip), then reconciles with
+ * whichever of the ack / WS echo arrives first (see reconcileAfterSend and
+ * prependOrReconcileOptimistic in messageCacheUpdaters.ts for both-order
+ * safety — a render can never observe both the optimistic row and the real
+ * message at once).
+ *
+ * Scope (v1):
+ * - Only inserts optimistically in NORMAL mode at the LIVE EDGE. A detached
+ *   normal-mode window (deep scrollback past MESSAGE_MAX_PAGES, #404) is
+ *   guarded here directly (falls back to a plain send with no optimistic
+ *   row); anchored mode is a wholly separate query key that this hook never
+ *   touches, so it's excluded by construction. See the PR-13 report for why
+ *   "skip" was chosen over "insert + force jump" for the detached case: the
+ *   existing, regression-tested own-send detached-reset in
+ *   messageHandlers.handleNewMessage already handles it correctly once the
+ *   real echo lands, and duplicating that dance here would be fragile for
+ *   very little value (perceived-latency wins matter at the live edge,
+ *   which is not where a detached reader's attention is anyway).
+ * - Messages with pending attachments are the CALLER's responsibility to
+ *   exclude — see hooks/useMessageFileUpload.ts, which routes attachment
+ *   sends through the plain useSendMessage + upload-then-attach flow
+ *   instead of this hook.
+ */
+export function useOptimisticSendMessage(
+  contextType: MessageContext,
+  contextId: string,
+): UseOptimisticSendMessageResult {
+  const queryClient = useQueryClient();
+  const { user: currentUser } = useCurrentUser();
+  const { sendMessage: rawSendMessage, canSend } = useSendMessage(contextType);
+  const queryKey = queryKeyFor(contextType, contextId);
+
+  const sendMessage = useCallback(
+    async (payload: NewMessagePayload): Promise<SendMessageResult> => {
+      const authorId = payload.authorId ?? currentUser?.id ?? null;
+      const existing = queryClient.getQueryData<MessagesInfiniteData>(queryKey);
+
+      // Scope guard: skip the optimistic row when detached from the live
+      // edge (prependMessageToInfinite would no-op anyway, but skipping here
+      // also avoids creating a 'pending'/'failed' row that would never be
+      // visible until a reset — see the doc comment above).
+      if (isDetachedFromLiveEdge(existing)) {
+        return rawSendMessage(payload);
+      }
+
+      const clientId = `pending-${crypto.randomUUID()}`;
+      const optimisticMessage: Message = {
+        ...payload,
+        authorId,
+        id: clientId,
+        clientId,
+        sendStatus: "pending",
+      } as Message;
+
+      queryClient.setQueryData(queryKey, (old: unknown) =>
+        prependMessageToInfinite(old as never, optimisticMessage),
+      );
+
+      const result = await rawSendMessage(payload);
+      reconcileAfterSend(queryClient, queryKey, clientId, optimisticMessage, result);
+      return result;
+    },
+    [queryClient, queryKey, currentUser, rawSendMessage],
+  );
+
+  return { sendMessage, canSend };
+}
+
+export interface UseOptimisticMessageRetryResult {
+  /** Re-emits the message with the SAME clientId — never creates a duplicate row. */
+  retry: () => Promise<void>;
+  /** Removes the optimistic row from the cache. No API call — it was never persisted. */
+  remove: () => void;
+}
+
+/**
+ * Retry/delete actions for a 'pending'/'failed' optimistic message.
+ *
+ * Self-contained — called directly by the row that renders the message
+ * (mirrors useMessageActions), so retry/delete don't need to be threaded
+ * down as props through the container → VirtualMessageList chain.
+ */
+export function useOptimisticMessageRetry(message: Message): UseOptimisticMessageRetryResult {
+  const queryClient = useQueryClient();
+  const contextType = message.channelId ? VoiceSessionType.Channel : VoiceSessionType.Dm;
+  const contextId = message.channelId || message.directMessageGroupId || "";
+  const { sendMessage: rawSendMessage } = useSendMessage(contextType);
+  const queryKey = queryKeyFor(contextType, contextId);
+
+  const retry = useCallback(async () => {
+    const clientId = message.clientId;
+    if (!clientId) return;
+
+    const { id: _id, sendStatus: _status, clientId: _clientId, ...rest } = message;
+    const sentAt = new Date().toISOString();
+    const retryPayload: NewMessagePayload = { ...rest, sentAt };
+    const optimisticMessage: Message = { ...message, sentAt, sendStatus: "pending" };
+
+    queryClient.setQueryData(queryKey, (old: unknown) => markOptimisticPending(old as never, clientId));
+
+    const result = await rawSendMessage(retryPayload);
+    reconcileAfterSend(queryClient, queryKey, clientId, optimisticMessage, result);
+  }, [message, queryClient, queryKey, rawSendMessage]);
+
+  const remove = useCallback(() => {
+    const clientId = message.clientId;
+    if (!clientId) return;
+    queryClient.setQueryData(queryKey, (old: unknown) => removeOptimisticMessage(old as never, clientId));
+  }, [message, queryClient, queryKey]);
+
+  return { retry, remove };
+}

--- a/frontend/src/hooks/useOptimisticSendMessage.ts
+++ b/frontend/src/hooks/useOptimisticSendMessage.ts
@@ -39,11 +39,13 @@ function queryKeyFor(contextType: MessageContext, contextId: string): MessageQue
  * - success + the real id is NOT in the cache yet (ack beat the echo):
  *   promote the optimistic row in place to the real id (best-effort — we
  *   only have `messageId` from the ack, not the full enriched message, so
- *   this keeps our own locally-known content). When the echo arrives after,
- *   `prependMessageToInfinite`'s dedupe-by-id sees the id already present
- *   and no-ops — a documented v1 tradeoff: any content the echo would have
- *   added (e.g. resolved link previews) won't retroactively populate this
- *   row until the next update.
+ *   this keeps our own locally-known content). `clientId` is intentionally
+ *   KEPT (not cleared) on the promoted row so it keeps a stable React key
+ *   across the id swap (see VirtualMessageList's row keying). When the echo
+ *   arrives after, `prependOrReconcileOptimistic`'s id-match branch now
+ *   MERGES the echo into this row instead of no-op'ing on the id-already-
+ *   present check — so any richer content the echo carries (e.g. a resolved
+ *   `replyTo`) still lands (fix round 1; previously permanently dropped).
  * - failure: mark 'failed' for the retry/delete UI.
  *
  * This is a no-op against a clientId that's already gone (the echo-first
@@ -67,13 +69,31 @@ function reconcileAfterSend(
         ...optimisticMessage,
         id: result.messageId,
         sendStatus: undefined,
-        clientId: undefined,
       };
       return replaceOptimisticMessage(typedOld, clientId, promoted);
     }
     return markOptimisticFailed(typedOld, clientId);
   });
 }
+
+/**
+ * Module-level in-flight guard (fix round 1, Important 3): prevents a
+ * second submit for the SAME optimistic row's clientId from racing a send
+ * that's already outstanding — e.g. a double-clicked Retry button, or Retry
+ * firing while the original send is still in flight. Consulted by both
+ * `sendMessage` and `retry` so they see each other's in-flight state
+ * (retry runs in a different hook instance than the composer's send).
+ *
+ * This does NOT prevent multiple DIFFERENT optimistic rows from being in
+ * flight concurrently for the same author (composer send + a retry of an
+ * older failed row, or two sequential composer sends) — that's expected
+ * and handled by the content-based echo correlation in
+ * `prependOrReconcileOptimistic`, not by this guard.
+ *
+ * Module-level (not component/hook-instance state) because it must be
+ * shared across every hook instance that could touch the same clientId.
+ */
+const inFlightClientIds = new Set<string>();
 
 export interface UseOptimisticSendMessageResult {
   sendMessage: (payload: NewMessagePayload) => Promise<SendMessageResult>;
@@ -140,14 +160,40 @@ export function useOptimisticSendMessage(
         prependMessageToInfinite(old as never, optimisticMessage),
       );
 
-      const result = await rawSendMessage(payload);
-      reconcileAfterSend(queryClient, queryKey, clientId, optimisticMessage, result);
-      return result;
+      inFlightClientIds.add(clientId);
+      try {
+        const result = await rawSendMessage(payload);
+        reconcileAfterSend(queryClient, queryKey, clientId, optimisticMessage, result);
+        return result;
+      } finally {
+        inFlightClientIds.delete(clientId);
+      }
     },
     [queryClient, queryKey, currentUser, rawSendMessage],
   );
 
   return { sendMessage, canSend };
+}
+
+/**
+ * Builds the wire payload for a retry from an explicit field allowlist —
+ * NOT destructure-and-spread of the cached `Message` — so a future
+ * cache-only field added to `Message` (alongside `sendStatus`/`clientId`)
+ * can't silently leak onto the wire just by existing on the object. Mirrors
+ * the fields useMessageFileUpload's handleSendMessage builds for the
+ * original (non-attachment) send.
+ */
+function buildRetryPayload(message: Message, sentAt: string): NewMessagePayload {
+  return {
+    ...(message.channelId ? { channelId: message.channelId } : {}),
+    ...(message.directMessageGroupId ? { directMessageGroupId: message.directMessageGroupId } : {}),
+    authorId: message.authorId,
+    spans: message.spans,
+    attachments: message.attachments,
+    reactions: message.reactions,
+    sentAt,
+    ...(message.replyToId ? { replyToId: message.replyToId } : {}),
+  };
 }
 
 export interface UseOptimisticMessageRetryResult {
@@ -174,16 +220,23 @@ export function useOptimisticMessageRetry(message: Message): UseOptimisticMessag
   const retry = useCallback(async () => {
     const clientId = message.clientId;
     if (!clientId) return;
+    // Guard: a retry already in flight for this clientId (e.g. double-clicked
+    // Retry) no-ops rather than firing a second concurrent send.
+    if (inFlightClientIds.has(clientId)) return;
 
-    const { id: _id, sendStatus: _status, clientId: _clientId, ...rest } = message;
     const sentAt = new Date().toISOString();
-    const retryPayload: NewMessagePayload = { ...rest, sentAt };
+    const retryPayload = buildRetryPayload(message, sentAt);
     const optimisticMessage: Message = { ...message, sentAt, sendStatus: "pending" };
 
     queryClient.setQueryData(queryKey, (old: unknown) => markOptimisticPending(old as never, clientId));
 
-    const result = await rawSendMessage(retryPayload);
-    reconcileAfterSend(queryClient, queryKey, clientId, optimisticMessage, result);
+    inFlightClientIds.add(clientId);
+    try {
+      const result = await rawSendMessage(retryPayload);
+      reconcileAfterSend(queryClient, queryKey, clientId, optimisticMessage, result);
+    } finally {
+      inFlightClientIds.delete(clientId);
+    }
   }, [message, queryClient, queryKey, rawSendMessage]);
 
   const remove = useCallback(() => {

--- a/frontend/src/hooks/useSendMessage.ts
+++ b/frontend/src/hooks/useSendMessage.ts
@@ -6,8 +6,11 @@ import { SocketContext } from "../utils/SocketContext";
 import { ClientEvents } from '@semaphore-chat/shared';
 import type { Message } from "../types/message.type";
 
-// Omit id for new message payloads
-export type NewMessagePayload = Omit<Message, "id">;
+// Omit id for new message payloads. sendStatus/clientId are cache-local
+// fields added for optimistic sending (see types/message.type.ts) — they
+// must never be part of an outgoing socket payload, so they're excluded
+// here too, not just left optional.
+export type NewMessagePayload = Omit<Message, "id" | "sendStatus" | "clientId">;
 
 export type MessageContext = VoiceSessionType;
 

--- a/frontend/src/socket-hub/handlers/messageHandlers.ts
+++ b/frontend/src/socket-hub/handlers/messageHandlers.ts
@@ -28,7 +28,7 @@ import {
 } from '../../api-client/@tanstack/react-query.gen';
 import type { ThreadRepliesResponseDto, EnrichedThreadReplyDto } from '../../api-client';
 import {
-  prependMessageToInfinite,
+  prependOrReconcileOptimistic,
   updateMessageInInfinite,
   deleteMessageFromInfinite,
   findMessageInInfinite,
@@ -61,8 +61,11 @@ export const handleNewMessage: SocketEventHandler<
 
   if (!detached) {
     await queryClient.cancelQueries({ queryKey });
+    // Reconciles in place with a matching optimistic (pending/failed) row
+    // from the same author if the echo beats the sender's own ack — see
+    // prependOrReconcileOptimistic (PR-13).
     queryClient.setQueryData(queryKey, (old: unknown) =>
-      prependMessageToInfinite(old as never, message as Message),
+      prependOrReconcileOptimistic(old as never, message as Message),
     );
   }
 

--- a/frontend/src/types/message.type.ts
+++ b/frontend/src/types/message.type.ts
@@ -1,1 +1,27 @@
-export { SpanType, type Span, type Reaction, type FileMetadata, type LinkPreview, type Message } from '@semaphore-chat/shared';
+export { SpanType, type Span, type Reaction, type FileMetadata, type LinkPreview } from '@semaphore-chat/shared';
+import type { Message as SharedMessage } from '@semaphore-chat/shared';
+
+/** Lifecycle status for an optimistically-sent message (PR-13). */
+export type SendStatus = 'pending' | 'failed';
+
+/**
+ * Frontend message type. Extends the shared wire type (`@semaphore-chat/shared`)
+ * with two fields used for optimistic sending:
+ *
+ * - `sendStatus`: `'pending'` while a locally-created message is waiting for
+ *   the server ack/echo, `'failed'` if the send timed out or errored.
+ *   Absent (`undefined`) for every real, server-sourced message.
+ * - `clientId`: the id the client generated for an optimistic message
+ *   (equal to its `id` while pending/failed — see useOptimisticSendMessage).
+ *   Used to correlate an optimistic cache entry with its eventual ack/echo
+ *   so a retry or reconciliation can find the right row without relying on
+ *   `id` staying stable.
+ *
+ * Both fields are CACHE-LOCAL ONLY — they live in the TanStack Query cache
+ * and are never included in an outgoing socket payload. `NewMessagePayload`
+ * (hooks/useSendMessage.ts) explicitly omits them from the wire type.
+ */
+export interface Message extends SharedMessage {
+  sendStatus?: SendStatus;
+  clientId?: string;
+}

--- a/frontend/src/utils/messageCacheUpdaters.ts
+++ b/frontend/src/utils/messageCacheUpdaters.ts
@@ -98,6 +98,13 @@ export function findMessageInInfinite(
 // Whichever runs first "wins" the swap; the other is then a no-op against
 // an id/clientId that's already gone — see reconcileAfterSend in
 // hooks/useOptimisticSendMessage.ts for the ack-side idempotency check.
+//
+// Multi-pending correlation invariant (fix round 1): with more than one
+// optimistic row in flight for the same author (e.g. a timed-out send left
+// a 'failed' bubble while a fresh send is 'pending'), authorId ALONE is not
+// enough to pick the right row — see the doc comment on
+// `prependOrReconcileOptimistic` below for the content-equality rule that
+// replaces it.
 
 /** True if a cached row is a not-yet-settled optimistic message. */
 function isOptimisticRow(message: unknown): boolean {
@@ -106,19 +113,67 @@ function isOptimisticRow(message: unknown): boolean {
 }
 
 /**
+ * Flattens a message's spans to plain text for echo-correlation purposes
+ * only (NOT a general-purpose renderer — mentions/formatting are collapsed
+ * to their raw `text`). This is a client-side heuristic standing in for a
+ * real correlation key; the durable fix is a server-echoed client nonce in
+ * the broadcast payload (backend + shared change, tracked as a follow-up).
+ */
+function flattenSpansText(spans: Message['spans'] | undefined): string {
+  return (spans ?? []).map(s => s.text ?? '').join('');
+}
+
+/**
+ * Content-equality check used to disambiguate among multiple same-author
+ * optimistic rows. Compares flattened span text — sufficient to tell two
+ * different in-flight sends apart without needing a real nonce.
+ */
+function isSameOptimisticContent(a: Message, b: Message): boolean {
+  return flattenSpansText(a.spans) === flattenSpansText(b.spans);
+}
+
+/**
  * Insert a WS-echoed message, reconciling it in place with a matching
- * 'pending'/'failed' optimistic row from the SAME author if one exists —
- * the echo can arrive before the sender's own ack. Falls back to a plain
- * prepend (dedup-by-id, live-edge-only — same rules as
- * `prependMessageToInfinite`) when there's no match.
+ * optimistic row if one exists — the echo can arrive before the sender's
+ * own ack (echo-first), or after the ack already promoted/removed a row
+ * (in which case this is an id-match merge, not a correlation match — see
+ * below). Falls back to a plain prepend (dedup-by-id, live-edge-only — same
+ * rules as `prependMessageToInfinite`) when neither applies.
  *
- * Correlates by authorId + sendStatus, not clientId: the echo payload never
- * carries clientId (it's cache-local, never sent to the server). Matches the
- * first qualifying row in the page — if a single author somehow has two
- * sends in flight at once, the "wrong" one could be picked, but that's
- * harmless: the ack-side reconciliation (`replaceOptimisticMessage` /
- * `removeOptimisticMessage`) is idempotent regardless of which optimistic
- * row this function already resolved.
+ * Two distinct cases, handled in order:
+ *
+ * 1. **Id already present** (most commonly: ack-first already promoted the
+ *    optimistic row to this same real id, and the echo is now confirming
+ *    it). MERGE the echo payload into the existing row — echo wins for
+ *    server-derived fields — instead of skipping, so enrichment the ack
+ *    didn't carry (e.g. a resolved `replyTo`) isn't permanently lost. The
+ *    row's `clientId` (if any) is preserved through the merge so the row
+ *    keeps a stable React key across the swap (see VirtualMessageList).
+ *
+ * 2. **Correlation match**: find an optimistic ('pending' OR 'failed') row
+ *    from the SAME author whose flattened span text is content-EQUAL to the
+ *    incoming message. Content equality — not authorId alone — is required
+ *    because more than one optimistic row can be in flight for the same
+ *    author at once (a fresh send while an earlier one is still 'failed'
+ *    from a timeout). Author-only matching would let one send's echo
+ *    reconcile a completely unrelated row.
+ *
+ *    'failed' rows ARE eligible for this content-exact match: a late echo
+ *    for a row that already timed out means the server actually received
+ *    it, so replacing the failed row with the real message is correct — it
+ *    prevents a subsequent Retry from double-posting. 'failed' rows are
+ *    NEVER eligible for a looser author-only match, only this exact one.
+ *
+ *    If no row matches on author+content, falls through to a plain insert
+ *    (no reconcile) — an unreconciled optimistic row is still safe: it
+ *    resolves via its own ack (exact clientId) or eventually times out to
+ *    'failed'.
+ *
+ * Known v1 gap: if a single author has two sends in flight with byte-for-
+ * byte IDENTICAL content, this can't tell them apart (picks the first
+ * match). Rare in practice (would require sending the same text twice
+ * before either resolves) and self-healing either way — the ack-side
+ * reconciliation is idempotent regardless of which row got matched first.
  */
 export function prependOrReconcileOptimistic(
   old: InfiniteData<PaginatedMessagesResponseDto> | undefined,
@@ -128,14 +183,31 @@ export function prependOrReconcileOptimistic(
   if (isDetachedFromLiveEdge(old)) return old;
   const firstPage = old.pages[0];
   if (!firstPage) return old;
-  if (firstPage.messages.some(m => m.id === message.id)) return old;
+
+  const existingIdIndex = firstPage.messages.findIndex(m => m.id === message.id);
+  if (existingIdIndex >= 0) {
+    const existing = firstPage.messages[existingIdIndex] as unknown as Message;
+    const merged = { ...existing, ...message, clientId: existing.clientId } as never;
+    const messages = firstPage.messages.map((m, i) => (i === existingIdIndex ? merged : m));
+    return {
+      ...old,
+      pages: [{ ...firstPage, messages }, ...old.pages.slice(1)],
+    };
+  }
 
   const optimisticIndex = firstPage.messages.findIndex(
-    m => isOptimisticRow(m) && m.authorId === message.authorId,
+    m =>
+      isOptimisticRow(m) &&
+      (m as unknown as Message).authorId === message.authorId &&
+      isSameOptimisticContent(m as unknown as Message, message),
   );
 
   const messages = optimisticIndex >= 0
-    ? firstPage.messages.map((m, i) => (i === optimisticIndex ? (message as never) : m))
+    ? firstPage.messages.map((m, i) => {
+        if (i !== optimisticIndex) return m;
+        const matched = m as unknown as Message;
+        return { ...message, clientId: matched.clientId } as never;
+      })
     : [message as never, ...firstPage.messages];
 
   return {
@@ -145,11 +217,30 @@ export function prependOrReconcileOptimistic(
 }
 
 /**
+ * True if a cached row is still the unreconciled optimistic placeholder for
+ * `clientId` — i.e. `id === clientId`, which only holds before promotion/
+ * reconciliation changes `id` to the real server id. Every clientId-keyed
+ * mutation below (`replaceOptimisticMessage`, `removeOptimisticMessage`,
+ * `markOptimisticFailed`, `markOptimisticPending`) uses this guard, NOT a
+ * bare `clientId` match, because fix round 1 intentionally RETAINS
+ * `clientId` on a row after it's reconciled (for stable React keying — see
+ * `prependOrReconcileOptimistic`). Without this guard, a clientId-only match
+ * could hit an already-settled real message and wrongly mutate it — e.g. a
+ * lost ack (echo arrived and reconciled, but the ack itself times out)
+ * would otherwise flip a persisted message back to 'failed'.
+ */
+function isUnreconciledPlaceholder(message: unknown, clientId: string): boolean {
+  const msg = message as Message;
+  return msg.clientId === clientId && msg.id === clientId;
+}
+
+/**
  * Reconciliation: replace the optimistic row matched by `clientId` with the
  * real, server-sourced message (or server-shaped promotion of the
- * optimistic content). No-op (returns `old` unchanged) if no row with that
- * clientId is found — the echo-first race already reconciled/removed it via
- * `prependOrReconcileOptimistic`, so there's nothing left to do.
+ * optimistic content). No-op (returns `old` unchanged) if no still-
+ * unreconciled row with that clientId is found — either the echo-first race
+ * already reconciled/removed it via `prependOrReconcileOptimistic`, or (see
+ * `isUnreconciledPlaceholder`) it's already settled and must not be touched.
  */
 export function replaceOptimisticMessage(
   old: InfiniteData<PaginatedMessagesResponseDto> | undefined,
@@ -161,7 +252,7 @@ export function replaceOptimisticMessage(
   const pages = old.pages.map(page => ({
     ...page,
     messages: page.messages.map(m => {
-      if ((m as unknown as Message).clientId === clientId) {
+      if (isUnreconciledPlaceholder(m, clientId)) {
         found = true;
         return realMessage as never;
       }
@@ -178,6 +269,11 @@ export function replaceOptimisticMessage(
  * (ack-after-echo — the real row already exists under its own id, so the
  * placeholder is redundant) and for the user-facing "delete failed message"
  * action.
+ *
+ * Only removes a row that's STILL the unreconciled placeholder — see
+ * `isUnreconciledPlaceholder`. Without this guard, the ack-side "the echo
+ * already inserted the real row, so my placeholder is redundant" cleanup
+ * would delete that already-reconciled row instead of leaving it alone.
  */
 export function removeOptimisticMessage(
   old: InfiniteData<PaginatedMessagesResponseDto> | undefined,
@@ -188,12 +284,17 @@ export function removeOptimisticMessage(
     ...old,
     pages: old.pages.map(page => ({
       ...page,
-      messages: page.messages.filter(m => (m as unknown as Message).clientId !== clientId),
+      messages: page.messages.filter(m => !isUnreconciledPlaceholder(m, clientId)),
     })),
   };
 }
 
-/** Set `sendStatus: 'failed'` on the optimistic row matched by `clientId`. */
+/**
+ * Set `sendStatus: 'failed'` on the optimistic row matched by `clientId`.
+ * Guarded by `isUnreconciledPlaceholder` (not a bare clientId match) — e.g.
+ * a lost ack for a send whose echo already reconciled the row must NOT flip
+ * that now-settled, real message back to 'failed'.
+ */
 export function markOptimisticFailed(
   old: InfiniteData<PaginatedMessagesResponseDto> | undefined,
   clientId: string,
@@ -204,7 +305,7 @@ export function markOptimisticFailed(
     pages: old.pages.map(page => ({
       ...page,
       messages: page.messages.map(m =>
-        (m as unknown as Message).clientId === clientId
+        isUnreconciledPlaceholder(m, clientId)
           ? ({ ...(m as unknown as Message), sendStatus: 'failed' } as never)
           : m,
       ),
@@ -215,7 +316,8 @@ export function markOptimisticFailed(
 /**
  * Reset a 'failed' optimistic row back to 'pending' — used at the start of
  * a retry, before the retry's send has settled. Keeps the same clientId/id
- * so no duplicate row is created.
+ * so no duplicate row is created. Guarded by `isUnreconciledPlaceholder` for
+ * the same reason as `markOptimisticFailed`.
  */
 export function markOptimisticPending(
   old: InfiniteData<PaginatedMessagesResponseDto> | undefined,
@@ -227,7 +329,7 @@ export function markOptimisticPending(
     pages: old.pages.map(page => ({
       ...page,
       messages: page.messages.map(m =>
-        (m as unknown as Message).clientId === clientId
+        isUnreconciledPlaceholder(m, clientId)
           ? ({ ...(m as unknown as Message), sendStatus: 'pending' } as never)
           : m,
       ),

--- a/frontend/src/utils/messageCacheUpdaters.ts
+++ b/frontend/src/utils/messageCacheUpdaters.ts
@@ -83,3 +83,155 @@ export function findMessageInInfinite(
   return undefined;
 }
 
+// --- Optimistic send (PR-13) ---
+//
+// An optimistic message is inserted with `id === clientId` and
+// `sendStatus: 'pending'`. It's reconciled with the server in one of two
+// ways depending on which arrives first:
+//   - ack-first:  useOptimisticSendMessage's ack callback (has messageId,
+//     not the full message) calls `replaceOptimisticMessage`, swapping the
+//     optimistic row's identity to the real id in place.
+//   - echo-first: the WS NEW_MESSAGE handler calls `prependOrReconcileOptimistic`,
+//     which finds the matching optimistic row and swaps it for the full real
+//     message in the SAME cache update (not remove-then-insert), so no
+//     render can ever show both.
+// Whichever runs first "wins" the swap; the other is then a no-op against
+// an id/clientId that's already gone — see reconcileAfterSend in
+// hooks/useOptimisticSendMessage.ts for the ack-side idempotency check.
+
+/** True if a cached row is a not-yet-settled optimistic message. */
+function isOptimisticRow(message: unknown): boolean {
+  const status = (message as Message).sendStatus;
+  return status === 'pending' || status === 'failed';
+}
+
+/**
+ * Insert a WS-echoed message, reconciling it in place with a matching
+ * 'pending'/'failed' optimistic row from the SAME author if one exists —
+ * the echo can arrive before the sender's own ack. Falls back to a plain
+ * prepend (dedup-by-id, live-edge-only — same rules as
+ * `prependMessageToInfinite`) when there's no match.
+ *
+ * Correlates by authorId + sendStatus, not clientId: the echo payload never
+ * carries clientId (it's cache-local, never sent to the server). Matches the
+ * first qualifying row in the page — if a single author somehow has two
+ * sends in flight at once, the "wrong" one could be picked, but that's
+ * harmless: the ack-side reconciliation (`replaceOptimisticMessage` /
+ * `removeOptimisticMessage`) is idempotent regardless of which optimistic
+ * row this function already resolved.
+ */
+export function prependOrReconcileOptimistic(
+  old: InfiniteData<PaginatedMessagesResponseDto> | undefined,
+  message: Message,
+): InfiniteData<PaginatedMessagesResponseDto> | undefined {
+  if (!old) return old;
+  if (isDetachedFromLiveEdge(old)) return old;
+  const firstPage = old.pages[0];
+  if (!firstPage) return old;
+  if (firstPage.messages.some(m => m.id === message.id)) return old;
+
+  const optimisticIndex = firstPage.messages.findIndex(
+    m => isOptimisticRow(m) && m.authorId === message.authorId,
+  );
+
+  const messages = optimisticIndex >= 0
+    ? firstPage.messages.map((m, i) => (i === optimisticIndex ? (message as never) : m))
+    : [message as never, ...firstPage.messages];
+
+  return {
+    ...old,
+    pages: [{ ...firstPage, messages }, ...old.pages.slice(1)],
+  };
+}
+
+/**
+ * Reconciliation: replace the optimistic row matched by `clientId` with the
+ * real, server-sourced message (or server-shaped promotion of the
+ * optimistic content). No-op (returns `old` unchanged) if no row with that
+ * clientId is found — the echo-first race already reconciled/removed it via
+ * `prependOrReconcileOptimistic`, so there's nothing left to do.
+ */
+export function replaceOptimisticMessage(
+  old: InfiniteData<PaginatedMessagesResponseDto> | undefined,
+  clientId: string,
+  realMessage: Message,
+): InfiniteData<PaginatedMessagesResponseDto> | undefined {
+  if (!old) return old;
+  let found = false;
+  const pages = old.pages.map(page => ({
+    ...page,
+    messages: page.messages.map(m => {
+      if ((m as unknown as Message).clientId === clientId) {
+        found = true;
+        return realMessage as never;
+      }
+      return m;
+    }),
+  }));
+  if (!found) return old;
+  return { ...old, pages };
+}
+
+/**
+ * Remove the optimistic row matched by `clientId` without inserting
+ * anything. Used when the WS echo already inserted the real message
+ * (ack-after-echo — the real row already exists under its own id, so the
+ * placeholder is redundant) and for the user-facing "delete failed message"
+ * action.
+ */
+export function removeOptimisticMessage(
+  old: InfiniteData<PaginatedMessagesResponseDto> | undefined,
+  clientId: string,
+): InfiniteData<PaginatedMessagesResponseDto> | undefined {
+  if (!old) return old;
+  return {
+    ...old,
+    pages: old.pages.map(page => ({
+      ...page,
+      messages: page.messages.filter(m => (m as unknown as Message).clientId !== clientId),
+    })),
+  };
+}
+
+/** Set `sendStatus: 'failed'` on the optimistic row matched by `clientId`. */
+export function markOptimisticFailed(
+  old: InfiniteData<PaginatedMessagesResponseDto> | undefined,
+  clientId: string,
+): InfiniteData<PaginatedMessagesResponseDto> | undefined {
+  if (!old) return old;
+  return {
+    ...old,
+    pages: old.pages.map(page => ({
+      ...page,
+      messages: page.messages.map(m =>
+        (m as unknown as Message).clientId === clientId
+          ? ({ ...(m as unknown as Message), sendStatus: 'failed' } as never)
+          : m,
+      ),
+    })),
+  };
+}
+
+/**
+ * Reset a 'failed' optimistic row back to 'pending' — used at the start of
+ * a retry, before the retry's send has settled. Keeps the same clientId/id
+ * so no duplicate row is created.
+ */
+export function markOptimisticPending(
+  old: InfiniteData<PaginatedMessagesResponseDto> | undefined,
+  clientId: string,
+): InfiniteData<PaginatedMessagesResponseDto> | undefined {
+  if (!old) return old;
+  return {
+    ...old,
+    pages: old.pages.map(page => ({
+      ...page,
+      messages: page.messages.map(m =>
+        (m as unknown as Message).clientId === clientId
+          ? ({ ...(m as unknown as Message), sendStatus: 'pending' } as never)
+          : m,
+      ),
+    })),
+  };
+}
+


### PR DESCRIPTION
## Summary
- Messages now appear instantly on send as a pending bubble (reduced opacity + clock), reconciled against whichever arrives first — the server ack or the WS echo — with **at most one visible instance at every step of both orders** (race-tested in both directions).
- Failed sends (10s timeout / socket error) show retry/delete actions (keyboard-reachable); retry reuses the same client id with an in-flight interlock against double-clicks.
- **Correlation invariant**: the echo reconciles by author + flattened-content equality — never author-only — uniformly for pending and failed rows. A late echo matching a *failed* row replaces it, which is exactly the double-post prevention for timeout-then-server-succeeded. Settled rows are immune to stray late acks (`isUnreconciledPlaceholder` guard — this closed a latent bug found during implementation). Durable follow-up logged: server-echoed client nonce for exact correlation.
- Scope guards: optimistic insert only in normal mode at the live edge (detached and anchored states skip; pending-attachment messages keep their own flow). Cache-local `sendStatus`/`clientId` are type-excluded from wire payloads; rows key by clientId so pending→real promotion doesn't remount (DOM-identity test).

## Test plan
- 173 files / 1800 tests (+13 for this work: multi-pending disambiguation both directions, ack-first enrichment merge, concurrent-retry guard, settled-row immunity, DOM-identity, unmount-mid-retry), type-check + lint clean; #416 detachment and #426 list suites untouched and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sAJfCfBfMm8chbZMsh5Y5