### PR TITLE
fix(ci): restore --publish never for Linux electron-builder builds

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -202,7 +202,15 @@ jobs:
         # install path is /opt/semaphore-chat (no space — spaces break
         # Electron's zygote re-exec, #349). Keep using this script for every
         # Linux electron-builder invocation.
-        run: pnpm run build:all && pnpm run electron-builder:linux -- AppImage deb rpm --publish never
+        #
+        # NOTE: do NOT pass args to electron-builder via `pnpm run <script> --
+        # <args>`. pnpm forwards a literal `--` to the script, and
+        # electron-builder's CLI treats `--` as end-of-options, silently
+        # dropping anything after it — `--publish never` was ignored this way,
+        # so on a tag push electron-builder tried to publish, hit a 403 with a
+        # read-only GITHUB_TOKEN, and the whole Linux build (incl. the AppImage)
+        # failed. pnpm forwards bare args without the `--` separator.
+        run: pnpm run build:all && pnpm run electron-builder:linux AppImage deb rpm --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem

The **v0.3.0 release shipped Windows-only** — no Linux AppImage (nor deb/rpm), even though all three packages built successfully. The Linux build job died at electron-builder's publish step with `403 Resource not accessible by integration`, the step aborted before its artifacts were uploaded, and `create-release` (which ORs windows/linux success) published a release with only the Windows installer.

## Root cause

Commit `194198d` (#377) changed the Linux invocation in `electron-build.yml` from a direct `pnpm exec electron-builder --linux … --publish never` to:

```
pnpm run electron-builder:linux -- AppImage deb rpm --publish never
```

**pnpm `run` forwards a literal `--` to the script** (verified with pnpm 10.30.0, the CI version), and **electron-builder's yargs CLI treats `--` as end-of-options**. So `--publish never` was silently dropped:

```
electron-builder -c.productName=semaphore-chat --linux -- AppImage deb rpm --publish never
```

With `--publish` unset and the build triggered by a tag push, electron-builder defaulted to `onTag` publishing (`• artifacts will be published reason=tag is defined tag=v0.3.0` in the run log), tried to create a GitHub release with the build job's read-only `GITHUB_TOKEN`, and failed.

## Fix

Drop the `--` separator — pnpm forwards bare args directly:

```
pnpm run electron-builder:linux AppImage deb rpm --publish never
```

No `permissions: contents: write` added to build jobs on purpose: build jobs should stay read-only, and `create-release` already owns release creation.

## Backfill

v0.3.0's Linux artifacts are being rebuilt from a `backfill/v0.3.0-linux` branch (v0.3.0 tag + this same fix) and will be attached to the existing v0.3.0 release.