### PR TITLE
feat(a11y): message-list keyboard navigation and screen-reader announcements

### DIFF
--- a/frontend/src/__tests__/components/MessageComponent.contextMenu.test.tsx
+++ b/frontend/src/__tests__/components/MessageComponent.contextMenu.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { renderWithProviders, runAxe, expectNoAxeViolations } from '../test-utils';
@@ -139,6 +140,70 @@ describe('MessageComponent context menu (web)', () => {
     await waitFor(() => {
       expect(document.activeElement).toBe(messageRow);
     });
+  });
+
+  it('falls back to the list container when the row unmounts before the deferred focus-restore frame runs', async () => {
+    // Mirrors MemberList.contextMenuFocusRestore.test.tsx's "detached-node"
+    // case: a message row can disappear from the loaded window (pagination
+    // cap eviction) while its context menu is still in the middle of
+    // closing — restoreFocus's fallback must land on the list container
+    // instead of silently dropping focus to <body>.
+    //
+    // Unlike MemberList (whose menu is owned by the LIST, decoupled from
+    // the row), MessageContextMenu is a child of MessageComponent itself —
+    // removing the row also tears down the menu, so the row can't be
+    // removed *before* Escape the way MemberList's test does (there'd be no
+    // menu left to fire Escape on). Instead this pins down the actual race:
+    // restoreFocus's requestAnimationFrame is captured (not run) so the row
+    // can be removed in the gap between "Escape closed the menu" and "the
+    // deferred frame actually executes" — real rAF fires within ~1 frame,
+    // too fast to reliably interleave a synchronous rerender otherwise.
+    const rafCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    });
+
+    try {
+      const message = createMessage({
+        spans: [{ type: SpanType.PLAINTEXT, text: 'Removable message' }],
+      });
+
+      function Wrapper({ show }: { show: boolean }) {
+        const listRef = React.useRef<HTMLDivElement>(null);
+        return (
+          <div ref={listRef} tabIndex={-1} data-testid="list-container">
+            {show && <MessageComponent message={message} listContainerRef={listRef} />}
+          </div>
+        );
+      }
+
+      const { rerender } = renderWithProviders(<Wrapper show={true} />);
+
+      fireEvent.contextMenu(screen.getByText('Removable message'), {
+        clientX: 10,
+        clientY: 10,
+      });
+      const menu = await screen.findByRole('menu');
+
+      // MUI calls onClose synchronously for Escape (ahead of the exit
+      // transition), so handleCloseContextMenu — and the requestAnimationFrame
+      // it schedules — has already run by the time this returns.
+      fireEvent.keyDown(menu, { key: 'Escape' });
+      expect(rafCallbacks.length).toBeGreaterThan(0);
+
+      // The row is removed from the tree before the deferred frame runs.
+      rerender(<Wrapper show={false} />);
+      expect(screen.queryByText('Removable message')).not.toBeInTheDocument();
+
+      act(() => {
+        rafCallbacks.forEach((cb) => cb(0));
+      });
+
+      expect(document.activeElement).toBe(screen.getByTestId('list-container'));
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('has no axe violations while the context menu is open', async () => {

--- a/frontend/src/__tests__/components/MessageContainer.test.tsx
+++ b/frontend/src/__tests__/components/MessageContainer.test.tsx
@@ -3,6 +3,7 @@ import { screen, act } from '@testing-library/react';
 import { renderWithProviders } from '../test-utils';
 import MessageContainer from '../../components/Message/MessageContainer';
 import { createMessage, resetFactoryCounter } from '../test-utils/factories';
+import { SpanType } from '../../types/message.type';
 
 // ── Mock child components ──────────────────────────────────────────────
 vi.mock('../../components/Message/MessageSkeleton', () => ({
@@ -648,6 +649,134 @@ describe('MessageContainer', () => {
       act(() => (lastVirtualListProps!.onVisibleRangeChange as (s: number, e: number) => void)(5, 2));
       act(() => (lastVirtualListProps!.onVisibleRangeChange as (s: number, e: number) => void)(0, -1));
       expect(mockMarkAsRead).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── aria-live announcements (useMessageListAnnouncer wiring) ─────────
+  describe('live-region announcements', () => {
+    const otherMessage = (id: string, text: string) =>
+      createMessage({
+        id,
+        authorId: 'other-user',
+        spans: [{ type: SpanType.PLAINTEXT, text }],
+      });
+    const ownMessage = (id: string, text: string) =>
+      createMessage({
+        id,
+        authorId: 'current-user-1',
+        spans: [{ type: SpanType.PLAINTEXT, text }],
+      });
+
+    function liveRegionText(): string {
+      return screen.getByTestId('message-list-live-region').textContent ?? '';
+    }
+
+    function setAtBottom(atBottom: boolean) {
+      act(() => {
+        (lastVirtualListProps!.onAtBottomChange as (b: boolean) => void)(atBottom);
+      });
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    async function flushAnnouncer() {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2100);
+      });
+    }
+
+    it('is silent for the initial page load (no baseline "new message" spam)', async () => {
+      renderWithProviders(
+        <MessageContainer
+          {...defaultProps}
+          messages={[otherMessage('m1', 'hello there')]}
+          channelId="ch-1"
+        />,
+      );
+      await flushAnnouncer();
+      expect(liveRegionText()).toBe('');
+    });
+
+    it('announces a new message from another author when not at the live edge', async () => {
+      const initial = [otherMessage('m1', 'hello there')];
+      const { rerender } = renderWithProviders(
+        <MessageContainer {...defaultProps} messages={initial} channelId="ch-1" />,
+      );
+      setAtBottom(false);
+
+      const withNew = [otherMessage('m2', 'second message'), ...initial];
+      rerender(<MessageContainer {...defaultProps} messages={withNew} channelId="ch-1" />);
+
+      await flushAnnouncer();
+      expect(liveRegionText()).toContain('second message');
+    });
+
+    it('does not announce while at the bottom (message already visible)', async () => {
+      const initial = [otherMessage('m1', 'hello there')];
+      const { rerender } = renderWithProviders(
+        <MessageContainer {...defaultProps} messages={initial} channelId="ch-1" />,
+      );
+      // atBottom defaults to true — never toggled false here.
+
+      const withNew = [otherMessage('m2', 'second message'), ...initial];
+      rerender(<MessageContainer {...defaultProps} messages={withNew} channelId="ch-1" />);
+
+      await flushAnnouncer();
+      expect(liveRegionText()).toBe('');
+    });
+
+    it('does not announce the reader\'s own messages', async () => {
+      const initial = [otherMessage('m1', 'hello there')];
+      const { rerender } = renderWithProviders(
+        <MessageContainer {...defaultProps} messages={initial} channelId="ch-1" />,
+      );
+      setAtBottom(false);
+
+      const withOwn = [ownMessage('m2', 'my own message'), ...initial];
+      rerender(<MessageContainer {...defaultProps} messages={withOwn} channelId="ch-1" />);
+
+      await flushAnnouncer();
+      expect(liveRegionText()).toBe('');
+    });
+
+    it('coalesces several messages arriving within the batch window into a count', async () => {
+      const initial = [otherMessage('m1', 'hello there')];
+      const { rerender } = renderWithProviders(
+        <MessageContainer {...defaultProps} messages={initial} channelId="ch-1" />,
+      );
+      setAtBottom(false);
+
+      const withNew = [
+        otherMessage('m3', 'third'),
+        otherMessage('m2', 'second'),
+        ...initial,
+      ];
+      rerender(<MessageContainer {...defaultProps} messages={withNew} channelId="ch-1" />);
+
+      await flushAnnouncer();
+      expect(liveRegionText()).toContain('2 new messages');
+    });
+
+    it('does not announce across a channel switch (baseline resets, not a "new message")', async () => {
+      const initial = [otherMessage('m1', 'hello there')];
+      const { rerender } = renderWithProviders(
+        <MessageContainer {...defaultProps} messages={initial} channelId="ch-1" />,
+      );
+      setAtBottom(false);
+
+      const otherChannelMessages = [otherMessage('m2', 'a different channel')];
+      rerender(
+        <MessageContainer {...defaultProps} messages={otherChannelMessages} channelId="ch-2" />,
+      );
+
+      await flushAnnouncer();
+      expect(liveRegionText()).toBe('');
     });
   });
 });

--- a/frontend/src/__tests__/components/VirtualMessageList.rovingFocus.test.tsx
+++ b/frontend/src/__tests__/components/VirtualMessageList.rovingFocus.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fireEvent, screen, cleanup } from '@testing-library/react';
+import { act, fireEvent, screen, cleanup } from '@testing-library/react';
 import { renderWithProviders, runAxe, expectNoAxeViolations } from '../test-utils';
 import VirtualMessageList from '../../components/Message/VirtualMessageList';
 import { createMessage, resetFactoryCounter } from '../test-utils/factories';
@@ -20,6 +20,10 @@ import { SpanType } from '../../types/message.type';
  * in moveFocus succeeds on its first attempt here (the target row is always
  * already present), consistent with how VirtualMessageList.test.tsx already
  * runs requestAnimationFrame synchronously.
+ *
+ * Exception: the "rAF-retry supersession" describe below re-stubs rAF with a
+ * manually-flushed queue (NOT synchronous) — interleaving two overlapping
+ * moveFocus retry loops requires controlling exactly when each frame fires.
  */
 
 vi.mock('../../utils/platform', () => ({
@@ -281,6 +285,183 @@ describe('VirtualMessageList roving row focus', () => {
     const textNode = screen.getByText('one');
     fireEvent.keyDown(textNode, { key: 'Escape' });
     expect(onEscapeToInput).not.toHaveBeenCalled();
+  });
+
+  it('mode switch resets roving focus to the mode default even when the focused row id still resolves', () => {
+    const messages = [
+      msg('m1', 'one'),
+      msg('m2', 'two'),
+      msg('m3', 'three'),
+      msg('m4', 'four'),
+      msg('m5', 'five'),
+    ];
+    const { rerender } = renderWithProviders(
+      <VirtualMessageList {...baseProps} orderedMessages={messages} />,
+    );
+    fireEvent.keyDown(rowFor('five'), { key: 'Home' }); // -> 'one'
+    expect(rowFor('one')).toHaveAttribute('tabindex', '0');
+
+    rerender(
+      <VirtualMessageList {...baseProps} orderedMessages={messages} mode="anchored" />,
+    );
+
+    // 'm1' still resolves in the new data window (same array), but the mode
+    // switch must reset the roving target to anchored mode's own default
+    // (the centered row), not silently carry the stale key over.
+    expect(rowFor('one')).toHaveAttribute('tabindex', '-1');
+    expect(rowFor('three')).toHaveAttribute('tabindex', '0');
+  });
+
+  it('applies a themed :focus-visible outline rule to the row container', () => {
+    renderWithProviders(
+      <VirtualMessageList {...baseProps} orderedMessages={[msg('m1', 'one')]} />,
+    );
+    const row = rowFor('one');
+    // Emotion inserts component styles as <style> tags; assert the row's own
+    // generated class carries a :focus-visible outline (the themed focus
+    // ring), rather than relying on the browser default outline.
+    const css = Array.from(document.querySelectorAll('style'))
+      .map(
+        (tag) =>
+          tag.textContent ||
+          Array.from(tag.sheet?.cssRules ?? [])
+            .map((rule) => rule.cssText)
+            .join('\n'),
+      )
+      .join('\n');
+    const hasFocusRing = Array.from(row.classList).some((cls) => {
+      const idx = css.indexOf(`.${cls}:focus-visible`);
+      return idx !== -1 && css.slice(idx, idx + 300).includes('outline');
+    });
+    expect(hasFocusRing).toBe(true);
+  });
+
+  describe('rAF-retry supersession', () => {
+    /** Replaces the synchronous rAF stub with a manually-flushed queue so
+     * two moveFocus retry loops can be genuinely interleaved. Returns the
+     * queue plus a helper that diffs which frame ids a callback scheduled. */
+    function installRafQueue({ inertCancel }: { inertCancel: boolean }) {
+      const queue = new Map<number, FrameRequestCallback>();
+      const cancelled = new Set<number>();
+      let nextRafId = 1;
+      vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+        const id = nextRafId++;
+        queue.set(id, cb);
+        return id;
+      });
+      vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+        cancelled.add(id);
+        if (!inertCancel) queue.delete(id);
+      });
+      const newFramesSince = (before: Set<number>) =>
+        [...queue.keys()].filter((id) => !before.has(id));
+      const snapshot = () => new Set(queue.keys());
+      const scheduledCount = () => nextRafId - 1;
+      return { queue, cancelled, snapshot, newFramesSince, scheduledCount };
+    }
+
+    it('a superseded moveFocus loop never applies focus, even when its frame resolves last', () => {
+      // cancelAnimationFrame is deliberately INERT here: it simulates the
+      // stale frame having already been dequeued past the point of
+      // cancellation, proving the seq guard ALONE prevents the stale focus
+      // (cancellation is only an optimization on top of it).
+      const { queue, snapshot, newFramesSince, scheduledCount } = installRafQueue({
+        inertCancel: true,
+      });
+
+      renderWithProviders(
+        <VirtualMessageList
+          {...baseProps}
+          orderedMessages={[msg('m1', 'one'), msg('m2', 'two'), msg('m3', 'three')]}
+        />,
+      );
+
+      // First navigation: targets 'two', schedules its retry frame (queued,
+      // NOT yet run).
+      const beforeFirst = snapshot();
+      fireEvent.keyDown(rowFor('three'), { key: 'ArrowUp' });
+      const staleFrames = newFramesSince(beforeFirst);
+      expect(staleFrames).toHaveLength(1);
+      const staleId = staleFrames[0];
+
+      // Second navigation lands before the first loop's frame ever fires:
+      // targets 'one', supersedes the first loop.
+      const beforeSecond = snapshot();
+      fireEvent.keyDown(rowFor('two'), { key: 'ArrowUp' });
+      const liveFrames = newFramesSince(beforeSecond).filter((id) => id !== staleId);
+      expect(liveFrames).toHaveLength(1);
+      const liveId = liveFrames[0];
+
+      // Record every element that actually receives DOM focus from here on
+      // (focusin bubbles to document), so an intermediate stale focus can't
+      // hide behind a later correct activeElement.
+      const focusedTargets: EventTarget[] = [];
+      const recordFocus = (event: FocusEvent) => {
+        if (event.target) focusedTargets.push(event.target);
+      };
+      document.addEventListener('focusin', recordFocus);
+      try {
+        // The NEWER loop's frame resolves first and focuses its target...
+        act(() => queue.get(liveId)!(0));
+        expect(document.activeElement).toBe(rowFor('one'));
+
+        // ...then the SUPERSEDED loop's frame fires last (worst-case order —
+        // exactly the race where "last writer wins" would corrupt focus).
+        const scheduledBeforeStale = scheduledCount();
+        act(() => queue.get(staleId)!(0));
+
+        // The stale loop must abort: no focus applied to its old target, no
+        // reschedule of further frames, roving state still on the new target.
+        expect(focusedTargets).not.toContain(rowFor('two'));
+        expect(document.activeElement).toBe(rowFor('one'));
+        expect(scheduledCount()).toBe(scheduledBeforeStale);
+        expect(rowFor('one')).toHaveAttribute('tabindex', '0');
+        expect(rowFor('two')).toHaveAttribute('tabindex', '-1');
+      } finally {
+        document.removeEventListener('focusin', recordFocus);
+      }
+    });
+
+    it('a superseding call cancels the previous pending retry frame outright', () => {
+      const { cancelled, snapshot, newFramesSince } = installRafQueue({
+        inertCancel: false,
+      });
+
+      renderWithProviders(
+        <VirtualMessageList
+          {...baseProps}
+          orderedMessages={[msg('m1', 'one'), msg('m2', 'two'), msg('m3', 'three')]}
+        />,
+      );
+
+      const before = snapshot();
+      fireEvent.keyDown(rowFor('three'), { key: 'ArrowUp' });
+      const [staleId] = newFramesSince(before);
+
+      fireEvent.keyDown(rowFor('two'), { key: 'ArrowUp' });
+      expect(cancelled.has(staleId)).toBe(true);
+    });
+
+    it('unmount cancels the pending moveFocus retry frame', () => {
+      const { cancelled, snapshot, newFramesSince } = installRafQueue({
+        inertCancel: false,
+      });
+
+      const { unmount } = renderWithProviders(
+        <VirtualMessageList
+          {...baseProps}
+          orderedMessages={[msg('m1', 'one'), msg('m2', 'two')]}
+        />,
+      );
+
+      const before = snapshot();
+      fireEvent.keyDown(rowFor('two'), { key: 'ArrowUp' });
+      const [pendingFocusFrame] = newFramesSince(before);
+      expect(pendingFocusFrame).toBeDefined();
+
+      unmount();
+      expect(cancelled.has(pendingFocusFrame)).toBe(true);
+    });
   });
 
   describe('list semantics', () => {

--- a/frontend/src/__tests__/components/VirtualMessageList.rovingFocus.test.tsx
+++ b/frontend/src/__tests__/components/VirtualMessageList.rovingFocus.test.tsx
@@ -1,0 +1,310 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, screen, cleanup } from '@testing-library/react';
+import { renderWithProviders, runAxe, expectNoAxeViolations } from '../test-utils';
+import VirtualMessageList from '../../components/Message/VirtualMessageList';
+import { createMessage, resetFactoryCounter } from '../test-utils/factories';
+import { SpanType } from '../../types/message.type';
+
+/**
+ * Roving row-focus keyboard navigation + list semantics.
+ *
+ * Unlike VirtualMessageList.test.tsx (which mocks MessageComponent to a
+ * plain stub, keeping the unit boundary at "does VirtualMessageList wire
+ * virtua correctly"), this file renders the REAL MessageComponent so the
+ * full roving-focus path — Container's tabIndex/onKeyDown/onFocus wiring,
+ * guarded against bubbled events from descendant controls, and the
+ * Enter/ContextMenu-opens-menu integration — is exercised end-to-end.
+ * `virtua` is still mocked (jsdom can't do real layout/virtualization),
+ * rendering every row unconditionally — which also means the rAF-retry loop
+ * in moveFocus succeeds on its first attempt here (the target row is always
+ * already present), consistent with how VirtualMessageList.test.tsx already
+ * runs requestAnimationFrame synchronously.
+ */
+
+vi.mock('../../utils/platform', () => ({
+  isElectron: vi.fn(() => false),
+  isWeb: vi.fn(() => true),
+}));
+vi.mock('../../utils/clipboard', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: { id: 'current-user', username: 'alice' } }),
+}));
+vi.mock('../../contexts/UserProfileContext', () => ({
+  useUserProfile: () => ({ openProfile: vi.fn() }),
+}));
+vi.mock('../../components/Common/UserAvatar', () => ({
+  default: () => <div data-testid="avatar" />,
+}));
+
+const mockPermissions = {
+  canEdit: true,
+  canDelete: true,
+  canPin: true,
+  canReact: true,
+  isOwnMessage: true,
+};
+vi.mock('../../hooks/useMessagePermissions', () => ({
+  useMessagePermissions: () => mockPermissions,
+}));
+
+const mockActions = {
+  isEditing: false,
+  editText: '',
+  editAttachments: [],
+  stagedForDelete: false,
+  isDeleting: false,
+  setEditText: vi.fn(),
+  handleEditClick: vi.fn(),
+  handleEditSave: vi.fn(),
+  handleEditCancel: vi.fn(),
+  handleRemoveAttachment: vi.fn(),
+  handleDeleteClick: vi.fn(),
+  handleConfirmDelete: vi.fn(),
+  handleCancelDelete: vi.fn(),
+  handleConfirmThreadDelete: vi.fn(),
+  handleCancelThreadDelete: vi.fn(),
+  showThreadDeleteConfirm: false,
+  handleReactionClick: vi.fn(),
+  handleEmojiSelect: vi.fn(),
+  handlePin: vi.fn(),
+  handleUnpin: vi.fn(),
+};
+vi.mock('../../components/Message/useMessageActions', () => ({
+  useMessageActions: () => mockActions,
+}));
+
+vi.mock('virtua', async () => {
+  const ReactMod = await import('react');
+  return {
+    VList: ReactMod.forwardRef(
+      (props: Record<string, unknown>, ref: React.Ref<unknown>) => {
+        ReactMod.useImperativeHandle(
+          ref,
+          () => ({
+            scrollToIndex: vi.fn(),
+            scrollTo: vi.fn(),
+            scrollBy: vi.fn(),
+            findItemIndex: vi.fn(() => 0),
+            getItemOffset: vi.fn(() => 0),
+            getItemSize: vi.fn(() => 0),
+            scrollOffset: 0,
+            scrollSize: 1000,
+            viewportSize: 400,
+            cache: {},
+          }),
+          [],
+        );
+        return (
+          <div
+            data-testid="vlist"
+            role={props.role as string | undefined}
+            aria-label={props['aria-label'] as string | undefined}
+          >
+            {props.children as React.ReactNode}
+          </div>
+        );
+      },
+    ),
+  };
+});
+
+function msg(id: string, text: string) {
+  return createMessage({ id, spans: [{ type: SpanType.PLAINTEXT, text }] });
+}
+
+function rowFor(text: string): HTMLElement {
+  const node = screen.getByText(text);
+  const row = node.closest('[data-row-focus-target]');
+  if (!row) throw new Error(`row focus target not found for "${text}"`);
+  return row as HTMLElement;
+}
+
+const baseProps = {
+  authorId: 'current-user',
+  isLoadingMore: false,
+  unreadCount: 0,
+  lastReadIndex: -1,
+};
+
+beforeEach(() => {
+  resetFactoryCounter();
+  // rAF runs synchronously — the mocked VList renders every row
+  // unconditionally, so moveFocus's retry loop always finds its target on
+  // the first attempt.
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('VirtualMessageList roving row focus', () => {
+  it('lands the initial roving-tabindex target on the newest row', () => {
+    renderWithProviders(
+      <VirtualMessageList
+        {...baseProps}
+        orderedMessages={[msg('m1', 'one'), msg('m2', 'two'), msg('m3', 'three')]}
+      />,
+    );
+    expect(rowFor('three')).toHaveAttribute('tabindex', '0');
+    expect(rowFor('one')).toHaveAttribute('tabindex', '-1');
+    expect(rowFor('two')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('ArrowUp moves the roving target and DOM focus to the previous row', () => {
+    renderWithProviders(
+      <VirtualMessageList
+        {...baseProps}
+        orderedMessages={[msg('m1', 'one'), msg('m2', 'two'), msg('m3', 'three')]}
+      />,
+    );
+    fireEvent.keyDown(rowFor('three'), { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(rowFor('two'));
+    expect(rowFor('two')).toHaveAttribute('tabindex', '0');
+    expect(rowFor('three')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('ArrowDown moves focus forward', () => {
+    renderWithProviders(
+      <VirtualMessageList
+        {...baseProps}
+        orderedMessages={[msg('m1', 'one'), msg('m2', 'two'), msg('m3', 'three')]}
+      />,
+    );
+    fireEvent.keyDown(rowFor('three'), { key: 'ArrowUp' }); // now on 'two'
+    fireEvent.keyDown(rowFor('two'), { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(rowFor('three'));
+  });
+
+  it('clamps at the top and bottom edges (no-op past the first/last row)', () => {
+    renderWithProviders(
+      <VirtualMessageList {...baseProps} orderedMessages={[msg('m1', 'one'), msg('m2', 'two')]} />,
+    );
+    fireEvent.keyDown(rowFor('two'), { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(rowFor('two'));
+
+    fireEvent.keyDown(rowFor('two'), { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(rowFor('one'));
+    fireEvent.keyDown(rowFor('one'), { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(rowFor('one'));
+  });
+
+  it('Home moves focus to the oldest-loaded row, End to the newest', () => {
+    renderWithProviders(
+      <VirtualMessageList
+        {...baseProps}
+        orderedMessages={[msg('m1', 'one'), msg('m2', 'two'), msg('m3', 'three')]}
+      />,
+    );
+    fireEvent.keyDown(rowFor('three'), { key: 'Home' });
+    expect(document.activeElement).toBe(rowFor('one'));
+    fireEvent.keyDown(rowFor('one'), { key: 'End' });
+    expect(document.activeElement).toBe(rowFor('three'));
+  });
+
+  it('keeps the roving target on the same message across a re-render (new message appended)', () => {
+    const { rerender } = renderWithProviders(
+      <VirtualMessageList
+        {...baseProps}
+        orderedMessages={[msg('m1', 'one'), msg('m2', 'two'), msg('m3', 'three')]}
+      />,
+    );
+    fireEvent.keyDown(rowFor('three'), { key: 'ArrowUp' }); // -> 'two'
+    expect(rowFor('two')).toHaveAttribute('tabindex', '0');
+
+    rerender(
+      <VirtualMessageList
+        {...baseProps}
+        orderedMessages={[
+          msg('m1', 'one'),
+          msg('m2', 'two'),
+          msg('m3', 'three'),
+          msg('m4', 'four'),
+        ]}
+      />,
+    );
+    // Still 'two' — not reset to the new newest row just because a message arrived.
+    expect(rowFor('two')).toHaveAttribute('tabindex', '0');
+    expect(rowFor('four')).toHaveAttribute('tabindex', '-1');
+
+    fireEvent.keyDown(rowFor('two'), { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(rowFor('three'));
+  });
+
+  it('Escape (no menu open) calls onEscapeToInput', () => {
+    const onEscapeToInput = vi.fn();
+    renderWithProviders(
+      <VirtualMessageList
+        {...baseProps}
+        orderedMessages={[msg('m1', 'one')]}
+        onEscapeToInput={onEscapeToInput}
+      />,
+    );
+    fireEvent.keyDown(rowFor('one'), { key: 'Escape' });
+    expect(onEscapeToInput).toHaveBeenCalledTimes(1);
+  });
+
+  it('Enter opens the row context menu', async () => {
+    renderWithProviders(
+      <VirtualMessageList {...baseProps} orderedMessages={[msg('m1', 'one')]} />,
+    );
+    fireEvent.keyDown(rowFor('one'), { key: 'Enter' });
+    expect(await screen.findByRole('menu')).toBeInTheDocument();
+    expect(screen.getByText('Edit Message')).toBeInTheDocument();
+  });
+
+  it('ContextMenu key also opens the row context menu', async () => {
+    renderWithProviders(
+      <VirtualMessageList {...baseProps} orderedMessages={[msg('m1', 'one')]} />,
+    );
+    fireEvent.keyDown(rowFor('one'), { key: 'ContextMenu' });
+    expect(await screen.findByRole('menu')).toBeInTheDocument();
+  });
+
+  it('does not hijack keys bubbling from a descendant control (only the row itself is a valid target)', () => {
+    const onEscapeToInput = vi.fn();
+    renderWithProviders(
+      <VirtualMessageList
+        {...baseProps}
+        orderedMessages={[msg('m1', 'one')]}
+        onEscapeToInput={onEscapeToInput}
+      />,
+    );
+    const textNode = screen.getByText('one');
+    fireEvent.keyDown(textNode, { key: 'Escape' });
+    expect(onEscapeToInput).not.toHaveBeenCalled();
+  });
+
+  describe('list semantics', () => {
+    it('uses role="list" with an accessible name, and role="listitem" per row', () => {
+      renderWithProviders(
+        <VirtualMessageList {...baseProps} orderedMessages={[msg('m1', 'one'), msg('m2', 'two')]} />,
+      );
+      expect(screen.getByRole('list', { name: 'Messages' })).toBeInTheDocument();
+      expect(screen.getAllByRole('listitem').length).toBe(2);
+    });
+
+    it('has no axe violations across a small rendered list', async () => {
+      renderWithProviders(
+        <VirtualMessageList
+          {...baseProps}
+          orderedMessages={[msg('m1', 'one'), msg('m2', 'two'), msg('m3', 'three')]}
+        />,
+      );
+      // Bounded to WCAG A/AA tags — see EmojiPickerPopover.test.tsx for why
+      // (axe's full default rule set is too slow per-node under coverage).
+      const results = await runAxe(document.body, {
+        runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa'] },
+      });
+      expectNoAxeViolations(results);
+    }, 60000);
+  });
+});

--- a/frontend/src/components/Message/MessageComponent.tsx
+++ b/frontend/src/components/Message/MessageComponent.tsx
@@ -51,6 +51,25 @@ interface MessageProps {
   onQuoteReply?: (message: MessageType) => void;
   /** Context type to determine if read receipts should be shown */
   contextType?: VoiceSessionType;
+
+  // ── Roving row focus (keyboard navigation across the message list) ──
+  /** This row's position in the rendered (chronological) order. Required for
+   * roving-focus key handling to report the right target to the parent. */
+  rowIndex?: number;
+  /** True when this row is the current roving-tabindex target (tabIndex=0). */
+  isRovingFocused?: boolean;
+  /** ArrowUp/Down/Home/End/Escape, delegated up — the parent owns index math,
+   * scrolling the target into view, and imperatively focusing it once mounted. */
+  onRovingKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>, index: number) => void;
+  /** Fired when this row's Container actually receives DOM focus (Tab, a
+   * mouse-driven restore, or the parent's own imperative focus after an
+   * arrow-key move) — keeps the parent's roving-tabindex state in sync with
+   * reality regardless of how focus got here. */
+  onRovingFocus?: (index: number) => void;
+  /** Stable ref to the list's scroll container — passed to the context-menu
+   * focus-restore fallback so a row deleted while its menu is still closing
+   * doesn't drop focus to <body> (mirrors MemberList's wiring from #428). */
+  listContainerRef?: React.RefObject<HTMLElement | null>;
 }
 
 function MessageComponentInner({
@@ -64,6 +83,11 @@ function MessageComponentInner({
   onOpenThread,
   onQuoteReply,
   contextType,
+  rowIndex,
+  isRovingFocused,
+  onRovingKeyDown,
+  onRovingFocus,
+  listContainerRef,
 }: MessageProps) {
   // Community custom emojis (for rendering EMOJI spans + custom reactions).
   const { byId: emojiById } = useCommunityCustomEmojis(communityId);
@@ -145,15 +169,56 @@ function MessageComponentInner({
     event.preventDefault();
     captureTrigger(event.currentTarget as HTMLElement);
     setContextMenuPosition({ top: event.clientY, left: event.clientX });
-  }, [captureTrigger]);
+    // Right-click also claims the roving-tabindex slot for this row, so
+    // keyboard navigation resumes from here once the menu closes (instead of
+    // wherever it happened to be before the click).
+    if (rowIndex !== undefined) onRovingFocus?.(rowIndex);
+  }, [captureTrigger, rowIndex, onRovingFocus]);
 
   const handleCloseContextMenu = useCallback(() => {
     setContextMenuPosition(null);
     // Right-click (and long-press) open this menu with no keyboard-reachable
     // invoker button, so — unlike an anchorEl Menu — MUI can't auto-restore
-    // focus. Return it to the message row itself.
-    restoreFocus();
-  }, [restoreFocus]);
+    // focus. Return it to the message row itself. If the row was removed
+    // from the list while the menu was still closing (e.g. deleted), fall
+    // back to the list's scroll container instead of dropping to <body>.
+    restoreFocus(listContainerRef?.current);
+  }, [restoreFocus, listContainerRef]);
+
+  /**
+   * Enter / ContextMenu (menu key) / Shift+F10 open the row's action menu
+   * from the keyboard, positioned near the focused row itself (there's no
+   * MouseEvent to read a click position from). Guarded to only fire when the
+   * Container itself is the focus target — bubbled keydowns from the edit
+   * textarea, toolbar buttons, or menu items must not be hijacked.
+   */
+  const handleContainerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.target !== event.currentTarget) return;
+
+      if (
+        event.key === 'Enter' ||
+        event.key === 'ContextMenu' ||
+        (event.shiftKey && event.key === 'F10')
+      ) {
+        event.preventDefault();
+        const rect = event.currentTarget.getBoundingClientRect();
+        captureTrigger(event.currentTarget);
+        setContextMenuPosition({ top: rect.bottom, left: rect.left });
+        if (rowIndex !== undefined) onRovingFocus?.(rowIndex);
+        return;
+      }
+
+      if (rowIndex !== undefined) {
+        onRovingKeyDown?.(event, rowIndex);
+      }
+    },
+    [captureTrigger, rowIndex, onRovingFocus, onRovingKeyDown],
+  );
+
+  const handleContainerFocus = useCallback(() => {
+    if (rowIndex !== undefined) onRovingFocus?.(rowIndex);
+  }, [rowIndex, onRovingFocus]);
 
   const handleAddReaction = useCallback(() => {
     // Save position for emoji picker, close context menu
@@ -182,8 +247,9 @@ function MessageComponentInner({
     // reached via the context menu, so closing the emoji picker should
     // return focus to the message row too (a no-op if it was opened via
     // the touch sheet instead, since no trigger was captured for that path).
-    restoreFocus();
-  }, [restoreFocus]);
+    // Same list-container fallback as handleCloseContextMenu.
+    restoreFocus(listContainerRef?.current);
+  }, [restoreFocus, listContainerRef]);
 
   // Under touch UI, wire long-press handlers and suppress native selection /
   // context menu; otherwise keep desktop right-click behavior untouched.
@@ -210,9 +276,13 @@ function MessageComponentInner({
       isSearchHighlight={isSearchHighlight}
       isPending={isPending}
       isFailed={isFailed}
-      // Not in tab order (-1) — only focused programmatically, to restore
-      // focus here after the right-click/long-press context menu closes.
-      tabIndex={-1}
+      // Roving tabindex: only the current roving-focus row is in the natural
+      // Tab order (0); every other row is -1 — still focusable
+      // programmatically (context-menu restore, arrow-key navigation).
+      tabIndex={isRovingFocused ? 0 : -1}
+      data-row-focus-target="true"
+      onKeyDown={handleContainerKeyDown}
+      onFocus={handleContainerFocus}
       {...containerInteractionProps}
     >
       <div style={{ marginRight: 12, marginTop: 4 }}>
@@ -465,6 +535,12 @@ const MessageComponent = React.memo(MessageComponentInner, (prevProps, nextProps
     prevProps.isThreadReply === nextProps.isThreadReply &&
     prevProps.isAuthor === nextProps.isAuthor &&
     prevProps.contextType === nextProps.contextType &&
+    // Roving-focus wiring: these genuinely change per-row across renders
+    // (a prepend shifts rowIndex; focus moving changes isRovingFocused for
+    // exactly two rows) and must not be skipped by the memo, or a row can
+    // end up with a stale index closure or a stuck tabIndex.
+    prevProps.rowIndex === nextProps.rowIndex &&
+    prevProps.isRovingFocused === nextProps.isRovingFocused &&
     // Deep compare spans array (content equality, not reference)
     prevMsg.spans.length === nextMsg.spans.length &&
     prevMsg.spans.every((s, i) =>

--- a/frontend/src/components/Message/MessageComponentStyles.tsx
+++ b/frontend/src/components/Message/MessageComponentStyles.tsx
@@ -100,4 +100,15 @@ export const Container = styled("div", {
       opacity: 0,
     },
   },
+  // Roving-tabindex focus ring: mirrors the app's other themed
+  // `outline: 2px solid` treatment (see TrimTimeline's trim-handle
+  // `&:focus` styling) rather than relying on the browser default outline,
+  // which is invisible against this Container's own border/background
+  // states above. `:focus-visible` (not `:focus`) so a mouse/touch click
+  // that also focuses the row (context menu, restoreFocus fallback) doesn't
+  // draw the ring — only real keyboard navigation does.
+  "&:focus-visible": {
+    outline: `2px solid ${theme.palette.primary.main}`,
+    outlineOffset: -2,
+  },
 }));

--- a/frontend/src/components/Message/MessageContainer.tsx
+++ b/frontend/src/components/Message/MessageContainer.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Box, Typography, Fab } from "@mui/material";
+import { visuallyHidden } from "@mui/utils";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import MessageSkeleton from "./MessageSkeleton";
 import VirtualMessageList, { type VirtualMessageListHandle } from "./VirtualMessageList";
@@ -8,6 +9,7 @@ import { useMessageVisibility } from "../../hooks/useMessageVisibility";
 import { useReadReceipts } from "../../hooks/useReadReceipts";
 import { useResponsive } from "../../hooks/useResponsive";
 import { useAnchoredModeTransition } from "../../hooks/useAnchoredModeTransition";
+import { useMessageListAnnouncer } from "../../hooks/useMessageListAnnouncer";
 import TypingIndicator from "./TypingIndicator";
 
 interface MessageContainerProps {
@@ -118,6 +120,31 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
     scrollToBottomRef.current = scrollToBottom;
     atBottomRef.current = atBottom;
   });
+
+  // Throttled aria-live announcement for new incoming messages arriving
+  // while the reader is scrolled away from the live edge — wired off the
+  // same `atBottom` signal the FAB/unread logic above already uses.
+  const liveAnnouncement = useMessageListAnnouncer({
+    orderedMessages,
+    atBottom,
+    authorId,
+    contextKey,
+    enabled: !isLoading,
+  });
+
+  // Escape (pressed while a message row has roving focus) returns focus to
+  // the composer. The composer is rendered as `messageInput` below —
+  // structurally always the sibling Box right after the list — so it's
+  // located via a DOM query relative to that Box rather than threading a
+  // ref through every page that constructs a <MessageInput />.
+  const messageInputBoxRef = useRef<HTMLDivElement>(null);
+  const handleEscapeToInput = useCallback(() => {
+    const root = messageInputBoxRef.current;
+    const target = root?.querySelector<HTMLElement>(
+      'textarea, [contenteditable="true"]',
+    );
+    target?.focus();
+  }, []);
 
   const handleDetachedJumpToPresent = useCallback(() => {
     void resetToPresent?.();
@@ -313,6 +340,7 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
             resetKey={contextKey}
             onAtBottomChange={setAtBottom}
             onVisibleRangeChange={handleVisibleRangeChange}
+            onEscapeToInput={handleEscapeToInput}
           />
         ) : (
           <Box
@@ -335,8 +363,21 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
         </Box>
 
         {/* Input rendered outside scroll container — stable DOM, never unmounted by message changes */}
-        <Box sx={{ flexShrink: 0 }}>
+        <Box ref={messageInputBoxRef} sx={{ flexShrink: 0 }}>
           {messageInput}
+        </Box>
+
+        {/* Polite live region for new-message announcements (throttled,
+            coalescing — see useMessageListAnnouncer). Always mounted so
+            screen readers pick up mutations; visually hidden. */}
+        <Box
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          data-testid="message-list-live-region"
+          sx={visuallyHidden}
+        >
+          {liveAnnouncement}
         </Box>
 
         {mode === 'anchored' && jumpToPresent ? (

--- a/frontend/src/components/Message/VirtualMessageList.tsx
+++ b/frontend/src/components/Message/VirtualMessageList.tsx
@@ -3,7 +3,10 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
+  useState,
+  type KeyboardEvent,
 } from "react";
 import { Box } from "@mui/material";
 import { VList, type VListHandle } from "virtua";
@@ -76,6 +79,11 @@ export interface VirtualMessageListProps {
    * Consumed by read-tracking (fed to markAsRead) in MessageContainer.
    */
   onVisibleRangeChange?: (startIndex: number, endIndex: number) => void;
+
+  /** Escape (pressed while a row has roving focus, no menu open) returns
+   * focus to the message composer — implemented by the caller since the
+   * composer lives outside this component. */
+  onEscapeToInput?: () => void;
 }
 
 /**
@@ -117,6 +125,20 @@ export interface VirtualMessageListProps {
  *   Both positioning paths use the double-rAF re-assert pattern (a single
  *   rAF races virtua's measurement readiness on first mount).
  * - **atBottom**: derived from virtua's scroll offset, reported upward for FABs.
+ *
+ * **Roving row focus**: exactly one row is in the natural Tab order at a
+ * time (`focusedRowKey`, tracked by row identity — `clientId ?? id` — so it
+ * survives prepends/appends/the optimistic id-swap without any manual index
+ * shifting). ArrowUp/Down/Home/End move it; the target index is resolved to
+ * a message, `scrollToIndex` brings it into virtua's real render window, and
+ * a short rAF-retry loop focuses the row once it actually mounts. virtua's
+ * `keepMounted` was investigated as an alternative and rejected: items kept
+ * mounted outside the true visible window are rendered with
+ * `visibility: hidden` (see virtua's Virtualizer item wrapper), and
+ * hidden elements are not part of the focus order in any browser — so
+ * `keepMounted` preserves component state across scroll but cannot itself
+ * hold focus. Scrolling the target into the *real* window first is the only
+ * way to land focus on it, which is what `moveFocus` below does.
  */
 const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageListProps>(
   (
@@ -142,10 +164,12 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
       resetKey,
       onAtBottomChange,
       onVisibleRangeChange,
+      onEscapeToInput,
     },
     ref,
   ) => {
     const vlistRef = useRef<VListHandle>(null);
+    const listContainerRef = useRef<HTMLDivElement>(null);
     const pinnedRef = useRef(true);
     const initialPositionedRef = useRef(false);
 
@@ -160,6 +184,127 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
     const len = orderedMessages.length;
     const oldestId = orderedMessages[0]?.id;
     const newestId = orderedMessages[len - 1]?.id;
+
+    // ── Roving row focus ──────────────────────────────────────────────
+    // Tracked by row identity (matches the `rowKey` used below) rather than
+    // a raw array index, so it survives prepends/appends/the optimistic
+    // id-swap without any manual index-shifting.
+    const [focusedRowKey, setFocusedRowKey] = useState<string | null>(null);
+    const focusedIndex = useMemo(() => {
+      if (focusedRowKey === null) return -1;
+      return orderedMessages.findIndex(
+        (m) => (m.clientId ?? m.id) === focusedRowKey,
+      );
+    }, [orderedMessages, focusedRowKey]);
+
+    // Latest-value refs so the stable callbacks below (moveFocus, row
+    // key/focus delegates) never need `orderedMessages`/`len` in their own
+    // dependency arrays — keeps their identities stable across renders,
+    // which matters since they're passed straight through to a
+    // React.memo'd child (MessageComponent).
+    const orderedMessagesRef = useRef(orderedMessages);
+    orderedMessagesRef.current = orderedMessages;
+    const onEscapeToInputRef = useRef(onEscapeToInput);
+    onEscapeToInputRef.current = onEscapeToInput;
+
+    // Default/fallback roving target: whenever `focusedRowKey` is unset
+    // (initial mount), or no longer resolves to a loaded row (context/mode
+    // switch swapped the data window entirely, the row was deleted, or it
+    // was evicted at the pagination cap), fall back to a sensible default —
+    // the newest row in normal mode, the centered row in anchored mode
+    // (mirroring the initial-positioning effect above). This is a *pure*
+    // derived value (useMemo, not an effect + setState): it only decides
+    // what's DISPLAYED as the tabIndex=0 row this render. It deliberately
+    // does not write the fallback back into `focusedRowKey` state — the
+    // first genuine navigation (moveFocus/handleRowFocus) does that. An
+    // earlier version computed this via an effect that called setState,
+    // which scheduled an extra render on every eviction/context-switch;
+    // since `isPrepend`'s baseline ref updates unconditionally after every
+    // commit (not just "real" ones), that extra render re-derived
+    // `isPrepend` against an already-advanced baseline and silently
+    // flipped `shift` back to false one render after virtua needed to see
+    // it true — corrupting the prepend/cap-eviction scroll-compensation
+    // tests. A pure fallback avoids the extra render entirely.
+    const effectiveFocusedIndex = useMemo(() => {
+      if (focusedIndex !== -1) return focusedIndex;
+      if (len === 0) return -1;
+      return mode === 'anchored' ? Math.max(0, Math.floor((len - 1) / 2)) : len - 1;
+    }, [focusedIndex, len, mode]);
+
+    /** Moves the roving target to `rawIndex` (clamped), scrolls it into
+     * virtua's real render window, and imperatively focuses it once it
+     * mounts (retried across a few animation frames — see the module doc
+     * comment for why `keepMounted` alone can't do this). */
+    const moveFocus = useCallback((rawIndex: number) => {
+      const messages = orderedMessagesRef.current;
+      const targetLen = messages.length;
+      if (targetLen === 0) return;
+      const targetIndex = Math.max(0, Math.min(rawIndex, targetLen - 1));
+      const targetMessage = messages[targetIndex];
+      if (!targetMessage) return;
+
+      setFocusedRowKey(targetMessage.clientId ?? targetMessage.id);
+      vlistRef.current?.scrollToIndex(targetIndex, { align: 'nearest' });
+
+      let attempts = 0;
+      const tryFocus = () => {
+        const root = listContainerRef.current;
+        if (root) {
+          const rows = root.querySelectorAll<HTMLElement>('[data-message-id]');
+          for (const row of rows) {
+            if (row.dataset.messageId === targetMessage.id) {
+              const focusTarget = row.querySelector<HTMLElement>(
+                '[data-row-focus-target]',
+              );
+              if (focusTarget) {
+                focusTarget.focus();
+                return;
+              }
+              break;
+            }
+          }
+        }
+        attempts += 1;
+        if (attempts < 12) requestAnimationFrame(tryFocus);
+      };
+      requestAnimationFrame(tryFocus);
+    }, []);
+
+    const handleRowKeyDown = useCallback(
+      (event: KeyboardEvent<HTMLDivElement>, index: number) => {
+        switch (event.key) {
+          case 'ArrowDown':
+            event.preventDefault();
+            moveFocus(index + 1);
+            break;
+          case 'ArrowUp':
+            event.preventDefault();
+            moveFocus(index - 1);
+            break;
+          case 'Home':
+            event.preventDefault();
+            moveFocus(0);
+            break;
+          case 'End':
+            event.preventDefault();
+            moveFocus(orderedMessagesRef.current.length - 1);
+            break;
+          case 'Escape':
+            event.preventDefault();
+            onEscapeToInputRef.current?.();
+            break;
+          default:
+            break;
+        }
+      },
+      [moveFocus],
+    );
+
+    const handleRowFocus = useCallback((index: number) => {
+      const message = orderedMessagesRef.current[index];
+      if (!message) return;
+      setFocusedRowKey(message.clientId ?? message.id);
+    }, []);
 
     // At MESSAGE_MAX_PAGES, TanStack evicts pages from the end OPPOSITE the
     // fetch direction, and eviction is PAGE-granular (an entire page — up to
@@ -256,6 +401,9 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
       prevLenRef.current = 0;
       prevNewestIdRef.current = undefined;
       prevMessagesRef.current = [];
+      // Roving-focus reset for a context/mode switch is handled by the
+      // focusResetKeyRef-guarded effect above (folded in deliberately — see
+      // its comment for why a separate reset here caused a mount-time race).
       onAtBottomChange?.(true);
     }, [resetKey, mode, onAtBottomChange]);
 
@@ -453,7 +601,12 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
 
     return (
       <Box
+        ref={listContainerRef}
         data-testid="virtual-scroll-container"
+        // Not in the natural Tab order — only a fallback focus target for
+        // the context-menu restore when a row is removed while its menu is
+        // still closing (see MessageComponent's listContainerRef usage).
+        tabIndex={-1}
         sx={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}
       >
         {isLoadingMore && (
@@ -463,8 +616,21 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
             <MessageSkeleton />
           </Box>
         )}
+        {/* role="list"/"listitem" rather than the ARIA "feed" pattern:
+            feed's aria-posinset/aria-setsize imply an honest, stable total
+            item count, which this virtualized + paginated + cap-evicted
+            window can't provide (the loaded window's size isn't the
+            channel's total message count, and it shrinks/grows via
+            eviction independent of user action). Feed's Ctrl+Arrow
+            per-article navigation model also doesn't fit — rows aren't
+            independently-landmarked articles, they're moved between via the
+            plain roving-tabindex Arrow keys implemented here. A plain list
+            with an aria-label, one listitem per row, correctly conveys
+            "a list of messages" without those false guarantees. */}
         <VList
           ref={vlistRef}
+          role="list"
+          aria-label="Messages"
           shift={isPrepend}
           onScroll={handleScroll}
           style={{ flex: 1, minHeight: 0 }}
@@ -491,7 +657,7 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
               : rowKey;
 
             return (
-              <div key={key} data-message-id={message.id}>
+              <div key={key} data-message-id={message.id} role="listitem">
                 {showDividerBefore && (
                   <UnreadMessageDivider unreadCount={unreadCount} />
                 )}
@@ -508,6 +674,11 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
                       ? VoiceSessionType.Dm
                       : VoiceSessionType.Channel
                   }
+                  rowIndex={index}
+                  isRovingFocused={index === effectiveFocusedIndex}
+                  onRovingKeyDown={handleRowKeyDown}
+                  onRovingFocus={handleRowFocus}
+                  listContainerRef={listContainerRef}
                 />
               </div>
             );

--- a/frontend/src/components/Message/VirtualMessageList.tsx
+++ b/frontend/src/components/Message/VirtualMessageList.tsx
@@ -138,7 +138,22 @@ export interface VirtualMessageListProps {
  * hidden elements are not part of the focus order in any browser — so
  * `keepMounted` preserves component state across scroll but cannot itself
  * hold focus. Scrolling the target into the *real* window first is the only
- * way to land focus on it, which is what `moveFocus` below does.
+ * way to land focus on it, which is what `moveFocus` below does. Concurrent
+ * calls (a second arrow-key press before the first target has mounted) are
+ * resolved by a supersession token so only the LATEST call's loop can ever
+ * apply `.focus()` — see `moveFocus`'s own doc comment for the mechanism.
+ *
+ * Re-render note (pre-existing class, not introduced by this feature):
+ * `MessageContainer`'s `useMessageListAnnouncer` batch-flush calls
+ * `setAnnouncement`, which — like every other piece of state this
+ * component's parent already owns (`atBottom`, loading flags, etc.) —
+ * re-renders `MessageContainer` and cascades a re-render of this
+ * (non-memoized) `VirtualMessageList`. That's harmless here: `orderedMessages`
+ * keeps its memoized reference, virtua's own diffing is cheap, and every row
+ * (`MessageComponent`) is wrapped in `React.memo` with an explicit
+ * comparator, so the cascade stops there without re-rendering the list body.
+ * Same category of re-render this component has always tolerated from its
+ * parent; not a new performance concern from the announcer.
  */
 const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageListProps>(
   (
@@ -207,6 +222,21 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
     const onEscapeToInputRef = useRef(onEscapeToInput);
     onEscapeToInputRef.current = onEscapeToInput;
 
+    // moveFocus's rAF-retry supersession (see moveFocus's doc comment):
+    // `focusRequestSeqRef` is bumped once per moveFocus call and captured by
+    // that call's retry closure; `pendingFocusRafRef` tracks the currently
+    // in-flight frame id so it can be cancelled outright (superseded by a
+    // newer moveFocus call, or the component unmounting) rather than left to
+    // self-abort on its own next tick.
+    const focusRequestSeqRef = useRef(0);
+    const pendingFocusRafRef = useRef(0);
+    const cancelPendingFocusRaf = () => {
+      if (pendingFocusRafRef.current) {
+        cancelAnimationFrame(pendingFocusRafRef.current);
+        pendingFocusRafRef.current = 0;
+      }
+    };
+
     // Default/fallback roving target: whenever `focusedRowKey` is unset
     // (initial mount), or no longer resolves to a loaded row (context/mode
     // switch swapped the data window entirely, the row was deleted, or it
@@ -234,7 +264,20 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
     /** Moves the roving target to `rawIndex` (clamped), scrolls it into
      * virtua's real render window, and imperatively focuses it once it
      * mounts (retried across a few animation frames — see the module doc
-     * comment for why `keepMounted` alone can't do this). */
+     * comment for why `keepMounted` alone can't do this).
+     *
+     * Each call spawns its own rAF-retry loop, and a fast second call
+     * (another arrow-key press before the first loop's target has mounted)
+     * would otherwise leave two independent loops running concurrently —
+     * whichever's frame happens to fire LAST wins `.focus()`, which can
+     * silently apply a stale, superseded target over the real current one.
+     * Guarded with a supersession token (`focusRequestSeqRef`): each call
+     * claims the next seq, and the retry closure aborts (no focus, no
+     * further reschedule) the moment it observes a newer claim — that seq
+     * guard alone is what guarantees only the latest call's loop can act.
+     * The in-flight frame id is additionally tracked (`pendingFocusRafRef`)
+     * so a superseded or unmounting loop is also cancelled outright rather
+     * than left to self-abort on its next tick. */
     const moveFocus = useCallback((rawIndex: number) => {
       const messages = orderedMessagesRef.current;
       const targetLen = messages.length;
@@ -246,8 +289,24 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
       setFocusedRowKey(targetMessage.clientId ?? targetMessage.id);
       vlistRef.current?.scrollToIndex(targetIndex, { align: 'nearest' });
 
+      // Cancel any still-pending retry loop from a prior moveFocus call
+      // before starting this one, and claim a fresh seq so that loop's
+      // closure (if its frame is already mid-flight) recognizes it's stale.
+      cancelPendingFocusRaf();
+      const seq = ++focusRequestSeqRef.current;
+
       let attempts = 0;
       const tryFocus = () => {
+        // Superseded by a newer moveFocus call (or a context/mode switch or
+        // unmount — both also bump the seq)? Abort silently: no focus, no
+        // reschedule. Checked BEFORE touching `pendingFocusRafRef`, so a
+        // stale frame that slipped past cancellation can never zero the ref
+        // while it holds the LIVE loop's pending frame id (which would
+        // orphan that frame from the unmount cleanup). Correctness rests on
+        // this seq guard alone; the cancelAnimationFrame calls are an
+        // optimization that stops stale frames from firing at all.
+        if (seq !== focusRequestSeqRef.current) return;
+        pendingFocusRafRef.current = 0;
         const root = listContainerRef.current;
         if (root) {
           const rows = root.querySelectorAll<HTMLElement>('[data-message-id]');
@@ -265,9 +324,11 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
           }
         }
         attempts += 1;
-        if (attempts < 12) requestAnimationFrame(tryFocus);
+        if (attempts < 12) {
+          pendingFocusRafRef.current = requestAnimationFrame(tryFocus);
+        }
       };
-      requestAnimationFrame(tryFocus);
+      pendingFocusRafRef.current = requestAnimationFrame(tryFocus);
     }, []);
 
     const handleRowKeyDown = useCallback(
@@ -401,14 +462,39 @@ const VirtualMessageList = forwardRef<VirtualMessageListHandle, VirtualMessageLi
       prevLenRef.current = 0;
       prevNewestIdRef.current = undefined;
       prevMessagesRef.current = [];
-      // Roving-focus reset for a context/mode switch is handled by the
-      // focusResetKeyRef-guarded effect above (folded in deliberately — see
-      // its comment for why a separate reset here caused a mount-time race).
+      // Roving focus: a context switch (new channel/DM) obviously must not
+      // carry over the old context's focused row. A bare mode switch
+      // (normal <-> anchored) within the SAME context needs the same reset
+      // even though the previously-focused message id can still resolve in
+      // the new data window (normal-window cache vs. anchored-window cache
+      // overlap) — carrying it over would silently land tabIndex=0 on
+      // whatever row happened to occupy that id, rather than the mode's own
+      // sensible default (newest in normal, centered in anchored). Cleared
+      // here (not left to the pure `effectiveFocusedIndex` fallback alone)
+      // so the fallback's "nothing explicitly focused" case is actually
+      // true again after a mode flip, not just papered over by the fallback
+      // still resolving the stale key to a live row.
+      setFocusedRowKey(null);
+      // Kill any in-flight moveFocus retry loop from the previous
+      // context/mode: cancel its pending frame, and bump the supersession
+      // seq so a frame already dequeued past cancellation self-aborts.
+      cancelPendingFocusRaf();
+      focusRequestSeqRef.current += 1;
       onAtBottomChange?.(true);
     }, [resetKey, mode, onAtBottomChange]);
 
-    // Cancel any pending positioning frames on unmount.
-    useEffect(() => cancelPositioningRafs, []);
+    // Cancel any pending positioning AND roving-focus retry frames on
+    // unmount — an in-flight moveFocus rAF loop must not keep querying
+    // (or scheduling further frames against) a torn-down listContainerRef.
+    // The seq bump invalidates any frame that has already been dequeued and
+    // can no longer be cancelled (see tryFocus's seq guard).
+    useEffect(() => {
+      return () => {
+        cancelPositioningRafs();
+        cancelPendingFocusRaf();
+        focusRequestSeqRef.current += 1;
+      };
+    }, []);
 
     // highlightMessageId as of the latest render, read (not depended on) by
     // the initial-positioning effect below so it can detect "no jump target"

--- a/frontend/src/hooks/useMessageListAnnouncer.ts
+++ b/frontend/src/hooks/useMessageListAnnouncer.ts
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { userControllerGetUserByIdOptions } from "../api-client/@tanstack/react-query.gen";
+import type { Message } from "../types/message.type";
+import { SpanType } from "../types/message.type";
+
+/** Batch window: qualifying messages arriving within this window of the
+ * first one are coalesced into a single announcement. */
+const ANNOUNCEMENT_BATCH_WINDOW_MS = 2000;
+const PREVIEW_MAX_LENGTH = 80;
+
+interface CachedUserSummary {
+  displayName?: string;
+  username?: string;
+}
+
+/**
+ * Flattens a message's spans into a short plain-text preview for the
+ * aria-live announcement. Mentions/emoji are rendered as short placeholders
+ * rather than resolved (resolving them would need extra lookups the
+ * announcer doesn't otherwise need) — good enough for a truncated preview.
+ */
+function buildPreviewText(message: Message): string {
+  const text = message.spans
+    .map((span) => {
+      switch (span.type) {
+        case SpanType.PLAINTEXT:
+        case SpanType.CODE_BLOCK:
+        case SpanType.EMOJI:
+          return span.text ?? "";
+        case SpanType.SPECIAL_MENTION:
+          return `@${span.specialKind ?? "mention"}`;
+        case SpanType.USER_MENTION:
+        case SpanType.ALIAS_MENTION:
+          return "@mention";
+        default:
+          return "";
+      }
+    })
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (text) {
+    return text.length > PREVIEW_MAX_LENGTH
+      ? `${text.slice(0, PREVIEW_MAX_LENGTH).trimEnd()}…`
+      : text;
+  }
+  return message.attachments && message.attachments.length > 0
+    ? "Sent an attachment"
+    : "New message";
+}
+
+export interface UseMessageListAnnouncerOptions {
+  /** Chronological (oldest-first) render order — same array VirtualMessageList gets. */
+  orderedMessages: Message[];
+  /** Whether the list is currently pinned to the live edge (from VirtualMessageList's onAtBottomChange). */
+  atBottom: boolean;
+  authorId: string;
+  /** Channel/DM identity — resets the "seen newest" baseline on context switch. */
+  contextKey?: string;
+  enabled?: boolean;
+}
+
+/**
+ * Produces a throttled, coalescing aria-live announcement string for new
+ * incoming messages that arrive while the reader is scrolled away from the
+ * live edge. Own messages, and messages arriving while already at the
+ * bottom (visible without any announcement needed), are silently ignored.
+ *
+ * Wired off the same `atBottom` signal MessageContainer's FAB/unread logic
+ * already uses — no separate detachment tracking.
+ */
+export function useMessageListAnnouncer({
+  orderedMessages,
+  atBottom,
+  authorId,
+  contextKey,
+  enabled = true,
+}: UseMessageListAnnouncerOptions): string {
+  const queryClient = useQueryClient();
+  const [announcement, setAnnouncement] = useState("");
+
+  // Baseline: the row key (clientId ?? id) of the newest message we've
+  // already accounted for. `undefined` means "not yet observed" (initial
+  // load / just switched context) — the first observation only records the
+  // baseline, it never announces (avoids announcing the whole initial page
+  // as if every message in it just arrived).
+  const prevNewestKeyRef = useRef<string | undefined>(undefined);
+  const atBottomRef = useRef(atBottom);
+  atBottomRef.current = atBottom;
+
+  const pendingRef = useRef<Message[]>([]);
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const flush = useCallback(() => {
+    flushTimerRef.current = null;
+    const batch = pendingRef.current;
+    pendingRef.current = [];
+    if (batch.length === 0) return;
+
+    let text: string;
+    if (batch.length === 1) {
+      const message = batch[0];
+      const cached = message.authorId
+        ? queryClient.getQueryData<CachedUserSummary>(
+            userControllerGetUserByIdOptions({ path: { id: message.authorId } })
+              .queryKey,
+          )
+        : undefined;
+      const author = message.webhook?.name ?? cached?.displayName ?? cached?.username;
+      const preview = buildPreviewText(message);
+      text = author ? `${author}: ${preview}` : preview;
+    } else {
+      text = `${batch.length} new messages`;
+    }
+
+    // Clear-then-set forces a re-announcement even when the text is
+    // identical to the last one — most screen readers only announce
+    // aria-live regions on an actual text mutation, not a same-value set.
+    setAnnouncement("");
+    requestAnimationFrame(() => setAnnouncement(text));
+  }, [queryClient]);
+
+  // Reset the baseline (and drop any pending batch) on channel/DM switch —
+  // otherwise the first message of a freshly loaded context would look like
+  // "a new incoming message" the moment it loads.
+  useEffect(() => {
+    prevNewestKeyRef.current = undefined;
+    pendingRef.current = [];
+    if (flushTimerRef.current) {
+      clearTimeout(flushTimerRef.current);
+      flushTimerRef.current = null;
+    }
+  }, [contextKey]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const newest = orderedMessages[orderedMessages.length - 1];
+    const newestKey = newest ? (newest.clientId ?? newest.id) : undefined;
+
+    if (prevNewestKeyRef.current === undefined) {
+      prevNewestKeyRef.current = newestKey;
+      return;
+    }
+    if (newestKey === undefined || newestKey === prevNewestKeyRef.current) return;
+
+    // Find everything appended since the last observed newest message so a
+    // burst of several messages between two renders is counted accurately,
+    // not just the single latest one. If the previous newest fell out of
+    // the loaded window (evicted at the pagination cap), fall back to
+    // treating only the current newest as new.
+    const prevIndex = orderedMessages.findIndex(
+      (m) => (m.clientId ?? m.id) === prevNewestKeyRef.current,
+    );
+    const newTail =
+      prevIndex === -1 ? (newest ? [newest] : []) : orderedMessages.slice(prevIndex + 1);
+    prevNewestKeyRef.current = newestKey;
+
+    if (atBottomRef.current) return;
+    const incoming = newTail.filter((m) => m.authorId !== authorId);
+    if (incoming.length === 0) return;
+
+    pendingRef.current.push(...incoming);
+    if (!flushTimerRef.current) {
+      flushTimerRef.current = setTimeout(flush, ANNOUNCEMENT_BATCH_WINDOW_MS);
+    }
+  }, [orderedMessages, authorId, enabled, flush]);
+
+  useEffect(
+    () => () => {
+      if (flushTimerRef.current) clearTimeout(flushTimerRef.current);
+    },
+    [],
+  );
+
+  return announcement;
+}


### PR DESCRIPTION
## Summary
- Completes the a11y follow-up deferred from #428: the message list gains full keyboard navigation — roving tabindex rows (ArrowUp/Down, Home/End), Enter/ContextMenu-key opens the row's action menu (reusing #428's focus-restore machinery, with the list container as fallback for the deleted-message case), Escape returns focus to the composer, themed `:focus-visible` ring.
- Off-window focus is fully handled (not timeboxed out): virtua's `keepMounted` renders `visibility:hidden` — excluded from focus order (verified against the bundled source) — so navigation uses `scrollToIndex` + a bounded rAF retry with a supersession token: overlapping navigations can never fight (proven by a genuinely interleaved rAF race test with inert cancelAnimationFrame, isolating the seq-guard as the correctness mechanism).
- A polite, throttled live region announces incoming messages only when the reader is away from the live edge (never own messages; coalesces to "N new messages" per ~2s batch), wired off the existing detachment signals.
- `role="list"` semantics chosen over `feed` deliberately — posinset/setsize can't be honest under pagination + cap eviction (justified in-code).
- The three protected regression suites (#416 detachment, #426 anchored mode, #431 optimistic sends) are untouched across all commits (blob-hash verified in review).

## Test plan
- 178 files / 1900 tests (+24 for this work: 17 rovingFocus incl. the supersession race, mode-switch reset, focus-ring rendering; 6 container; 1 context-menu fallback), type-check clean, lint baseline unchanged; bounded WCAG-tag axe scan on the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sAJfCfBfMm8chbZMsh5Y5