### PR TITLE
fix(unread): stop peer DM reads wiping badges, gate auto-read on focus

### DIFF
--- a/frontend/src/__tests__/hooks/useMessageVisibility.test.ts
+++ b/frontend/src/__tests__/hooks/useMessageVisibility.test.ts
@@ -21,11 +21,21 @@ describe('useMessageVisibility', () => {
       defaultOptions: { queries: { retry: false } },
     });
     mockSocket = createMockSocket();
+    // jsdom defaults document.hasFocus() to false, but every pre-existing
+    // test in this file assumes a focused/visible tab (that's the common
+    // case being tested) — stub it focused by default; the "blurred tab"
+    // describe block below overrides per-test.
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    });
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   function renderVisibility(options: {
@@ -297,6 +307,101 @@ describe('useMessageVisibility', () => {
       act(() => result.current.markAsRead('msg-1'));
       act(() => vi.advanceTimersByTime(1000));
 
+      expect(mockSocket.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('background-tab auto-read gating', () => {
+    it('does not optimistically clear or emit while the tab is blurred', () => {
+      vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+      seedUnreadData([
+        { channelId: 'ch-1', unreadCount: 5, mentionCount: 2 } as UnreadCountDto,
+      ]);
+
+      const { result } = renderVisibility({ channelId: 'ch-1' });
+
+      act(() => result.current.markAsRead('msg-1'));
+
+      const data = getUnreadData();
+      expect(data![0].unreadCount).toBe(5);
+      expect(data![0].mentionCount).toBe(2);
+
+      act(() => vi.advanceTimersByTime(1000));
+      expect(mockSocket.emit).not.toHaveBeenCalled();
+    });
+
+    it('does not optimistically clear or emit while the tab is hidden (visibilityState)', () => {
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'hidden',
+        configurable: true,
+      });
+      seedUnreadData([
+        { channelId: 'ch-1', unreadCount: 5, mentionCount: 2 } as UnreadCountDto,
+      ]);
+
+      const { result } = renderVisibility({ channelId: 'ch-1' });
+
+      act(() => result.current.markAsRead('msg-1'));
+
+      expect(getUnreadData()![0].unreadCount).toBe(5);
+      act(() => vi.advanceTimersByTime(1000));
+      expect(mockSocket.emit).not.toHaveBeenCalled();
+    });
+
+    it('replays the last pending message id once focus returns', () => {
+      const hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+      seedUnreadData([
+        { channelId: 'ch-1', unreadCount: 5, mentionCount: 2 } as UnreadCountDto,
+      ]);
+
+      const { result } = renderVisibility({ channelId: 'ch-1' });
+
+      // MessageContainer keeps calling markAsRead with the newest visible id
+      // even while blurred — simulate a couple of calls, only the latest
+      // should survive to be replayed.
+      act(() => {
+        result.current.markAsRead('msg-1');
+        result.current.markAsRead('msg-2');
+      });
+
+      // Still blurred: no optimistic clear, no emit.
+      expect(getUnreadData()![0].unreadCount).toBe(5);
+      act(() => vi.advanceTimersByTime(1000));
+      expect(mockSocket.emit).not.toHaveBeenCalled();
+
+      // Focus regained.
+      hasFocusSpy.mockReturnValue(true);
+      act(() => {
+        window.dispatchEvent(new Event('focus'));
+      });
+
+      const data = getUnreadData();
+      expect(data![0].unreadCount).toBe(0);
+      expect(data![0].mentionCount).toBe(0);
+      expect(data![0].lastReadMessageId).toBe('msg-2');
+
+      act(() => vi.advanceTimersByTime(1000));
+      expect(mockSocket.emit).toHaveBeenCalledWith(ClientEvents.MARK_AS_READ, {
+        lastReadMessageId: 'msg-2',
+        channelId: 'ch-1',
+      });
+    });
+
+    it('does nothing on focus regained when there was no pending blurred id', () => {
+      const hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+      seedUnreadData([
+        { channelId: 'ch-1', unreadCount: 5, mentionCount: 2 } as UnreadCountDto,
+      ]);
+
+      renderVisibility({ channelId: 'ch-1' });
+
+      hasFocusSpy.mockReturnValue(true);
+      act(() => {
+        window.dispatchEvent(new Event('focus'));
+      });
+
+      // Nothing was pending, so the count is untouched (markAsRead was never called).
+      expect(getUnreadData()![0].unreadCount).toBe(5);
       expect(mockSocket.emit).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/__tests__/socket-hub/handlers/messageHandlers.test.ts
+++ b/frontend/src/__tests__/socket-hub/handlers/messageHandlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { QueryClient } from '@tanstack/react-query';
 import type { InfiniteData } from '@tanstack/react-query';
 import type { PaginatedMessagesResponseDto, DmPeerReadDto } from '../../../api-client/types.gen';
@@ -16,6 +16,7 @@ import {
   readReceiptsControllerGetDmPeerReadsQueryKey,
   userControllerGetProfileQueryKey,
 } from '../../../api-client/@tanstack/react-query.gen';
+import { setActiveDmGroupId } from '../../../utils/activeDmTracking';
 
 function makeMessage(overrides: Record<string, unknown> = {}) {
   return {
@@ -189,6 +190,165 @@ describe('messageHandlers', () => {
         readReceiptsControllerGetUnreadCountsQueryKey(),
       );
       expect(unread![0].unreadCount).toBe(0);
+    });
+
+    describe('unread suppression for the actively-viewed context (transient badge flash)', () => {
+      let hasFocusSpy: ReturnType<typeof vi.spyOn>;
+
+      afterEach(() => {
+        hasFocusSpy?.mockRestore();
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'visible',
+          configurable: true,
+        });
+        window.history.pushState({}, '', '/');
+        setActiveDmGroupId(null);
+      });
+
+      it('does not increment unread when the channel is actively viewed and the tab is focused', async () => {
+        hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'visible',
+          configurable: true,
+        });
+        window.history.pushState({}, '', '/community/c1/channel/ch-1');
+
+        const queryClient = new QueryClient();
+        queryClient.setQueryData(userControllerGetProfileQueryKey(), { id: 'me' });
+        queryClient.setQueryData(readReceiptsControllerGetUnreadCountsQueryKey(), [
+          { channelId: 'ch-1', unreadCount: 0, mentionCount: 0 },
+        ]);
+
+        const newMsg = makeMessage({ id: 'new-1', channelId: 'ch-1', authorId: 'other' });
+        await handleNewMessage({ message: newMsg as never }, queryClient);
+
+        const unread = queryClient.getQueryData<{ channelId: string; unreadCount: number }[]>(
+          readReceiptsControllerGetUnreadCountsQueryKey(),
+        );
+        expect(unread![0].unreadCount).toBe(0);
+      });
+
+      it('still increments unread for the active channel when the tab is blurred', async () => {
+        hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+        window.history.pushState({}, '', '/community/c1/channel/ch-1');
+
+        const queryClient = new QueryClient();
+        queryClient.setQueryData(userControllerGetProfileQueryKey(), { id: 'me' });
+        queryClient.setQueryData(readReceiptsControllerGetUnreadCountsQueryKey(), [
+          { channelId: 'ch-1', unreadCount: 0, mentionCount: 0 },
+        ]);
+
+        const newMsg = makeMessage({ id: 'new-1', channelId: 'ch-1', authorId: 'other' });
+        await handleNewMessage({ message: newMsg as never }, queryClient);
+
+        const unread = queryClient.getQueryData<{ channelId: string; unreadCount: number }[]>(
+          readReceiptsControllerGetUnreadCountsQueryKey(),
+        );
+        expect(unread![0].unreadCount).toBe(1);
+      });
+
+      it('still increments unread when focused but viewing a different channel', async () => {
+        hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'visible',
+          configurable: true,
+        });
+        window.history.pushState({}, '', '/community/c1/channel/other-channel');
+
+        const queryClient = new QueryClient();
+        queryClient.setQueryData(userControllerGetProfileQueryKey(), { id: 'me' });
+        queryClient.setQueryData(readReceiptsControllerGetUnreadCountsQueryKey(), [
+          { channelId: 'ch-1', unreadCount: 0, mentionCount: 0 },
+        ]);
+
+        const newMsg = makeMessage({ id: 'new-1', channelId: 'ch-1', authorId: 'other' });
+        await handleNewMessage({ message: newMsg as never }, queryClient);
+
+        const unread = queryClient.getQueryData<{ channelId: string; unreadCount: number }[]>(
+          readReceiptsControllerGetUnreadCountsQueryKey(),
+        );
+        expect(unread![0].unreadCount).toBe(1);
+      });
+
+      it('does not increment unread when the DM is actively viewed and the tab is focused', async () => {
+        hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'visible',
+          configurable: true,
+        });
+        setActiveDmGroupId('dm-1');
+
+        const queryClient = new QueryClient();
+        queryClient.setQueryData(userControllerGetProfileQueryKey(), { id: 'me' });
+        queryClient.setQueryData(readReceiptsControllerGetUnreadCountsQueryKey(), [
+          { directMessageGroupId: 'dm-1', unreadCount: 0, mentionCount: 0 },
+        ]);
+
+        const newMsg = makeMessage({
+          id: 'new-1',
+          channelId: null,
+          directMessageGroupId: 'dm-1',
+          authorId: 'other',
+        });
+        await handleNewMessage({ message: newMsg as never }, queryClient);
+
+        const unread = queryClient.getQueryData<{ directMessageGroupId: string; unreadCount: number }[]>(
+          readReceiptsControllerGetUnreadCountsQueryKey(),
+        );
+        expect(unread![0].unreadCount).toBe(0);
+      });
+
+      it('still increments unread for a different DM group even when focused', async () => {
+        hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'visible',
+          configurable: true,
+        });
+        setActiveDmGroupId('dm-other');
+
+        const queryClient = new QueryClient();
+        queryClient.setQueryData(userControllerGetProfileQueryKey(), { id: 'me' });
+        queryClient.setQueryData(readReceiptsControllerGetUnreadCountsQueryKey(), [
+          { directMessageGroupId: 'dm-1', unreadCount: 0, mentionCount: 0 },
+        ]);
+
+        const newMsg = makeMessage({
+          id: 'new-1',
+          channelId: null,
+          directMessageGroupId: 'dm-1',
+          authorId: 'other',
+        });
+        await handleNewMessage({ message: newMsg as never }, queryClient);
+
+        const unread = queryClient.getQueryData<{ directMessageGroupId: string; unreadCount: number }[]>(
+          readReceiptsControllerGetUnreadCountsQueryKey(),
+        );
+        expect(unread![0].unreadCount).toBe(1);
+      });
+
+      it('still inserts the message into the message cache even when the unread bump is suppressed', async () => {
+        hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'visible',
+          configurable: true,
+        });
+        window.history.pushState({}, '', '/community/c1/channel/ch-1');
+
+        const queryClient = new QueryClient();
+        const queryKey = channelMessagesQueryKey('ch-1');
+        queryClient.setQueryData(queryKey, makeInfiniteData([]));
+        queryClient.setQueryData(userControllerGetProfileQueryKey(), { id: 'me' });
+        queryClient.setQueryData(readReceiptsControllerGetUnreadCountsQueryKey(), [
+          { channelId: 'ch-1', unreadCount: 0, mentionCount: 0 },
+        ]);
+
+        const newMsg = makeMessage({ id: 'new-1', channelId: 'ch-1', authorId: 'other' });
+        await handleNewMessage({ message: newMsg as never }, queryClient);
+
+        const data = queryClient.getQueryData<InfiniteData<PaginatedMessagesResponseDto>>(queryKey);
+        expect(data!.pages[0].messages).toHaveLength(1);
+        expect(data!.pages[0].messages[0].id).toBe('new-1');
+      });
     });
   });
 
@@ -465,6 +625,132 @@ describe('messageHandlers', () => {
 
       const peerReads = queryClient.getQueryData<DmPeerReadDto[]>(peerReadsKey);
       expect(peerReads).toHaveLength(0);
+    });
+
+    describe('Bug-A regression matrix: cross-user DM badge clearing', () => {
+      function seedForCurrentUser(queryClient: QueryClient) {
+        queryClient.setQueryData(userControllerGetProfileQueryKey(), { id: 'user-a' });
+        queryClient.setQueryData(readReceiptsControllerGetUnreadCountsQueryKey(), [
+          { directMessageGroupId: 'g1', unreadCount: 3, mentionCount: 1, communityId: 'c1' },
+        ]);
+      }
+
+      function getUnreadEntry(queryClient: QueryClient) {
+        const data = queryClient.getQueryData<
+          { directMessageGroupId: string; unreadCount: number; mentionCount: number; communityId?: string }[]
+        >(readReceiptsControllerGetUnreadCountsQueryKey());
+        return data![0];
+      }
+
+      it('userId belongs to a DM peer: own unread counts are unchanged, but peer-reads cache is updated', () => {
+        const queryClient = new QueryClient();
+        seedForCurrentUser(queryClient);
+        const peerReadsKey = readReceiptsControllerGetDmPeerReadsQueryKey({
+          path: { directMessageGroupId: 'g1' },
+        });
+        queryClient.setQueryData(peerReadsKey, [] as DmPeerReadDto[]);
+
+        handleReadReceiptUpdated(
+          {
+            channelId: null,
+            directMessageGroupId: 'g1',
+            lastReadMessageId: 'msg-5',
+            lastReadAt: '2024-01-01T00:00:00Z',
+            userId: 'user-b',
+          },
+          queryClient,
+        );
+
+        const entry = getUnreadEntry(queryClient);
+        expect(entry.unreadCount).toBe(3);
+        expect(entry.mentionCount).toBe(1);
+
+        const peerReads = queryClient.getQueryData<DmPeerReadDto[]>(peerReadsKey);
+        expect(peerReads).toHaveLength(1);
+        expect(peerReads![0].userId).toBe('user-b');
+      });
+
+      it('userId matches the current user (self-sync-with-userId variant): counts are zeroed', () => {
+        const queryClient = new QueryClient();
+        seedForCurrentUser(queryClient);
+
+        handleReadReceiptUpdated(
+          {
+            channelId: null,
+            directMessageGroupId: 'g1',
+            lastReadMessageId: 'msg-5',
+            lastReadAt: '2024-01-01T00:00:00Z',
+            userId: 'user-a',
+          },
+          queryClient,
+        );
+
+        const entry = getUnreadEntry(queryClient);
+        expect(entry.unreadCount).toBe(0);
+        expect(entry.mentionCount).toBe(0);
+      });
+
+      it('no userId (self-sync): counts are zeroed', () => {
+        const queryClient = new QueryClient();
+        seedForCurrentUser(queryClient);
+
+        handleReadReceiptUpdated(
+          {
+            channelId: null,
+            directMessageGroupId: 'g1',
+            lastReadMessageId: 'msg-5',
+            lastReadAt: '2024-01-01T00:00:00Z',
+          },
+          queryClient,
+        );
+
+        const entry = getUnreadEntry(queryClient);
+        expect(entry.unreadCount).toBe(0);
+        expect(entry.mentionCount).toBe(0);
+      });
+
+      it('userId present but no profile cached yet: skips zeroing (safe — self-sync copy will still clear)', () => {
+        const queryClient = new QueryClient();
+        // No profile seeded.
+        queryClient.setQueryData(readReceiptsControllerGetUnreadCountsQueryKey(), [
+          { directMessageGroupId: 'g1', unreadCount: 3, mentionCount: 1, communityId: 'c1' },
+        ]);
+
+        handleReadReceiptUpdated(
+          {
+            channelId: null,
+            directMessageGroupId: 'g1',
+            lastReadMessageId: 'msg-5',
+            lastReadAt: '2024-01-01T00:00:00Z',
+            userId: 'user-b',
+          },
+          queryClient,
+        );
+
+        const entry = getUnreadEntry(queryClient);
+        expect(entry.unreadCount).toBe(3);
+        expect(entry.mentionCount).toBe(1);
+      });
+
+      it('zeroing preserves extra fields (e.g. communityId) already present on the entry', () => {
+        const queryClient = new QueryClient();
+        seedForCurrentUser(queryClient);
+
+        handleReadReceiptUpdated(
+          {
+            channelId: null,
+            directMessageGroupId: 'g1',
+            lastReadMessageId: 'msg-5',
+            lastReadAt: '2024-01-01T00:00:00Z',
+          },
+          queryClient,
+        );
+
+        const entry = getUnreadEntry(queryClient);
+        expect(entry.unreadCount).toBe(0);
+        expect(entry.mentionCount).toBe(0);
+        expect(entry.communityId).toBe('c1');
+      });
     });
   });
 });

--- a/frontend/src/__tests__/socket-hub/handlers/messageHandlers.test.ts
+++ b/frontend/src/__tests__/socket-hub/handlers/messageHandlers.test.ts
@@ -228,6 +228,38 @@ describe('messageHandlers', () => {
         expect(unread![0].unreadCount).toBe(0);
       });
 
+      it('still increments unread for the active, focused channel when detached from the live edge (#404)', async () => {
+        hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'visible',
+          configurable: true,
+        });
+        window.history.pushState({}, '', '/community/c1/channel/ch-1');
+
+        const queryClient = new QueryClient();
+        const queryKey = channelMessagesQueryKey('ch-1');
+        const detached: InfiniteData<PaginatedMessagesResponseDto> = {
+          ...makeInfiniteData([makeMessage({ id: 'stale-1' })]),
+          pageParams: ['cursor-uuid'],
+        };
+        queryClient.setQueryData(queryKey, detached);
+        queryClient.setQueryData(userControllerGetProfileQueryKey(), { id: 'me' });
+        queryClient.setQueryData(readReceiptsControllerGetUnreadCountsQueryKey(), [
+          { channelId: 'ch-1', unreadCount: 0, mentionCount: 0 },
+        ]);
+
+        const newMsg = makeMessage({ id: 'new-1', channelId: 'ch-1', authorId: 'other' });
+        await handleNewMessage({ message: newMsg as never }, queryClient);
+
+        // Detached: message not inserted and not visible, so the bump is the
+        // only signal — suppression must not apply even though the channel is
+        // actively viewed and focused.
+        const unread = queryClient.getQueryData<{ channelId: string; unreadCount: number }[]>(
+          readReceiptsControllerGetUnreadCountsQueryKey(),
+        );
+        expect(unread![0].unreadCount).toBe(1);
+      });
+
       it('still increments unread for the active channel when the tab is blurred', async () => {
         hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(false);
         window.history.pushState({}, '', '/community/c1/channel/ch-1');

--- a/frontend/src/__tests__/utils/activeContextTracking.test.ts
+++ b/frontend/src/__tests__/utils/activeContextTracking.test.ts
@@ -47,6 +47,18 @@ describe('activeContextTracking', () => {
     expect(isContextViewedAndFocused('ch-1', undefined)).toBe(false);
   });
 
+  it('does not prefix-match a channel id against a longer id in the route', () => {
+    window.history.pushState({}, '', '/community/c1/channel/ch-10');
+
+    expect(isContextViewedAndFocused('ch-1', undefined)).toBe(false);
+  });
+
+  it('matches when the channel segment is followed by a sub-route', () => {
+    window.history.pushState({}, '', '/community/c1/channel/ch-1/threads');
+
+    expect(isContextViewedAndFocused('ch-1', undefined)).toBe(true);
+  });
+
   it('returns true when focused and the active DM group matches', () => {
     setActiveDmGroupId('dm-1');
 

--- a/frontend/src/__tests__/utils/activeContextTracking.test.ts
+++ b/frontend/src/__tests__/utils/activeContextTracking.test.ts
@@ -1,0 +1,66 @@
+import { isContextViewedAndFocused } from '../../utils/activeContextTracking';
+import { setActiveDmGroupId } from '../../utils/activeDmTracking';
+
+describe('activeContextTracking', () => {
+  let hasFocusSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    hasFocusSpy.mockRestore();
+    window.history.pushState({}, '', '/');
+    setActiveDmGroupId(null);
+  });
+
+  it('returns false when the tab is blurred, even if the channel route matches', () => {
+    hasFocusSpy.mockReturnValue(false);
+    window.history.pushState({}, '', '/community/c1/channel/ch-1');
+
+    expect(isContextViewedAndFocused('ch-1', undefined)).toBe(false);
+  });
+
+  it('returns false when the tab is hidden, even if the channel route matches', () => {
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      configurable: true,
+    });
+    window.history.pushState({}, '', '/community/c1/channel/ch-1');
+
+    expect(isContextViewedAndFocused('ch-1', undefined)).toBe(false);
+  });
+
+  it('returns true when focused and the pathname matches the given channel', () => {
+    window.history.pushState({}, '', '/community/c1/channel/ch-1');
+
+    expect(isContextViewedAndFocused('ch-1', undefined)).toBe(true);
+  });
+
+  it('returns false when focused but viewing a different channel', () => {
+    window.history.pushState({}, '', '/community/c1/channel/other');
+
+    expect(isContextViewedAndFocused('ch-1', undefined)).toBe(false);
+  });
+
+  it('returns true when focused and the active DM group matches', () => {
+    setActiveDmGroupId('dm-1');
+
+    expect(isContextViewedAndFocused(undefined, 'dm-1')).toBe(true);
+  });
+
+  it('returns false when focused but a different DM group is active', () => {
+    setActiveDmGroupId('dm-other');
+
+    expect(isContextViewedAndFocused(undefined, 'dm-1')).toBe(false);
+  });
+
+  it('returns false when neither channelId nor dmGroupId is provided', () => {
+    expect(isContextViewedAndFocused(undefined, undefined)).toBe(false);
+    expect(isContextViewedAndFocused(null, null)).toBe(false);
+  });
+});

--- a/frontend/src/components/Mobile/Navigation/MobileBottomNavigation.tsx
+++ b/frontend/src/components/Mobile/Navigation/MobileBottomNavigation.tsx
@@ -28,7 +28,10 @@ import { LAYOUT_CONSTANTS, TOUCH_TARGETS } from '../../../utils/breakpoints';
  */
 export const MobileBottomNavigation: React.FC = () => {
   const { activeTab, setActiveTab } = useMobileNavigation();
-  const { data: unreadData } = useQuery(notificationsControllerGetUnreadCountOptions());
+  const { data: unreadData } = useQuery({
+    ...notificationsControllerGetUnreadCountOptions(),
+    refetchOnWindowFocus: true,
+  });
   const notificationCount = unreadData?.count ?? 0;
   const { totalDmUnreadCount } = useReadReceipts();
 

--- a/frontend/src/components/Notifications/NotificationBadge.tsx
+++ b/frontend/src/components/Notifications/NotificationBadge.tsx
@@ -19,7 +19,10 @@ interface NotificationBadgeProps {
 
 export const NotificationBadge: React.FC<NotificationBadgeProps> = ({ onClick }) => {
   // Unread count is seeded on mount and kept current via WebSocket cache updates in useNotifications
-  const { data } = useQuery(notificationsControllerGetUnreadCountOptions());
+  const { data } = useQuery({
+    ...notificationsControllerGetUnreadCountOptions(),
+    refetchOnWindowFocus: true,
+  });
 
   const unreadCount = data?.count ?? 0;
 

--- a/frontend/src/hooks/useAppBadge.ts
+++ b/frontend/src/hooks/useAppBadge.ts
@@ -12,7 +12,10 @@ import { notificationsControllerGetUnreadCountOptions } from '../api-client/@tan
  * handlers, so this re-renders on every unread change without polling.
  */
 export function useAppBadge(baseTitle: string): void {
-  const { data } = useQuery(notificationsControllerGetUnreadCountOptions());
+  const { data } = useQuery({
+    ...notificationsControllerGetUnreadCountOptions(),
+    refetchOnWindowFocus: true,
+  });
   const unreadCount = data?.count ?? 0;
 
   // PWA icon badge

--- a/frontend/src/hooks/useMessageVisibility.ts
+++ b/frontend/src/hooks/useMessageVisibility.ts
@@ -7,6 +7,7 @@ import { readReceiptsControllerGetUnreadCountsQueryKey } from "../api-client/@ta
 import type { UnreadCountDto, PaginatedMessagesResponseDto } from "../api-client";
 import { channelMessagesQueryKey, dmMessagesQueryKey } from "../utils/messageQueryKeys";
 import { isDetachedFromLiveEdge } from "../utils/messageCacheUpdaters";
+import { useWindowFocus } from "./useWindowFocus";
 
 interface UseMessageVisibilityProps {
   channelId?: string;
@@ -34,9 +35,14 @@ export const useMessageVisibility = ({
 }: UseMessageVisibilityProps) => {
   const { socket } = useContext(SocketContext);
   const queryClient = useQueryClient();
+  const isFocused = useWindowFocus();
   const lastMarkedMessageIdRef = useRef<string | null>(null);
   const pendingMessageIdRef = useRef<string | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Holds the latest message id seen while the tab was blurred/hidden —
+  // MessageContainer keeps calling markAsRead with the newest visible id
+  // even while backgrounded, so this always ends up holding the freshest one.
+  const pendingWhileUnfocusedRef = useRef<string | null>(null);
 
   // Clean up debounce timer when deps change or on unmount,
   // preventing stale closures from emitting to the wrong channel/socket.
@@ -46,6 +52,7 @@ export const useMessageVisibility = ({
         clearTimeout(debounceTimerRef.current);
         debounceTimerRef.current = null;
       }
+      pendingWhileUnfocusedRef.current = null;
     };
   }, [socket, channelId, directMessageGroupId, enabled]);
 
@@ -56,6 +63,15 @@ export const useMessageVisibility = ({
       if (!socket || !enabled) return;
       if (!channelId && !directMessageGroupId) return;
       if (lastMarkedMessageIdRef.current === messageId) return;
+
+      // Background tabs must not silently mark messages as read — stash the
+      // id and replay it once focus returns (see the focus-regained effect
+      // below). Checked imperatively (not via the useWindowFocus() value) so
+      // this callback's identity/deps stay stable across focus changes.
+      if (!(document.hasFocus() && document.visibilityState === 'visible')) {
+        pendingWhileUnfocusedRef.current = messageId;
+        return;
+      }
 
       // Optimistic cache clear — immediately remove unread/mention indicators.
       // Skipped while the messages window is detached from the live edge
@@ -116,6 +132,16 @@ export const useMessageVisibility = ({
     },
     [socket, channelId, directMessageGroupId, enabled, queryClient]
   );
+
+  // Replay the most recent visible message once the tab regains focus.
+  useEffect(() => {
+    if (!isFocused) return;
+    if (!socket || !enabled) return;
+    const pendingId = pendingWhileUnfocusedRef.current;
+    if (!pendingId) return;
+    pendingWhileUnfocusedRef.current = null;
+    markAsRead(pendingId);
+  }, [isFocused, socket, enabled, markAsRead]);
 
   return {
     markAsRead,

--- a/frontend/src/hooks/useReadReceipts.ts
+++ b/frontend/src/hooks/useReadReceipts.ts
@@ -4,9 +4,10 @@ import { readReceiptsControllerGetUnreadCountsOptions } from "../api-client/@tan
 import type { UnreadCountDto } from "../api-client";
 
 export function useReadReceipts() {
-  const { data: unreadCounts } = useQuery(
-    readReceiptsControllerGetUnreadCountsOptions()
-  );
+  const { data: unreadCounts } = useQuery({
+    ...readReceiptsControllerGetUnreadCountsOptions(),
+    refetchOnWindowFocus: true,
+  });
 
   const byId = useMemo(() => {
     const map = new Map<string, UnreadCountDto>();

--- a/frontend/src/socket-hub/handlers/messageHandlers.ts
+++ b/frontend/src/socket-hub/handlers/messageHandlers.ts
@@ -92,9 +92,11 @@ export const handleNewMessage: SocketEventHandler<
 
   // Skip the unread bump when the user is actively viewing this exact
   // context with the tab focused — it would just be cleared moments later
-  // by visible-range markAsRead, causing a badge flash. The message-cache
-  // insert above still happens unconditionally.
-  if (isContextViewedAndFocused(message.channelId, message.directMessageGroupId)) {
+  // by visible-range markAsRead, causing a badge flash. Not applied while
+  // detached from the live edge (#404): the new message wasn't inserted and
+  // isn't visible, so visible-range markAsRead won't fire and the bump is
+  // the only signal that messages arrived.
+  if (!detached && isContextViewedAndFocused(message.channelId, message.directMessageGroupId)) {
     return;
   }
 

--- a/frontend/src/socket-hub/handlers/messageHandlers.ts
+++ b/frontend/src/socket-hub/handlers/messageHandlers.ts
@@ -18,6 +18,7 @@ import type {
   PaginatedMessagesResponseDto,
 } from '../../api-client';
 import { messageQueryKeyForContext, channelMessagesQueryKey } from '../../utils/messageQueryKeys';
+import { isContextViewedAndFocused } from '../../utils/activeContextTracking';
 import {
   readReceiptsControllerGetUnreadCountsQueryKey,
   readReceiptsControllerGetDmPeerReadsQueryKey,
@@ -86,6 +87,14 @@ export const handleNewMessage: SocketEventHandler<
     if (detached) {
       void queryClient.resetQueries({ queryKey, exact: true });
     }
+    return;
+  }
+
+  // Skip the unread bump when the user is actively viewing this exact
+  // context with the tab focused — it would just be cleared moments later
+  // by visible-range markAsRead, causing a badge flash. The message-cache
+  // insert above still happens unconditionally.
+  if (isContextViewedAndFocused(message.channelId, message.directMessageGroupId)) {
     return;
   }
 
@@ -302,34 +311,52 @@ export const handleReadReceiptUpdated: SocketEventHandler<typeof ServerEvents.RE
   const { channelId, directMessageGroupId, lastReadMessageId } = payload;
   const id = channelId || directMessageGroupId;
   if (!id) return;
-  const queryKey = readReceiptsControllerGetUnreadCountsQueryKey();
-  queryClient.setQueryData(queryKey, (old: UnreadCountDto[] | undefined) => {
-    if (!old) return old;
-    const updated: UnreadCountDto = {
-      channelId: channelId || undefined,
-      directMessageGroupId: directMessageGroupId || undefined,
-      unreadCount: 0,
-      mentionCount: 0,
-      lastReadMessageId,
-      lastReadAt: new Date().toISOString(),
-    };
-    const index = old.findIndex(
-      (c) => (c.channelId || c.directMessageGroupId) === id,
-    );
-    if (index >= 0) {
-      const next = [...old];
-      next[index] = updated;
-      return next;
-    }
-    return [...old, updated];
-  });
+
+  const currentUser = queryClient.getQueryData<UserControllerGetProfileResponse>(
+    userControllerGetProfileQueryKey(),
+  );
+
+  // The backend emits this event twice for a DM read: once to the reader's
+  // user room WITHOUT `userId` (self-sync — always applies to us), and once
+  // to the DM room WITH `userId` (seen-by fan-out to all participants,
+  // including peers). Only zero OUR unread badge when the receipt isn't a
+  // peer's. If `userId` is present but we don't have our own profile cached
+  // yet, skip zeroing — the self-sync copy (no userId) will still clear it.
+  const isPeerReceipt = !!payload.userId && payload.userId !== currentUser?.id;
+
+  if (!isPeerReceipt) {
+    const queryKey = readReceiptsControllerGetUnreadCountsQueryKey();
+    queryClient.setQueryData(queryKey, (old: UnreadCountDto[] | undefined) => {
+      if (!old) return old;
+      const index = old.findIndex(
+        (c) => (c.channelId || c.directMessageGroupId) === id,
+      );
+      if (index >= 0) {
+        const next = [...old];
+        next[index] = {
+          ...next[index],
+          unreadCount: 0,
+          mentionCount: 0,
+          lastReadMessageId,
+          lastReadAt: new Date().toISOString(),
+        };
+        return next;
+      }
+      const updated: UnreadCountDto = {
+        channelId: channelId || undefined,
+        directMessageGroupId: directMessageGroupId || undefined,
+        unreadCount: 0,
+        mentionCount: 0,
+        lastReadMessageId,
+        lastReadAt: new Date().toISOString(),
+      };
+      return [...old, updated];
+    });
+  }
 
   // Direct cache update for DM peer reads (watermark-based "seen by" real-time sync)
   if (payload.userId && payload.directMessageGroupId) {
     // Skip if this is the current user's own read receipt
-    const currentUser = queryClient.getQueryData<UserControllerGetProfileResponse>(
-      userControllerGetProfileQueryKey(),
-    );
     if (currentUser && payload.userId === currentUser.id) return;
 
     const peerReadsKey = readReceiptsControllerGetDmPeerReadsQueryKey({

--- a/frontend/src/utils/activeContextTracking.ts
+++ b/frontend/src/utils/activeContextTracking.ts
@@ -23,8 +23,14 @@ export function isContextViewedAndFocused(
   const focused = document.hasFocus() && document.visibilityState === 'visible';
   if (!focused) return false;
 
-  if (channelId && window.location.pathname.includes(`/channel/${channelId}`)) {
-    return true;
+  if (channelId) {
+    // Boundary-safe match — a bare includes() would let one id prefix-match
+    // another (e.g. `ch-1` vs `/channel/ch-10`).
+    const segment = `/channel/${channelId}`;
+    const path = window.location.pathname;
+    if (path.endsWith(segment) || path.includes(`${segment}/`)) {
+      return true;
+    }
   }
 
   if (dmGroupId && getActiveDmGroupId() === dmGroupId) {

--- a/frontend/src/utils/activeContextTracking.ts
+++ b/frontend/src/utils/activeContextTracking.ts
@@ -1,0 +1,35 @@
+/**
+ * Determines whether a given channel/DM context is the one the user is
+ * currently looking at, AND the tab is focused/visible.
+ *
+ * Used to suppress transient unread-badge increments for messages arriving
+ * in the conversation the user is already actively viewing — those get
+ * cleared moments later by visible-range markAsRead anyway, so incrementing
+ * first just causes a one-frame badge flash.
+ *
+ * Mirrors the "is the user viewing this context" precedent in
+ * useNotificationSideEffects.ts (used there to suppress sound/desktop
+ * notifications), but reads the route directly via `window.location` since
+ * this runs outside React (socket-hub handlers have no access to router
+ * context).
+ */
+
+import { getActiveDmGroupId } from './activeDmTracking';
+
+export function isContextViewedAndFocused(
+  channelId?: string | null,
+  dmGroupId?: string | null,
+): boolean {
+  const focused = document.hasFocus() && document.visibilityState === 'visible';
+  if (!focused) return false;
+
+  if (channelId && window.location.pathname.includes(`/channel/${channelId}`)) {
+    return true;
+  }
+
+  if (dmGroupId && getActiveDmGroupId() === dmGroupId) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

Root-cause fixes for "unread indicators never show" (DM icon badge, DM rows, channel dots were fully wired but being wiped):

- **Cross-user DM badge clearing**: the DM-room copy of `READ_RECEIPT_UPDATED` (which carries `userId` for seen-by fan-out) was zeroing the *peer's* unread/mention counts — the own-user guard sat below the zeroing block. Zeroing now only applies to self receipts, and the cache entry is spread (not rebuilt) so future fields survive.
- **Background-tab auto-read**: `useMessageVisibility` marked visible messages read even from blurred/hidden tabs, silently consuming unreads. Now gated on `document.hasFocus() && visibilityState === 'visible'`, with the latest visible id stashed and replayed on refocus.
- **Focus reconciliation**: unread-count queries (read-receipts + notifications, all three notification call sites sharing the key) opt in to `refetchOnWindowFocus: true` so missed WS events self-heal on refocus (global default untouched).
- **Badge flash**: `handleNewMessage` no longer bumps unread for the actively-viewed, focused context (new `activeContextTracking` util mirroring the `useNotificationSideEffects` precedent).

## Tests

- Bug-A regression matrix (peer receipt → counts unchanged; self/no-userId → zeroed; userId present but profile uncached → unchanged; extra-field preservation)
- Focus-gated mark-as-read: blurred → no clear/no emit; refocus → replay
- Increment suppression matrix (focused/blurred × active/inactive context, channel + DM)
- Targeted suites: 88 tests green. Full local run hits the documented WSL2 env-contention flakes (failing files pass in isolation); relying on CI for the authoritative full run.

Part 1 of the unread/notification indicator work; community badges + mute-aware indicators follow in a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)