### PR TITLE
feat(helm): S3 object-storage configuration + replica-guard relaxation

### DIFF
--- a/docs-site/docs/installation/kubernetes.md
+++ b/docs-site/docs/installation/kubernetes.md
@@ -253,7 +253,48 @@ You can also set `fileStorage.accessMode` explicitly (`"ReadWriteOnce"` or `"Rea
 !!! warning "PVC accessModes are immutable"
     Kubernetes does not allow changing a PVC's `accessModes` after creation. If you're upgrading an existing release, keep `fileStorage.accessMode` set to whatever the PVC was already created with (older chart versions always used `ReadWriteMany`) — don't rely on auto-detection to change it. To actually switch modes, delete and let Helm recreate the PVC (this destroys any files that only lived there).
 
-If you set `fileStorage.enabled: false`, an ephemeral `emptyDir` is used and files are lost on pod restart. The chart refuses to render if you combine this with a backend that can scale beyond 1 replica (`backend.replicaCount` or HPA `maxReplicas` `> 1`), since uploads would 404 on the other pods. Set `fileStorage.allowEphemeral: true` to explicitly accept that risk instead. Similarly, the chart refuses to render if `fileStorage.accessMode` is explicitly forced to `ReadWriteOnce` while the backend can scale beyond 1 replica, since only one pod could mount the volume.
+If you set `fileStorage.enabled: false`, an ephemeral `emptyDir` is used and files are lost on pod restart. The chart refuses to render if you combine this with a backend that can scale beyond 1 replica (`backend.replicaCount` or HPA `maxReplicas` `> 1`), since uploads would 404 on the other pods. Set `fileStorage.allowEphemeral: true` to explicitly accept that risk instead, or — better — enable S3 object storage below, which removes the requirement entirely. Similarly, the chart refuses to render if `fileStorage.accessMode` is explicitly forced to `ReadWriteOnce` while the backend can scale beyond 1 replica, since only one pod could mount the volume.
+
+### S3 object storage
+
+As an alternative to the RWX-capable PVC above, the backend can write uploads directly to S3 (or an S3-compatible provider — MinIO, Cloudflare R2, Backblaze B2, etc.). This is the simplest way to run more than one backend replica: S3 uploads need no shared filesystem, so the RWX/NFS requirement in [File storage](#file-storage) doesn't apply.
+
+```yaml
+fileStorage:
+  # Set false once no files remain from a previous STORAGE_TYPE=LOCAL
+  # deployment — see the mixed-mode note below. Leave true while migrating.
+  enabled: false
+
+  s3:
+    enabled: true
+    bucket: "my-semaphore-uploads"
+    region: "us-east-1"
+    # endpoint: "https://minio.example.com"  # only for S3-compatible providers
+    # forcePathStyle: true                   # most self-hosted providers (e.g. MinIO) need this
+
+    # Preferred: reference a pre-created Secret instead of putting credentials
+    # in values (keeps them out of `helm get values` / release history).
+    existingSecret: "my-s3-credentials"
+    existingSecretAccessKeyIdKey: "S3_ACCESS_KEY_ID"       # key within the secret
+    existingSecretSecretAccessKeyKey: "S3_SECRET_ACCESS_KEY"
+```
+
+Without `existingSecret`, set `fileStorage.s3.accessKeyId` and `fileStorage.s3.secretAccessKey` inline instead — the chart renders them into a Secret it manages (`<release>-s3-secret`):
+
+```yaml
+fileStorage:
+  s3:
+    enabled: true
+    bucket: "my-semaphore-uploads"
+    region: "us-east-1"
+    accessKeyId: "AKIA..."
+    secretAccessKey: "..."
+```
+
+`fileStorage.s3.bucket`, `region`, and credentials (via one of the two routes above) are required when `s3.enabled: true` — the chart fails to render with a descriptive error if any are missing, mirroring the backend's own `STORAGE_TYPE=S3` validation.
+
+!!! note "Mixed mode: S3 plus the local PVC"
+    `fileStorage.enabled` and `fileStorage.s3.enabled` are independent switches. If both are `true`, the uploads PVC stays mounted alongside S3 — this is "mixed mode," for files that were uploaded while `STORAGE_TYPE=LOCAL` was active before you switched to S3. New uploads go to S3, but pre-existing local files keep being served from the PVC, so the PVC's `accessMode`/RWX requirements (and the render-time guard) still apply to it at more than one backend replica. Once no LOCAL-storage files remain, set `fileStorage.enabled: false` to drop the PVC (and its RWX requirement) entirely — at that point the backend can scale to any replica count with no shared storage of any kind.
 
 ### Replay storage (LiveKit egress)
 
@@ -279,10 +320,12 @@ secrets:
 
 The secret must contain: `JWT_SECRET`, `JWT_REFRESH_SECRET`, `LIVEKIT_API_SECRET`, and `REDIS_PASSWORD` (if using Redis auth).
 
+S3 credentials use a separate `fileStorage.s3.existingSecret` (see [S3 object storage](#s3-object-storage)) rather than this one, so you can manage/rotate them independently.
+
 ### Resources and autoscaling
 
 !!! note "File storage required for multiple backend replicas"
-    Scaling the backend beyond 1 potential replica (fixed `replicaCount`, or HPA `maxReplicas` — not `minReplicas`, since the HPA can scale up to `maxReplicas` at any time) requires `fileStorage.enabled: true` with a `ReadWriteMany` accessMode and an RWX-capable backend — see [File storage](#file-storage). The chart fails to render otherwise.
+    Scaling the backend beyond 1 potential replica (fixed `replicaCount`, or HPA `maxReplicas` — not `minReplicas`, since the HPA can scale up to `maxReplicas` at any time) requires EITHER `fileStorage.enabled: true` with a `ReadWriteMany` accessMode and an RWX-capable backend, OR `fileStorage.s3.enabled: true` (with `fileStorage.enabled: false`, once no local files remain) — see [File storage](#file-storage) and [S3 object storage](#s3-object-storage). The chart fails to render otherwise.
 
 ```yaml
 backend:
@@ -379,7 +422,7 @@ kubectl logs -n ingress-nginx -l app.kubernetes.io/component=controller
 - [ ] Resource limits and autoscaling configured
 - [ ] External PostgreSQL with authentication (recommended over bundled)
 - [ ] External Redis with authentication
-- [ ] `ReadWriteMany` PVC for file storage
+- [ ] `ReadWriteMany` PVC for file storage, or `fileStorage.s3.enabled: true` for S3 object storage
 - [ ] LiveKit webhook URL configured
 - [ ] Monitoring and alerting in place
 - [ ] Backup strategy for PostgreSQL

--- a/helm/semaphore-chat/templates/NOTES.txt
+++ b/helm/semaphore-chat/templates/NOTES.txt
@@ -102,15 +102,34 @@ LiveKit:
 {{- end }}
 {{- end }}
 
+{{- if .Values.fileStorage.s3.enabled }}
+
+☁️  File storage: S3 object storage ENABLED
+   New uploads (avatars, attachments) write directly to bucket
+   "{{ .Values.fileStorage.s3.bucket }}" in region "{{ .Values.fileStorage.s3.region }}".
+   No ReadWriteMany/NFS PVC is required for multi-replica deployments.
+{{- if .Values.fileStorage.enabled }}
+   ℹ️  MIXED MODE: fileStorage.enabled=true also keeps the local uploads PVC
+   mounted, to keep serving files uploaded before switching to S3
+   (STORAGE_TYPE=LOCAL). That PVC's accessMode/RWX requirements still apply
+   to it at more than one backend replica. Once no LOCAL-storage files
+   remain, set fileStorage.enabled=false to drop the PVC entirely.
+{{- end }}
+
+{{- end }}
+
 {{- if not .Values.fileStorage.enabled }}
+{{- if not .Values.fileStorage.s3.enabled }}
 
 ⚠️  WARNING: File storage is EPHEMERAL (fileStorage.enabled=false)
    Uploaded files (avatars, attachments) live on per-pod disk and will be
    LOST on pod restart. This is only safe with a single backend replica.
    To persist uploads across restarts (and to run more than one backend
    replica), set fileStorage.enabled=true and configure a ReadWriteMany-
-   capable backend (fileStorage.nfs.enabled=true or fileStorage.storageClassName).
+   capable backend (fileStorage.nfs.enabled=true or fileStorage.storageClassName),
+   or set fileStorage.s3.enabled=true to store uploads in S3 instead.
 
+{{- end }}
 {{- end }}
 
 {{- if .Values.fileStorage.enabled }}

--- a/helm/semaphore-chat/templates/_helpers.tpl
+++ b/helm/semaphore-chat/templates/_helpers.tpl
@@ -208,8 +208,8 @@ combination at render time rather than leaving the PVC Pending forever).
 {{- end }}
 
 {{/*
-Guard against two data-loss/unschedulable combinations of backend scale and
-file storage config:
+Guard against data-loss/unschedulable/misconfigured combinations of backend
+scale, file storage config, and S3 object storage config:
 
 1. Ephemeral storage with more than one pod. Uploaded files live on per-pod
    disk when fileStorage.enabled=false, so with more than one potential
@@ -217,10 +217,24 @@ file storage config:
    404 on the other pods and are lost on restart. Fails unless the operator
    has opted in via fileStorage.allowEphemeral=true.
 
+   NOT triggered when fileStorage.s3.enabled=true: with no PVC at all
+   (fileStorage.enabled=false) and S3 handling uploads, there is no ephemeral
+   per-pod disk in the upload path, so scaling to any number of replicas is
+   safe without allowEphemeral.
+
 2. A ReadWriteOnce uploads PVC with more than one potential backend replica.
    Only one pod can mount an RWO volume at a time, so the other pod(s) would
    fail to schedule. Fails unless the operator switches to an RWX-capable
    accessMode.
+
+   Still applies even when fileStorage.s3.enabled=true, AS LONG AS
+   fileStorage.enabled is ALSO true: that combination ("mixed mode") keeps
+   the uploads PVC mounted to serve files that were uploaded before the
+   switch to S3 (STORAGE_TYPE=LOCAL), so the PVC's accessMode/RWX
+   requirements still apply to it independently of S3. The failure message is
+   adjusted to explain the mixed-mode reason and mention that
+   fileStorage.enabled=false is also a valid fix once no LOCAL-storage files
+   remain (S3 itself needs no PVC).
 
 3. fileStorage.nfs.enabled=true with an effective accessMode of
    ReadWriteOnce. The chart-managed NFS PersistentVolume (templates/backend/
@@ -228,18 +242,44 @@ file storage config:
    never bind to it — it would sit Pending forever regardless of replica
    count. This can only happen via an explicit fileStorage.accessMode
    override (auto-detection already forces ReadWriteMany for NFS), so this
-   guard fires independently of potentialReplicas.
+   guard fires independently of potentialReplicas and of S3.
+
+4. fileStorage.s3.enabled=true with missing required S3 config: bucket,
+   region, and credentials via exactly one of existingSecret or the inline
+   accessKeyId/secretAccessKey pair. Mirrors the backend's own imperative
+   validation for STORAGE_TYPE=S3 (see backend/src/config/env.validation.ts)
+   so misconfiguration fails at `helm template`/`helm install` time instead
+   of as a backend crash loop.
+
+When fileStorage.s3.enabled=false, none of the S3-specific carve-outs above
+apply and this guard behaves byte-identically to its pre-S3 form.
 */}}
 {{- define "semaphore-chat.validateFileStorage" -}}
 {{- $replicas := include "semaphore-chat.backend.potentialReplicas" . | int -}}
-{{- if and (gt $replicas 1) (not .Values.fileStorage.enabled) (not .Values.fileStorage.allowEphemeral) -}}
-{{- fail (printf "semaphore-chat: backend can scale up to %d replicas (backend.replicaCount / backend.autoscaling.maxReplicas) but fileStorage.enabled=false. Ephemeral storage is per-pod: uploaded files will 404 on other pods and be lost on restart. Fix by doing ONE of: (1) set fileStorage.enabled=true and configure a ReadWriteMany-capable backend (fileStorage.nfs.enabled=true or fileStorage.storageClassName pointing at an RWX storage class), (2) cap backend.replicaCount=1 and backend.autoscaling.maxReplicas=1 (or disable autoscaling), or (3) accept the data-loss risk with --set fileStorage.allowEphemeral=true." $replicas) -}}
+{{- $s3 := .Values.fileStorage.s3 -}}
+{{- if and (gt $replicas 1) (not .Values.fileStorage.enabled) (not $s3.enabled) (not .Values.fileStorage.allowEphemeral) -}}
+{{- fail (printf "semaphore-chat: backend can scale up to %d replicas (backend.replicaCount / backend.autoscaling.maxReplicas) but fileStorage.enabled=false. Ephemeral storage is per-pod: uploaded files will 404 on other pods and be lost on restart. Fix by doing ONE of: (1) set fileStorage.enabled=true and configure a ReadWriteMany-capable backend (fileStorage.nfs.enabled=true or fileStorage.storageClassName pointing at an RWX storage class), (2) set fileStorage.s3.enabled=true to store uploads in S3 instead (no PVC required), (3) cap backend.replicaCount=1 and backend.autoscaling.maxReplicas=1 (or disable autoscaling), or (4) accept the data-loss risk with --set fileStorage.allowEphemeral=true." $replicas) -}}
 {{- end -}}
 {{- if and (gt $replicas 1) .Values.fileStorage.enabled (eq (include "semaphore-chat.fileStorage.accessMode" .) "ReadWriteOnce") -}}
+{{- if $s3.enabled -}}
+{{- fail (printf "semaphore-chat: fileStorage.s3.enabled=true, but fileStorage.enabled=true also keeps the local uploads PVC mounted (mixed mode, for files uploaded before switching to S3) and that PVC would use ReadWriteOnce while the backend can scale up to %d replicas — only one pod can mount it. Fix by doing ONE of: (1) point fileStorage at an RWX-capable storage class (fileStorage.nfs.enabled=true or fileStorage.storageClassName) and set fileStorage.accessMode=ReadWriteMany, (2) cap the backend at 1 potential replica, or (3) once no LOCAL-storage files remain, set fileStorage.enabled=false — S3 uploads don't need the PVC at all." $replicas) -}}
+{{- else -}}
 {{- fail (printf "semaphore-chat: backend can scale up to %d replicas (backend.replicaCount / backend.autoscaling.maxReplicas) but the uploads PVC would use ReadWriteOnce, which only one pod can mount at a time. Point fileStorage at an RWX-capable storage class (fileStorage.nfs.enabled=true or fileStorage.storageClassName pointing at NFS/EFS/AzureFile/etc.) and set fileStorage.accessMode=ReadWriteMany, or cap the backend at 1 potential replica." $replicas) -}}
+{{- end -}}
 {{- end -}}
 {{- if and .Values.fileStorage.enabled .Values.fileStorage.nfs.enabled (eq (include "semaphore-chat.fileStorage.accessMode" .) "ReadWriteOnce") -}}
 {{- fail "semaphore-chat: fileStorage.nfs.enabled=true but fileStorage.accessMode is explicitly set to ReadWriteOnce. The chart-managed NFS PersistentVolume only advertises ReadWriteMany, so a ReadWriteOnce PVC can never bind to it and would stay Pending indefinitely. Remove the fileStorage.accessMode override (auto-detection already forces ReadWriteMany for NFS) or set it to ReadWriteMany." -}}
+{{- end -}}
+{{- if $s3.enabled -}}
+{{- if not $s3.bucket -}}
+{{- fail "semaphore-chat: fileStorage.s3.enabled=true requires fileStorage.s3.bucket to be set." -}}
+{{- end -}}
+{{- if not $s3.region -}}
+{{- fail "semaphore-chat: fileStorage.s3.enabled=true requires fileStorage.s3.region to be set." -}}
+{{- end -}}
+{{- if and (not $s3.existingSecret) (or (not $s3.accessKeyId) (not $s3.secretAccessKey)) -}}
+{{- fail "semaphore-chat: fileStorage.s3.enabled=true requires S3 credentials. Set fileStorage.s3.existingSecret to a pre-created Secret containing the access key ID / secret access key (see existingSecretAccessKeyIdKey / existingSecretSecretAccessKeyKey), or set both fileStorage.s3.accessKeyId and fileStorage.s3.secretAccessKey to have the chart create one." -}}
+{{- end -}}
 {{- end -}}
 {{- end }}
 

--- a/helm/semaphore-chat/templates/backend/configmap.yaml
+++ b/helm/semaphore-chat/templates/backend/configmap.yaml
@@ -39,3 +39,15 @@ data:
   # Replay segments storage path
   REPLAY_SEGMENTS_PATH: {{ .Values.replayStorage.mountPath | quote }}
   {{- end }}
+
+  {{- if .Values.fileStorage.s3.enabled }}
+  # S3 object storage backend (credentials injected separately via
+  # secretKeyRef — see templates/backend/deployment.yaml)
+  STORAGE_TYPE: "S3"
+  S3_BUCKET: {{ .Values.fileStorage.s3.bucket | quote }}
+  S3_REGION: {{ .Values.fileStorage.s3.region | quote }}
+  {{- if .Values.fileStorage.s3.endpoint }}
+  S3_ENDPOINT: {{ .Values.fileStorage.s3.endpoint | quote }}
+  {{- end }}
+  S3_FORCE_PATH_STYLE: {{ .Values.fileStorage.s3.forcePathStyle | quote }}
+  {{- end }}

--- a/helm/semaphore-chat/templates/backend/deployment.yaml
+++ b/helm/semaphore-chat/templates/backend/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/backend/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/backend/secret.yaml") . | sha256sum }}
+        {{- if .Values.fileStorage.s3.enabled }}
+        checksum/s3-secret: {{ include (print $.Template.BasePath "/backend/s3-secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.backend.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -37,6 +40,19 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
+          {{- if .Values.fileStorage.s3.enabled }}
+          env:
+            - name: S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.fileStorage.s3.existingSecret }}{{ .Values.fileStorage.s3.existingSecret }}{{ else }}{{ include "semaphore-chat.fullname" . }}-s3-secret{{ end }}
+                  key: {{ if .Values.fileStorage.s3.existingSecret }}{{ .Values.fileStorage.s3.existingSecretAccessKeyIdKey }}{{ else }}S3_ACCESS_KEY_ID{{ end }}
+            - name: S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.fileStorage.s3.existingSecret }}{{ .Values.fileStorage.s3.existingSecret }}{{ else }}{{ include "semaphore-chat.fullname" . }}-s3-secret{{ end }}
+                  key: {{ if .Values.fileStorage.s3.existingSecret }}{{ .Values.fileStorage.s3.existingSecretSecretAccessKeyKey }}{{ else }}S3_SECRET_ACCESS_KEY{{ end }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "semaphore-chat.fullname" . }}-backend-config

--- a/helm/semaphore-chat/templates/backend/s3-secret.yaml
+++ b/helm/semaphore-chat/templates/backend/s3-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.fileStorage.s3.enabled (not .Values.fileStorage.s3.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "semaphore-chat.fullname" . }}-s3-secret
+  labels:
+    {{- include "semaphore-chat.backend.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  # S3 credentials (only rendered when fileStorage.s3.existingSecret is
+  # empty — set that instead to reference a pre-created Secret, mirroring
+  # secrets.existingSecret for the main application secret)
+  S3_ACCESS_KEY_ID: {{ .Values.fileStorage.s3.accessKeyId | quote }}
+  S3_SECRET_ACCESS_KEY: {{ .Values.fileStorage.s3.secretAccessKey | quote }}
+{{- end }}

--- a/helm/semaphore-chat/values.yaml
+++ b/helm/semaphore-chat/values.yaml
@@ -449,6 +449,57 @@ fileStorage:
   # Example custom options: ["nfsvers=4.1", "hard", "tcp"]
   # mountOptions: []
 
+  # S3-compatible object storage for uploads (avatars, attachments). When
+  # enabled, sets STORAGE_TYPE=S3 on the backend so new uploads write
+  # directly to the bucket instead of the local uploads PVC — this removes
+  # the RWX/NFS requirement for multi-replica deployments entirely (see
+  # semaphore-chat.validateFileStorage in _helpers.tpl).
+  #
+  # If fileStorage.enabled is ALSO true, the uploads PVC still gets created
+  # and mounted — that's "mixed mode": files uploaded before switching to S3
+  # (STORAGE_TYPE=LOCAL) remain on the PVC and are served from there, so the
+  # PVC's accessMode/RWX requirements still apply to it at >1 backend
+  # replicas. Once no LOCAL-storage files remain, set fileStorage.enabled to
+  # false to drop the PVC requirement completely.
+  s3:
+    # Set true to use S3 (or an S3-compatible provider) for file uploads.
+    enabled: false
+
+    # S3 bucket name. Required when s3.enabled=true.
+    bucket: ""
+
+    # AWS region, or the region your S3-compatible provider expects.
+    # Required when s3.enabled=true.
+    region: ""
+
+    # Custom S3 endpoint for S3-compatible providers (MinIO, R2, Backblaze
+    # B2, etc.). Leave empty ("") to use AWS S3's default endpoint for the
+    # configured region.
+    endpoint: ""
+
+    # Use path-style addressing (https://endpoint/bucket/key) instead of
+    # virtual-hosted-style (https://bucket.endpoint/key). Most self-hosted
+    # S3-compatible providers (e.g. MinIO) require this; leave false for AWS
+    # S3.
+    forcePathStyle: false
+
+    # Name of a pre-existing Kubernetes Secret containing the S3 credentials.
+    # Preferred over the inline accessKeyId/secretAccessKey below (keeps
+    # credentials out of `helm get values` / release history). When set, the
+    # inline credential values are ignored and no chart-managed Secret is
+    # created for S3 credentials.
+    existingSecret: ""
+    # Key within existingSecret holding the access key ID.
+    existingSecretAccessKeyIdKey: "S3_ACCESS_KEY_ID"
+    # Key within existingSecret holding the secret access key.
+    existingSecretSecretAccessKeyKey: "S3_SECRET_ACCESS_KEY"
+
+    # Inline credentials, used only when existingSecret is empty. Rendered
+    # into a chart-managed Secret (<release>-s3-secret) the same way
+    # secrets.jwtSecret etc. are rendered into <release>-secrets.
+    accessKeyId: ""
+    secretAccessKey: ""
+
 # ============================================
 # Replay Segments Storage Configuration
 # ============================================


### PR DESCRIPTION
## Summary
- Completes the #427 follow-up: the chart can now configure the S3 storage backend — `fileStorage.s3` block (bucket/region/endpoint/forcePathStyle) with credentials via `existingSecret` (preferred) or inline values rendered into a chart-managed Secret (mirroring the chart's existing secret conventions; credentials never appear outside a Secret manifest).
- Relaxes #417's multi-replica guard where S3 makes it safe: S3-on + PVC-off renders at any replica count (uploads go to S3, no PVC exists); S3-on + PVC-on (mixed mode serving legacy LOCAL files) keeps the RWO/RWX guard with a reworded message; S3-off is manifest-byte-identical to current main (proven by render diff).
- `region` is required alongside `bucket` (matches the backend's `S3_REGION` validation — a render that succeeded without it would crash-loop the backend); all required fields fail fast at render time.

## Test plan
- `helm lint --strict` clean; 11-scenario template matrix (guard truth table incl. both contested mixed-mode cells, secret-hygiene both credential routes, fail-fast cases) — reviewer independently re-ran 3 scenarios live against the commit.

Minor follow-ups noted in review: NOTES.txt wording appears on default installs; blank custom secret-key-name overrides render an invalid secretKeyRef; unconditional `FILE_UPLOAD_DEST` under S3-only mode (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sAJfCfBfMm8chbZMsh5Y5