### PR TITLE
feat(push): mark-as-read action button on push notifications

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4410,640 +4410,6 @@
         ]
       }
     },
-    "/api/notifications": {
-      "get": {
-        "operationId": "NotificationsController_getNotifications",
-        "parameters": [
-          {
-            "name": "unreadOnly",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "minimum": 1,
-              "maximum": 100,
-              "default": 50,
-              "type": "number"
-            }
-          },
-          {
-            "name": "offset",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "minimum": 0,
-              "default": 0,
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationListResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get notifications for current user with pagination\nGET /notifications?unreadOnly=true&limit=50&offset=0",
-        "tags": [
-          "Notifications"
-        ]
-      }
-    },
-    "/api/notifications/unread-count": {
-      "get": {
-        "operationId": "NotificationsController_getUnreadCount",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnreadCountResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get unread notification count\nGET /notifications/unread-count",
-        "tags": [
-          "Notifications"
-        ]
-      }
-    },
-    "/api/notifications/{id}/read": {
-      "post": {
-        "operationId": "NotificationsController_markAsRead",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Mark a notification as read\nPOST /notifications/:id/read",
-        "tags": [
-          "Notifications"
-        ]
-      }
-    },
-    "/api/notifications/read-all": {
-      "post": {
-        "operationId": "NotificationsController_markAllAsRead",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnreadCountResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Mark all notifications as read\nPOST /notifications/read-all",
-        "tags": [
-          "Notifications"
-        ]
-      }
-    },
-    "/api/notifications/{id}/dismiss": {
-      "post": {
-        "operationId": "NotificationsController_dismissNotification",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Dismiss a notification\nPOST /notifications/:id/dismiss",
-        "tags": [
-          "Notifications"
-        ]
-      }
-    },
-    "/api/notifications/{id}": {
-      "delete": {
-        "operationId": "NotificationsController_deleteNotification",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": ""
-          }
-        },
-        "summary": "Delete a notification\nDELETE /notifications/:id",
-        "tags": [
-          "Notifications"
-        ]
-      }
-    },
-    "/api/notifications/settings": {
-      "get": {
-        "operationId": "NotificationsController_getSettings",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserNotificationSettingsDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get user notification settings\nGET /notifications/settings",
-        "tags": [
-          "Notifications"
-        ]
-      },
-      "put": {
-        "operationId": "NotificationsController_updateSettings",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateNotificationSettingsDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserNotificationSettingsDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Update user notification settings\nPUT /notifications/settings",
-        "tags": [
-          "Notifications"
-        ]
-      }
-    },
-    "/api/notifications/channels/{channelId}/override": {
-      "get": {
-        "operationId": "NotificationsController_getChannelOverride",
-        "parameters": [
-          {
-            "name": "channelId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ChannelNotificationOverrideDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get channel notification override\nGET /notifications/channels/:channelId/override",
-        "tags": [
-          "Notifications"
-        ]
-      },
-      "put": {
-        "operationId": "NotificationsController_setChannelOverride",
-        "parameters": [
-          {
-            "name": "channelId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateChannelOverrideDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ChannelNotificationOverrideDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Set channel notification override\nPUT /notifications/channels/:channelId/override",
-        "tags": [
-          "Notifications"
-        ]
-      },
-      "delete": {
-        "operationId": "NotificationsController_deleteChannelOverride",
-        "parameters": [
-          {
-            "name": "channelId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": ""
-          }
-        },
-        "summary": "Delete channel notification override\nDELETE /notifications/channels/:channelId/override",
-        "tags": [
-          "Notifications"
-        ]
-      }
-    },
-    "/api/notifications/debug/send-test": {
-      "post": {
-        "operationId": "NotificationsController_sendTestNotification",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SendTestNotificationDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DebugNotificationResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "DEBUG: Send a test notification to the current user\nPOST /notifications/debug/send-test\nOnly available to OWNER users",
-        "tags": [
-          "Notifications"
-        ]
-      }
-    },
-    "/api/notifications/debug/subscriptions": {
-      "get": {
-        "operationId": "NotificationsController_getDebugSubscriptions",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DebugSubscriptionsResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "DEBUG: Get all push subscriptions for current user\nGET /notifications/debug/subscriptions\nOnly available to OWNER users",
-        "tags": [
-          "Notifications"
-        ]
-      }
-    },
-    "/api/notifications/debug/clear-all": {
-      "delete": {
-        "operationId": "NotificationsController_clearDebugSettings",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClearNotificationDataResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "DEBUG: Clear all notification settings for current user\nDELETE /notifications/debug/clear-all\nOnly available to OWNER users",
-        "tags": [
-          "Notifications"
-        ]
-      }
-    },
-    "/api/push/vapid-public-key": {
-      "get": {
-        "operationId": "PushNotificationsController_getVapidPublicKey",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VapidPublicKeyResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get the VAPID public key for client subscription\nReturns null if push notifications are not configured",
-        "tags": [
-          "PushNotifications"
-        ]
-      }
-    },
-    "/api/push/subscribe": {
-      "post": {
-        "operationId": "PushNotificationsController_subscribe",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SubscribePushDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SuccessMessageDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Subscribe to push notifications",
-        "tags": [
-          "PushNotifications"
-        ]
-      }
-    },
-    "/api/push/unsubscribe": {
-      "delete": {
-        "operationId": "PushNotificationsController_unsubscribe",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UnsubscribePushDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SuccessMessageDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Unsubscribe from push notifications",
-        "tags": [
-          "PushNotifications"
-        ]
-      }
-    },
-    "/api/push/status": {
-      "get": {
-        "operationId": "PushNotificationsController_getStatus",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PushStatusResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get current push subscription status",
-        "tags": [
-          "PushNotifications"
-        ]
-      }
-    },
-    "/api/push/test": {
-      "post": {
-        "operationId": "PushNotificationsController_sendTestPushToSelf",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestPushResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Send a test push notification to the current user\nPOST /push/test\nAny authenticated user can test their own push notifications",
-        "tags": [
-          "PushNotifications"
-        ]
-      }
-    },
-    "/api/push/debug/send-test": {
-      "post": {
-        "operationId": "PushNotificationsController_sendTestPush",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestPushResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "PushNotifications"
-        ]
-      }
-    },
-    "/api/presence/user/{userId}": {
-      "get": {
-        "operationId": "PresenceController_getUserPresence",
-        "parameters": [
-          {
-            "name": "userId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserPresenceResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Presence"
-        ]
-      }
-    },
-    "/api/presence/users/bulk": {
-      "get": {
-        "operationId": "PresenceController_getBulkPresence",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkPresenceResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Presence"
-        ]
-      }
-    },
-    "/api/presence/users/{userIds}": {
-      "get": {
-        "operationId": "PresenceController_getMultipleUserPresence",
-        "parameters": [
-          {
-            "name": "userIds",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkPresenceResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Presence"
-        ]
-      }
-    },
     "/api/moderation/ban/{communityId}/{userId}": {
       "post": {
         "operationId": "ModerationController_banUser",
@@ -5805,6 +5171,672 @@
         "summary": "Get all users who have read a specific message\nGET /read-receipts/message/:messageId/readers?channelId=xxx or ?directMessageGroupId=xxx",
         "tags": [
           "ReadReceipts"
+        ]
+      }
+    },
+    "/api/notifications": {
+      "get": {
+        "operationId": "NotificationsController_getNotifications",
+        "parameters": [
+          {
+            "name": "unreadOnly",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "maximum": 100,
+              "default": 50,
+              "type": "number"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 0,
+              "default": 0,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get notifications for current user with pagination\nGET /notifications?unreadOnly=true&limit=50&offset=0",
+        "tags": [
+          "Notifications"
+        ]
+      }
+    },
+    "/api/notifications/unread-count": {
+      "get": {
+        "operationId": "NotificationsController_getUnreadCount",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnreadCountResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get unread notification count\nGET /notifications/unread-count",
+        "tags": [
+          "Notifications"
+        ]
+      }
+    },
+    "/api/notifications/{id}/read": {
+      "post": {
+        "operationId": "NotificationsController_markAsRead",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Mark a notification as read\nPOST /notifications/:id/read",
+        "tags": [
+          "Notifications"
+        ]
+      }
+    },
+    "/api/notifications/read-all": {
+      "post": {
+        "operationId": "NotificationsController_markAllAsRead",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnreadCountResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Mark all notifications as read\nPOST /notifications/read-all",
+        "tags": [
+          "Notifications"
+        ]
+      }
+    },
+    "/api/notifications/{id}/dismiss": {
+      "post": {
+        "operationId": "NotificationsController_dismissNotification",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Dismiss a notification\nPOST /notifications/:id/dismiss",
+        "tags": [
+          "Notifications"
+        ]
+      }
+    },
+    "/api/notifications/{id}": {
+      "delete": {
+        "operationId": "NotificationsController_deleteNotification",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Delete a notification\nDELETE /notifications/:id",
+        "tags": [
+          "Notifications"
+        ]
+      }
+    },
+    "/api/notifications/settings": {
+      "get": {
+        "operationId": "NotificationsController_getSettings",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserNotificationSettingsDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get user notification settings\nGET /notifications/settings",
+        "tags": [
+          "Notifications"
+        ]
+      },
+      "put": {
+        "operationId": "NotificationsController_updateSettings",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateNotificationSettingsDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserNotificationSettingsDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Update user notification settings\nPUT /notifications/settings",
+        "tags": [
+          "Notifications"
+        ]
+      }
+    },
+    "/api/notifications/channels/{channelId}/override": {
+      "get": {
+        "operationId": "NotificationsController_getChannelOverride",
+        "parameters": [
+          {
+            "name": "channelId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChannelNotificationOverrideDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get channel notification override\nGET /notifications/channels/:channelId/override",
+        "tags": [
+          "Notifications"
+        ]
+      },
+      "put": {
+        "operationId": "NotificationsController_setChannelOverride",
+        "parameters": [
+          {
+            "name": "channelId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateChannelOverrideDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChannelNotificationOverrideDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Set channel notification override\nPUT /notifications/channels/:channelId/override",
+        "tags": [
+          "Notifications"
+        ]
+      },
+      "delete": {
+        "operationId": "NotificationsController_deleteChannelOverride",
+        "parameters": [
+          {
+            "name": "channelId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Delete channel notification override\nDELETE /notifications/channels/:channelId/override",
+        "tags": [
+          "Notifications"
+        ]
+      }
+    },
+    "/api/notifications/debug/send-test": {
+      "post": {
+        "operationId": "NotificationsController_sendTestNotification",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendTestNotificationDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebugNotificationResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "DEBUG: Send a test notification to the current user\nPOST /notifications/debug/send-test\nOnly available to OWNER users",
+        "tags": [
+          "Notifications"
+        ]
+      }
+    },
+    "/api/notifications/debug/subscriptions": {
+      "get": {
+        "operationId": "NotificationsController_getDebugSubscriptions",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebugSubscriptionsResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "DEBUG: Get all push subscriptions for current user\nGET /notifications/debug/subscriptions\nOnly available to OWNER users",
+        "tags": [
+          "Notifications"
+        ]
+      }
+    },
+    "/api/notifications/debug/clear-all": {
+      "delete": {
+        "operationId": "NotificationsController_clearDebugSettings",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClearNotificationDataResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "DEBUG: Clear all notification settings for current user\nDELETE /notifications/debug/clear-all\nOnly available to OWNER users",
+        "tags": [
+          "Notifications"
+        ]
+      }
+    },
+    "/api/notifications/push/mark-read": {
+      "post": {
+        "operationId": "PushActionsController_markRead",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushMarkReadDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessMessageDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Mark a notification as read from a push notification action button.\nPOST /notifications/push/mark-read",
+        "tags": [
+          "PushActions"
+        ]
+      }
+    },
+    "/api/push/vapid-public-key": {
+      "get": {
+        "operationId": "PushNotificationsController_getVapidPublicKey",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VapidPublicKeyResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get the VAPID public key for client subscription\nReturns null if push notifications are not configured",
+        "tags": [
+          "PushNotifications"
+        ]
+      }
+    },
+    "/api/push/subscribe": {
+      "post": {
+        "operationId": "PushNotificationsController_subscribe",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubscribePushDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessMessageDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Subscribe to push notifications",
+        "tags": [
+          "PushNotifications"
+        ]
+      }
+    },
+    "/api/push/unsubscribe": {
+      "delete": {
+        "operationId": "PushNotificationsController_unsubscribe",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnsubscribePushDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessMessageDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Unsubscribe from push notifications",
+        "tags": [
+          "PushNotifications"
+        ]
+      }
+    },
+    "/api/push/status": {
+      "get": {
+        "operationId": "PushNotificationsController_getStatus",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PushStatusResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get current push subscription status",
+        "tags": [
+          "PushNotifications"
+        ]
+      }
+    },
+    "/api/push/test": {
+      "post": {
+        "operationId": "PushNotificationsController_sendTestPushToSelf",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestPushResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Send a test push notification to the current user\nPOST /push/test\nAny authenticated user can test their own push notifications",
+        "tags": [
+          "PushNotifications"
+        ]
+      }
+    },
+    "/api/push/debug/send-test": {
+      "post": {
+        "operationId": "PushNotificationsController_sendTestPush",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestPushResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "PushNotifications"
+        ]
+      }
+    },
+    "/api/presence/user/{userId}": {
+      "get": {
+        "operationId": "PresenceController_getUserPresence",
+        "parameters": [
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserPresenceResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Presence"
+        ]
+      }
+    },
+    "/api/presence/users/bulk": {
+      "get": {
+        "operationId": "PresenceController_getBulkPresence",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkPresenceResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Presence"
+        ]
+      }
+    },
+    "/api/presence/users/{userIds}": {
+      "get": {
+        "operationId": "PresenceController_getMultipleUserPresence",
+        "parameters": [
+          {
+            "name": "userIds",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkPresenceResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Presence"
         ]
       }
     },
@@ -10513,489 +10545,16 @@
           "joinedAt"
         ]
       },
-      "NotificationAuthorDto": {
+      "ModerationBanUserDto": {
         "type": "object",
         "properties": {
-          "id": {
+          "reason": {
             "type": "string"
           },
-          "username": {
+          "expiresAt": {
             "type": "string"
-          },
-          "displayName": {
-            "type": "string",
-            "nullable": true
-          },
-          "avatarUrl": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "required": [
-          "id",
-          "username",
-          "displayName",
-          "avatarUrl"
-        ]
-      },
-      "NotificationMessageDto": {
-        "type": "object",
-        "properties": {
-          "spans": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SpanDto"
-            }
-          },
-          "id": {
-            "type": "string"
-          },
-          "channelId": {
-            "type": "string",
-            "nullable": true
-          },
-          "directMessageGroupId": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "required": [
-          "spans",
-          "id",
-          "channelId",
-          "directMessageGroupId"
-        ]
-      },
-      "NotificationDto": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "USER_MENTION",
-              "SPECIAL_MENTION",
-              "DIRECT_MESSAGE",
-              "CHANNEL_MESSAGE",
-              "THREAD_REPLY"
-            ]
-          },
-          "id": {
-            "type": "string"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "messageId": {
-            "type": "string",
-            "nullable": true
-          },
-          "channelId": {
-            "type": "string",
-            "nullable": true
-          },
-          "directMessageGroupId": {
-            "type": "string",
-            "nullable": true
-          },
-          "communityId": {
-            "type": "string",
-            "nullable": true
-          },
-          "authorId": {
-            "type": "string"
-          },
-          "parentMessageId": {
-            "type": "string",
-            "nullable": true
-          },
-          "read": {
-            "type": "boolean"
-          },
-          "dismissed": {
-            "type": "boolean"
-          },
-          "createdAt": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "author": {
-            "$ref": "#/components/schemas/NotificationAuthorDto"
-          },
-          "message": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/NotificationMessageDto"
-              }
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "id",
-          "userId",
-          "messageId",
-          "channelId",
-          "directMessageGroupId",
-          "authorId",
-          "parentMessageId",
-          "read",
-          "dismissed",
-          "createdAt"
-        ]
-      },
-      "NotificationListResponseDto": {
-        "type": "object",
-        "properties": {
-          "notifications": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/NotificationDto"
-            }
-          },
-          "total": {
-            "type": "number"
-          },
-          "unreadCount": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "notifications",
-          "total",
-          "unreadCount"
-        ]
-      },
-      "UnreadCountResponseDto": {
-        "type": "object",
-        "properties": {
-          "count": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "count"
-        ]
-      },
-      "UserNotificationSettingsDto": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "desktopEnabled": {
-            "type": "boolean"
-          },
-          "playSound": {
-            "type": "boolean"
-          },
-          "soundType": {
-            "type": "string"
-          },
-          "doNotDisturb": {
-            "type": "boolean"
-          },
-          "dndStartTime": {
-            "type": "string",
-            "nullable": true
-          },
-          "dndEndTime": {
-            "type": "string",
-            "nullable": true
-          },
-          "dndTimezone": {
-            "type": "string",
-            "nullable": true
-          },
-          "defaultChannelLevel": {
-            "type": "string"
-          },
-          "dmNotifications": {
-            "type": "boolean"
-          },
-          "createdAt": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "updatedAt": {
-            "format": "date-time",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "userId",
-          "desktopEnabled",
-          "playSound",
-          "soundType",
-          "doNotDisturb",
-          "dndStartTime",
-          "dndEndTime",
-          "dndTimezone",
-          "defaultChannelLevel",
-          "dmNotifications",
-          "createdAt",
-          "updatedAt"
-        ]
-      },
-      "UpdateNotificationSettingsDto": {
-        "type": "object",
-        "properties": {
-          "desktopEnabled": {
-            "type": "boolean"
-          },
-          "playSound": {
-            "type": "boolean"
-          },
-          "soundType": {
-            "type": "string",
-            "enum": [
-              "default",
-              "mention",
-              "dm"
-            ]
-          },
-          "doNotDisturb": {
-            "type": "boolean"
-          },
-          "dndStartTime": {
-            "type": "string",
-            "pattern": "/^([01]\\d|2[0-3]):([0-5]\\d)$/"
-          },
-          "dndEndTime": {
-            "type": "string",
-            "pattern": "/^([01]\\d|2[0-3]):([0-5]\\d)$/"
-          },
-          "dndTimezone": {
-            "type": "string",
-            "pattern": "/^[A-Za-z_]+(\\/[A-Za-z0-9_+-]+)*$/"
-          },
-          "defaultChannelLevel": {
-            "type": "string",
-            "enum": [
-              "all",
-              "mentions",
-              "none"
-            ]
-          },
-          "dmNotifications": {
-            "type": "boolean"
           }
         }
-      },
-      "ChannelNotificationOverrideDto": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "channelId": {
-            "type": "string"
-          },
-          "level": {
-            "type": "string"
-          },
-          "createdAt": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "updatedAt": {
-            "format": "date-time",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "userId",
-          "channelId",
-          "level",
-          "createdAt",
-          "updatedAt"
-        ]
-      },
-      "UpdateChannelOverrideDto": {
-        "type": "object",
-        "properties": {
-          "level": {
-            "type": "string",
-            "enum": [
-              "all",
-              "mentions",
-              "none"
-            ]
-          }
-        },
-        "required": [
-          "level"
-        ]
-      },
-      "SendTestNotificationDto": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "USER_MENTION",
-              "SPECIAL_MENTION",
-              "DIRECT_MESSAGE",
-              "CHANNEL_MESSAGE",
-              "THREAD_REPLY"
-            ]
-          },
-          "customMessage": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "DebugNotificationResponseDto": {
-        "type": "object",
-        "properties": {
-          "success": {
-            "type": "boolean"
-          },
-          "notification": {
-            "$ref": "#/components/schemas/NotificationDto"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "success",
-          "notification",
-          "message"
-        ]
-      },
-      "DebugPushSubscriptionDto": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "endpoint": {
-            "type": "string"
-          },
-          "userAgent": {
-            "type": "string",
-            "nullable": true
-          },
-          "createdAt": {
-            "format": "date-time",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "endpoint",
-          "createdAt"
-        ]
-      },
-      "DebugSubscriptionsResponseDto": {
-        "type": "object",
-        "properties": {
-          "subscriptions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DebugPushSubscriptionDto"
-            }
-          },
-          "count": {
-            "type": "number"
-          },
-          "pushEnabled": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "subscriptions",
-          "count",
-          "pushEnabled"
-        ]
-      },
-      "ClearNotificationDataResponseDto": {
-        "type": "object",
-        "properties": {
-          "success": {
-            "type": "boolean"
-          },
-          "notificationsDeleted": {
-            "type": "number"
-          },
-          "settingsDeleted": {
-            "type": "number"
-          },
-          "overridesDeleted": {
-            "type": "number"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "success",
-          "notificationsDeleted",
-          "settingsDeleted",
-          "overridesDeleted",
-          "message"
-        ]
-      },
-      "VapidPublicKeyResponseDto": {
-        "type": "object",
-        "properties": {
-          "publicKey": {
-            "type": "string",
-            "nullable": true
-          },
-          "enabled": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "publicKey",
-          "enabled"
-        ]
-      },
-      "PushSubscriptionKeys": {
-        "type": "object",
-        "properties": {
-          "p256dh": {
-            "type": "string"
-          },
-          "auth": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "p256dh",
-          "auth"
-        ]
-      },
-      "SubscribePushDto": {
-        "type": "object",
-        "properties": {
-          "endpoint": {
-            "type": "string"
-          },
-          "keys": {
-            "$ref": "#/components/schemas/PushSubscriptionKeys"
-          },
-          "userAgent": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "endpoint",
-          "keys"
-        ]
       },
       "SuccessMessageDto": {
         "type": "object",
@@ -11011,95 +10570,6 @@
           "success",
           "message"
         ]
-      },
-      "UnsubscribePushDto": {
-        "type": "object",
-        "properties": {
-          "endpoint": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "endpoint"
-        ]
-      },
-      "PushStatusResponseDto": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": "boolean"
-          },
-          "subscriptionCount": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "enabled",
-          "subscriptionCount"
-        ]
-      },
-      "TestPushResponseDto": {
-        "type": "object",
-        "properties": {
-          "success": {
-            "type": "boolean"
-          },
-          "sent": {
-            "type": "number"
-          },
-          "failed": {
-            "type": "number"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "success",
-          "sent",
-          "failed",
-          "message"
-        ]
-      },
-      "UserPresenceResponseDto": {
-        "type": "object",
-        "properties": {
-          "userId": {
-            "type": "string"
-          },
-          "isOnline": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "userId",
-          "isOnline"
-        ]
-      },
-      "BulkPresenceResponseDto": {
-        "type": "object",
-        "properties": {
-          "presence": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "boolean"
-            }
-          }
-        },
-        "required": [
-          "presence"
-        ]
-      },
-      "ModerationBanUserDto": {
-        "type": "object",
-        "properties": {
-          "reason": {
-            "type": "string"
-          },
-          "expiresAt": {
-            "type": "string"
-          }
-        }
       },
       "UnbanUserDto": {
         "type": "object",
@@ -11764,6 +11234,580 @@
           "displayName",
           "avatarUrl",
           "readAt"
+        ]
+      },
+      "NotificationAuthorDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "avatarUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "displayName",
+          "avatarUrl"
+        ]
+      },
+      "NotificationMessageDto": {
+        "type": "object",
+        "properties": {
+          "spans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpanDto"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string",
+            "nullable": true
+          },
+          "directMessageGroupId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "spans",
+          "id",
+          "channelId",
+          "directMessageGroupId"
+        ]
+      },
+      "NotificationDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "USER_MENTION",
+              "SPECIAL_MENTION",
+              "DIRECT_MESSAGE",
+              "CHANNEL_MESSAGE",
+              "THREAD_REPLY"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string",
+            "nullable": true
+          },
+          "channelId": {
+            "type": "string",
+            "nullable": true
+          },
+          "directMessageGroupId": {
+            "type": "string",
+            "nullable": true
+          },
+          "communityId": {
+            "type": "string",
+            "nullable": true
+          },
+          "authorId": {
+            "type": "string"
+          },
+          "parentMessageId": {
+            "type": "string",
+            "nullable": true
+          },
+          "read": {
+            "type": "boolean"
+          },
+          "dismissed": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "author": {
+            "$ref": "#/components/schemas/NotificationAuthorDto"
+          },
+          "message": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NotificationMessageDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "userId",
+          "messageId",
+          "channelId",
+          "directMessageGroupId",
+          "authorId",
+          "parentMessageId",
+          "read",
+          "dismissed",
+          "createdAt"
+        ]
+      },
+      "NotificationListResponseDto": {
+        "type": "object",
+        "properties": {
+          "notifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NotificationDto"
+            }
+          },
+          "total": {
+            "type": "number"
+          },
+          "unreadCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "notifications",
+          "total",
+          "unreadCount"
+        ]
+      },
+      "UnreadCountResponseDto": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "count"
+        ]
+      },
+      "UserNotificationSettingsDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "desktopEnabled": {
+            "type": "boolean"
+          },
+          "playSound": {
+            "type": "boolean"
+          },
+          "soundType": {
+            "type": "string"
+          },
+          "doNotDisturb": {
+            "type": "boolean"
+          },
+          "dndStartTime": {
+            "type": "string",
+            "nullable": true
+          },
+          "dndEndTime": {
+            "type": "string",
+            "nullable": true
+          },
+          "dndTimezone": {
+            "type": "string",
+            "nullable": true
+          },
+          "defaultChannelLevel": {
+            "type": "string"
+          },
+          "dmNotifications": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "desktopEnabled",
+          "playSound",
+          "soundType",
+          "doNotDisturb",
+          "dndStartTime",
+          "dndEndTime",
+          "dndTimezone",
+          "defaultChannelLevel",
+          "dmNotifications",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "UpdateNotificationSettingsDto": {
+        "type": "object",
+        "properties": {
+          "desktopEnabled": {
+            "type": "boolean"
+          },
+          "playSound": {
+            "type": "boolean"
+          },
+          "soundType": {
+            "type": "string",
+            "enum": [
+              "default",
+              "mention",
+              "dm"
+            ]
+          },
+          "doNotDisturb": {
+            "type": "boolean"
+          },
+          "dndStartTime": {
+            "type": "string",
+            "pattern": "/^([01]\\d|2[0-3]):([0-5]\\d)$/"
+          },
+          "dndEndTime": {
+            "type": "string",
+            "pattern": "/^([01]\\d|2[0-3]):([0-5]\\d)$/"
+          },
+          "dndTimezone": {
+            "type": "string",
+            "pattern": "/^[A-Za-z_]+(\\/[A-Za-z0-9_+-]+)*$/"
+          },
+          "defaultChannelLevel": {
+            "type": "string",
+            "enum": [
+              "all",
+              "mentions",
+              "none"
+            ]
+          },
+          "dmNotifications": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ChannelNotificationOverrideDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "channelId": {
+            "type": "string"
+          },
+          "level": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "channelId",
+          "level",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "UpdateChannelOverrideDto": {
+        "type": "object",
+        "properties": {
+          "level": {
+            "type": "string",
+            "enum": [
+              "all",
+              "mentions",
+              "none"
+            ]
+          }
+        },
+        "required": [
+          "level"
+        ]
+      },
+      "SendTestNotificationDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "USER_MENTION",
+              "SPECIAL_MENTION",
+              "DIRECT_MESSAGE",
+              "CHANNEL_MESSAGE",
+              "THREAD_REPLY"
+            ]
+          },
+          "customMessage": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "DebugNotificationResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "notification": {
+            "$ref": "#/components/schemas/NotificationDto"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "notification",
+          "message"
+        ]
+      },
+      "DebugPushSubscriptionDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "endpoint": {
+            "type": "string"
+          },
+          "userAgent": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "endpoint",
+          "createdAt"
+        ]
+      },
+      "DebugSubscriptionsResponseDto": {
+        "type": "object",
+        "properties": {
+          "subscriptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DebugPushSubscriptionDto"
+            }
+          },
+          "count": {
+            "type": "number"
+          },
+          "pushEnabled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "subscriptions",
+          "count",
+          "pushEnabled"
+        ]
+      },
+      "ClearNotificationDataResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "notificationsDeleted": {
+            "type": "number"
+          },
+          "settingsDeleted": {
+            "type": "number"
+          },
+          "overridesDeleted": {
+            "type": "number"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "notificationsDeleted",
+          "settingsDeleted",
+          "overridesDeleted",
+          "message"
+        ]
+      },
+      "PushMarkReadDto": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "Signed action token embedded in the push payload (data.markReadToken)."
+          }
+        },
+        "required": [
+          "token"
+        ]
+      },
+      "VapidPublicKeyResponseDto": {
+        "type": "object",
+        "properties": {
+          "publicKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "publicKey",
+          "enabled"
+        ]
+      },
+      "PushSubscriptionKeys": {
+        "type": "object",
+        "properties": {
+          "p256dh": {
+            "type": "string"
+          },
+          "auth": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "p256dh",
+          "auth"
+        ]
+      },
+      "SubscribePushDto": {
+        "type": "object",
+        "properties": {
+          "endpoint": {
+            "type": "string"
+          },
+          "keys": {
+            "$ref": "#/components/schemas/PushSubscriptionKeys"
+          },
+          "userAgent": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "endpoint",
+          "keys"
+        ]
+      },
+      "UnsubscribePushDto": {
+        "type": "object",
+        "properties": {
+          "endpoint": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "endpoint"
+        ]
+      },
+      "PushStatusResponseDto": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "subscriptionCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "enabled",
+          "subscriptionCount"
+        ]
+      },
+      "TestPushResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "sent": {
+            "type": "number"
+          },
+          "failed": {
+            "type": "number"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "sent",
+          "failed",
+          "message"
+        ]
+      },
+      "UserPresenceResponseDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string"
+          },
+          "isOnline": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "userId",
+          "isOnline"
+        ]
+      },
+      "BulkPresenceResponseDto": {
+        "type": "object",
+        "properties": {
+          "presence": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          }
+        },
+        "required": [
+          "presence"
         ]
       },
       "OnboardingStatusDto": {

--- a/backend/src/notifications/dto/push-mark-read.dto.ts
+++ b/backend/src/notifications/dto/push-mark-read.dto.ts
@@ -1,0 +1,12 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PushMarkReadDto {
+  @ApiProperty({
+    description:
+      'Signed action token embedded in the push payload (data.markReadToken).',
+  })
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';
+import { PushActionsController } from './push-actions.controller';
 import { NotificationsGateway } from './notifications.gateway';
 import { NotificationsFanoutProcessor } from './notifications-fanout.processor';
 import { DatabaseModule } from '@/database/database.module';
@@ -12,7 +13,7 @@ import { PresenceModule } from '@/presence/presence.module';
 import { RedisModule } from '@/redis/redis.module';
 
 @Module({
-  controllers: [NotificationsController],
+  controllers: [NotificationsController, PushActionsController],
   providers: [
     NotificationsService,
     NotificationsGateway,

--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -1622,6 +1622,103 @@ describe('NotificationsService', () => {
   });
 
   // ============================================================================
+  // PUSH ACTION TOKEN (Mark as read)
+  // ============================================================================
+
+  describe('push notification action token', () => {
+    const authorId = 'author-1';
+    const targetUserId = 'target-user';
+    const channelId = 'channel-1';
+
+    beforeEach(() => {
+      pushNotificationsService.isEnabled.mockReturnValue(true);
+    });
+
+    function setupForPushTest() {
+      const notification = NotificationFactory.build({
+        type: NotificationType.USER_MENTION,
+        authorId,
+        channelId,
+      });
+
+      mockDatabase.notification.create.mockResolvedValue({
+        ...notification,
+        author: {
+          id: authorId,
+          username: 'johndoe',
+          displayName: 'John Doe',
+          avatarUrl: null,
+        },
+        message: {
+          id: 'msg-1',
+          spans: [{ text: 'Hello' }],
+          channelId,
+          directMessageGroupId: null,
+        },
+        channel: { id: channelId, name: 'general', communityId: 'community-1' },
+      });
+
+      const settings = UserNotificationSettingsFactory.build();
+      mockDatabase.userNotificationSettings.upsert.mockResolvedValue(settings);
+      mockDatabase.channelNotificationOverride.findUnique.mockResolvedValue(
+        null,
+      );
+
+      return MessageFactory.build({
+        id: 'msg-1',
+        channelId,
+        authorId,
+        spans: [
+          {
+            type: SpanType.USER_MENTION,
+            userId: targetUserId,
+            text: null,
+            specialKind: null,
+            communityId: null,
+            aliasId: null,
+          },
+        ],
+      } as any);
+    }
+
+    it('should include markReadToken in push payload data when a token is created', async () => {
+      pushNotificationsService.createActionToken.mockReturnValue(
+        'signed-token-value',
+      );
+      const message = setupForPushTest();
+
+      await service.processMessageForNotifications(message as any);
+
+      expect(pushNotificationsService.createActionToken).toHaveBeenCalledWith(
+        targetUserId,
+        expect.any(String),
+      );
+      expect(pushNotificationsService.sendToUser).toHaveBeenCalledWith(
+        targetUserId,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            markReadToken: 'signed-token-value',
+          }),
+        }),
+      );
+    });
+
+    it('should omit markReadToken from push payload data when token creation returns null', async () => {
+      pushNotificationsService.createActionToken.mockReturnValue(null);
+      const message = setupForPushTest();
+
+      await service.processMessageForNotifications(message as any);
+
+      const call = pushNotificationsService.sendToUser.mock.calls.find(
+        ([uid]) => uid === targetUserId,
+      );
+      expect(call).toBeDefined();
+      const data = call![1].data as Record<string, unknown>;
+      expect(data).not.toHaveProperty('markReadToken');
+    });
+  });
+
+  // ============================================================================
   // PUSH NOTIFICATION BODY
   // ============================================================================
 

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -633,6 +633,14 @@ export class NotificationsService {
       const title = this.formatPushTitle(notification);
       const body = this.formatPushBody(notification);
 
+      // Scoped action token authorizing the "Mark as read" push action
+      // button (unauthenticated — the SW has no JWT). Omitted when
+      // JWT_SECRET isn't configured.
+      const markReadToken = this.pushNotificationsService.createActionToken(
+        userId,
+        notification.id,
+      );
+
       await this.pushNotificationsService.sendToUser(userId, {
         title,
         body,
@@ -643,6 +651,7 @@ export class NotificationsService {
           communityId: notification.channel?.communityId,
           directMessageGroupId: notification.directMessageGroupId,
           type: notification.type,
+          ...(markReadToken ? { markReadToken } : {}),
         },
       });
 

--- a/backend/src/notifications/push-actions.controller.spec.ts
+++ b/backend/src/notifications/push-actions.controller.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed } from '@suites/unit';
+import type { Mocked } from '@suites/doubles.jest';
+import { UnauthorizedException } from '@nestjs/common';
+import { PushActionsController } from './push-actions.controller';
+import { NotificationsService } from './notifications.service';
+import { PushNotificationsService } from '@/push-notifications/push-notifications.service';
+
+describe('PushActionsController', () => {
+  let controller: PushActionsController;
+  let notificationsService: Mocked<NotificationsService>;
+  let pushNotificationsService: Mocked<PushNotificationsService>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(
+      PushActionsController,
+    ).compile();
+
+    controller = unit;
+    notificationsService = unitRef.get(NotificationsService);
+    pushNotificationsService = unitRef.get(PushNotificationsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('markRead', () => {
+    it('should mark the notification as read when the token is valid', async () => {
+      const userId = 'user-123';
+      const notificationId = 'notification-456';
+      pushNotificationsService.verifyActionToken.mockReturnValue({
+        userId,
+        notificationId,
+      });
+      notificationsService.markAsRead.mockResolvedValue({} as any);
+
+      const result = await controller.markRead({ token: 'valid-token' });
+
+      expect(pushNotificationsService.verifyActionToken).toHaveBeenCalledWith(
+        'valid-token',
+      );
+      expect(notificationsService.markAsRead).toHaveBeenCalledWith(
+        notificationId,
+        userId,
+      );
+      expect(result).toEqual({
+        success: true,
+        message: 'Notification marked as read',
+      });
+    });
+
+    it('should throw UnauthorizedException and not call markAsRead when the token is invalid', async () => {
+      pushNotificationsService.verifyActionToken.mockReturnValue(null);
+
+      await expect(
+        controller.markRead({ token: 'invalid-token' }),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(notificationsService.markAsRead).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/notifications/push-actions.controller.ts
+++ b/backend/src/notifications/push-actions.controller.ts
@@ -1,0 +1,52 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Post,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
+import { NotificationsService } from './notifications.service';
+import { PushNotificationsService } from '@/push-notifications/push-notifications.service';
+import { PushMarkReadDto } from './dto/push-mark-read.dto';
+import { SuccessMessageDto } from '@/common/dto/common-response.dto';
+
+/**
+ * Endpoints hit by the service worker's push-notification action buttons.
+ *
+ * These are intentionally UNAUTHENTICATED (no JwtAuthGuard) — the service
+ * worker deliberately stores no JWT, so the signed, scoped `token` in the
+ * request body IS the auth. Each token is single-purpose: it authorizes
+ * marking exactly one notification as read for the user it was issued to,
+ * and expires after 7 days. See
+ * docs/superpowers/specs/2026-08-09-push-notification-actions-design.md
+ * for the full design rationale.
+ */
+@Controller('notifications/push')
+export class PushActionsController {
+  constructor(
+    private readonly notificationsService: NotificationsService,
+    private readonly pushNotificationsService: PushNotificationsService,
+  ) {}
+
+  /**
+   * Mark a notification as read from a push notification action button.
+   * POST /notifications/push/mark-read
+   */
+  @Post('mark-read')
+  @HttpCode(200)
+  @ApiOkResponse({ type: SuccessMessageDto })
+  async markRead(@Body() dto: PushMarkReadDto): Promise<SuccessMessageDto> {
+    const claims = this.pushNotificationsService.verifyActionToken(dto.token);
+    if (!claims) {
+      throw new UnauthorizedException('Invalid or expired action token');
+    }
+
+    await this.notificationsService.markAsRead(
+      claims.notificationId,
+      claims.userId,
+    );
+
+    return { success: true, message: 'Notification marked as read' };
+  }
+}

--- a/backend/src/push-notifications/push-notifications.service.spec.ts
+++ b/backend/src/push-notifications/push-notifications.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@suites/unit';
 import type { Mocked } from '@suites/doubles.jest';
 import { ConfigService } from '@nestjs/config';
+import { createHmac } from 'node:crypto';
 import { PushNotificationsService } from './push-notifications.service';
 import { DatabaseService } from '@/database/database.service';
 import { createMockDatabase } from '@/test-utils';
@@ -508,6 +509,167 @@ describe('PushNotificationsService', () => {
       expect(result).toEqual({ sent: 0, failed: 1 });
       expect(mockDatabase.pushSubscription.delete).toHaveBeenCalledWith({
         where: { id: 'sub-1' },
+      });
+    });
+  });
+
+  describe('action tokens', () => {
+    const jwtSecret = 'test-jwt-secret';
+    const userId = 'user-123';
+    const notificationId = 'notification-456';
+
+    beforeEach(() => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'JWT_SECRET') return jwtSecret;
+        return undefined;
+      });
+    });
+
+    describe('createActionToken', () => {
+      it('should return null when JWT_SECRET is not configured', () => {
+        configService.get.mockReturnValue(undefined);
+
+        const token = service.createActionToken(userId, notificationId);
+
+        expect(token).toBeNull();
+      });
+
+      it('should create a token with exactly two dot-separated parts', () => {
+        const token = service.createActionToken(userId, notificationId);
+
+        expect(token).not.toBeNull();
+        expect(token!.split('.')).toHaveLength(2);
+      });
+    });
+
+    describe('verifyActionToken', () => {
+      it('should round-trip: verify returns the ids used to create the token', () => {
+        const token = service.createActionToken(userId, notificationId);
+
+        const claims = service.verifyActionToken(token!);
+
+        expect(claims).toEqual({ userId, notificationId });
+      });
+
+      it('should return null when JWT_SECRET is not configured', () => {
+        const token = service.createActionToken(userId, notificationId);
+
+        configService.get.mockReturnValue(undefined);
+        const claims = service.verifyActionToken(token!);
+
+        expect(claims).toBeNull();
+      });
+
+      it('should reject a token with a tampered payload', () => {
+        const token = service.createActionToken(userId, notificationId);
+        const [, signature] = token!.split('.');
+
+        const tamperedPayload = Buffer.from(
+          JSON.stringify({
+            u: 'attacker',
+            n: notificationId,
+            exp: Math.floor(Date.now() / 1000) + 1000,
+          }),
+        ).toString('base64url');
+
+        const claims = service.verifyActionToken(
+          `${tamperedPayload}.${signature}`,
+        );
+
+        expect(claims).toBeNull();
+      });
+
+      it('should reject a token with a tampered signature', () => {
+        const token = service.createActionToken(userId, notificationId);
+        const [payloadB64, signature] = token!.split('.');
+        // Flip a character in the middle of the signature (not the last
+        // char — in a 32-byte base64url digest the last char's low bits
+        // are padding, so some substitutions there are no-ops).
+        const mid = Math.floor(signature.length / 2);
+        const tamperedChar = signature[mid] === 'A' ? 'B' : 'A';
+        const tamperedSignature =
+          signature.slice(0, mid) + tamperedChar + signature.slice(mid + 1);
+
+        const claims = service.verifyActionToken(
+          `${payloadB64}.${tamperedSignature}`,
+        );
+
+        expect(claims).toBeNull();
+      });
+
+      it('should reject a token with a truncated signature', () => {
+        const token = service.createActionToken(userId, notificationId);
+        const [payloadB64, signature] = token!.split('.');
+
+        const claims = service.verifyActionToken(
+          `${payloadB64}.${signature.slice(0, 4)}`,
+        );
+
+        expect(claims).toBeNull();
+      });
+
+      it.each(['', 'abc', 'a.b.c'])(
+        'should reject malformed token %j',
+        (malformed) => {
+          const claims = service.verifyActionToken(malformed);
+
+          expect(claims).toBeNull();
+        },
+      );
+
+      it('should reject an expired token', () => {
+        // Hand-craft a token using the same derivation as the service, but
+        // with an already-expired `exp`.
+        const key = createHmac('sha256', jwtSecret)
+          .update('semaphore-push-action-v1')
+          .digest();
+        const payload = {
+          u: userId,
+          n: notificationId,
+          exp: Math.floor(Date.now() / 1000) - 10,
+        };
+        const payloadB64 = Buffer.from(JSON.stringify(payload)).toString(
+          'base64url',
+        );
+        const signature = createHmac('sha256', key)
+          .update(payloadB64)
+          .digest('base64url');
+        const expiredToken = `${payloadB64}.${signature}`;
+
+        const claims = service.verifyActionToken(expiredToken);
+
+        expect(claims).toBeNull();
+      });
+
+      it('should reject a token whose payload is missing required fields', () => {
+        const key = createHmac('sha256', jwtSecret)
+          .update('semaphore-push-action-v1')
+          .digest();
+        const payload = { u: userId }; // missing n and exp
+        const payloadB64 = Buffer.from(JSON.stringify(payload)).toString(
+          'base64url',
+        );
+        const signature = createHmac('sha256', key)
+          .update(payloadB64)
+          .digest('base64url');
+
+        const claims = service.verifyActionToken(`${payloadB64}.${signature}`);
+
+        expect(claims).toBeNull();
+      });
+
+      it('should reject a token whose payload is unparseable JSON', () => {
+        const key = createHmac('sha256', jwtSecret)
+          .update('semaphore-push-action-v1')
+          .digest();
+        const payloadB64 = Buffer.from('not-json').toString('base64url');
+        const signature = createHmac('sha256', key)
+          .update(payloadB64)
+          .digest('base64url');
+
+        const claims = service.verifyActionToken(`${payloadB64}.${signature}`);
+
+        expect(claims).toBeNull();
       });
     });
   });

--- a/backend/src/push-notifications/push-notifications.service.ts
+++ b/backend/src/push-notifications/push-notifications.service.ts
@@ -1,10 +1,27 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Cron, CronExpression } from '@nestjs/schedule';
+import { createHmac, timingSafeEqual } from 'node:crypto';
 import * as webpush from 'web-push';
 import { DatabaseService } from '@/database/database.service';
 import { SubscribePushDto } from './dto/subscribe.dto';
 import { PushSubscription } from '@prisma/client';
+
+/**
+ * Domain-separation string used when deriving the push action-token signing
+ * key from JWT_SECRET. Never sign action tokens with the raw JWT_SECRET —
+ * a token signed with the raw secret could potentially be replayed against
+ * the passport JWT strategy.
+ */
+const ACTION_TOKEN_KEY_INFO = 'semaphore-push-action-v1';
+
+const ACTION_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+interface ActionTokenPayload {
+  u: string;
+  n: string;
+  exp: number;
+}
 
 export interface PushNotificationPayload {
   title: string;
@@ -283,6 +300,105 @@ export class PushNotificationsService implements OnModuleInit {
         error,
       );
     }
+  }
+
+  /**
+   * Derive the HMAC signing key for push action tokens from JWT_SECRET.
+   * Computed lazily (not cached at construction time) so it always reflects
+   * the current config, even if JWT_SECRET is loaded after this service is
+   * constructed.
+   */
+  private getActionTokenKey(): Buffer | null {
+    const jwtSecret = this.configService.get<string>('JWT_SECRET');
+    if (!jwtSecret) {
+      return null;
+    }
+    return createHmac('sha256', jwtSecret)
+      .update(ACTION_TOKEN_KEY_INFO)
+      .digest();
+  }
+
+  /**
+   * Create a signed, scoped action token that authorizes marking a single
+   * notification as read from an unauthenticated push-notification action
+   * button. Not single-use — see design doc for rationale.
+   */
+  createActionToken(userId: string, notificationId: string): string | null {
+    const key = this.getActionTokenKey();
+    if (!key) {
+      return null;
+    }
+
+    const payload: ActionTokenPayload = {
+      u: userId,
+      n: notificationId,
+      exp: Math.floor(Date.now() / 1000) + ACTION_TOKEN_TTL_SECONDS,
+    };
+
+    const payloadB64 = Buffer.from(JSON.stringify(payload)).toString(
+      'base64url',
+    );
+    const signature = createHmac('sha256', key)
+      .update(payloadB64)
+      .digest('base64url');
+
+    return `${payloadB64}.${signature}`;
+  }
+
+  /**
+   * Verify a push action token. Never throws — returns null for any
+   * malformed, tampered, or expired token.
+   */
+  verifyActionToken(
+    token: string,
+  ): { userId: string; notificationId: string } | null {
+    const key = this.getActionTokenKey();
+    if (!key) {
+      return null;
+    }
+
+    const parts = token.split('.');
+    if (parts.length !== 2) {
+      return null;
+    }
+    const [payloadB64, signature] = parts;
+
+    const expectedSignature = createHmac('sha256', key)
+      .update(payloadB64)
+      .digest('base64url');
+
+    const signatureBuf = Buffer.from(signature, 'base64url');
+    const expectedBuf = Buffer.from(expectedSignature, 'base64url');
+    if (signatureBuf.length !== expectedBuf.length) {
+      return null;
+    }
+    if (!timingSafeEqual(signatureBuf, expectedBuf)) {
+      return null;
+    }
+
+    let payload: ActionTokenPayload;
+    try {
+      payload = JSON.parse(
+        Buffer.from(payloadB64, 'base64url').toString('utf8'),
+      ) as ActionTokenPayload;
+    } catch {
+      return null;
+    }
+
+    if (
+      !payload ||
+      typeof payload.u !== 'string' ||
+      typeof payload.n !== 'string' ||
+      typeof payload.exp !== 'number'
+    ) {
+      return null;
+    }
+
+    if (payload.exp <= Math.floor(Date.now() / 1000)) {
+      return null;
+    }
+
+    return { userId: payload.u, notificationId: payload.n };
   }
 
   /**

--- a/docs/superpowers/specs/2026-08-09-push-notification-actions-design.md
+++ b/docs/superpowers/specs/2026-08-09-push-notification-actions-design.md
@@ -1,0 +1,90 @@
+# Push Notification Action Buttons — Design (Issue #397)
+
+Date: 2026-08-09
+Scope: "Mark as read" action button on push notifications. Inline reply is
+explicitly out of scope (see Non-Goals).
+
+## Problem
+
+Push notifications (web push via the service worker) currently support only
+one interaction: clicking the body opens/focuses the app at the relevant
+channel/DM. Users cannot dismiss a mention without opening the app. The SW
+deliberately stores no JWT, so any action that hits the backend needs its own
+auth strategy.
+
+## Design
+
+### Auth: scoped HMAC action token in the push payload
+
+The backend embeds a single-purpose signed token in each push payload
+(`data.markReadToken`). Properties:
+
+- **Payload**: `{ u: userId, n: notificationId, exp: epochSeconds }` with a
+  7-day expiry (push delivery TTL is 24h, but a displayed notification can be
+  clicked days later).
+- **Format**: `base64url(JSON payload) + "." + base64url(HMAC-SHA256(payload))`.
+- **Key**: derived from `JWT_SECRET` via `HMAC-SHA256(key=JWT_SECRET,
+  msg="semaphore-push-action-v1")`. Never the raw `JWT_SECRET` — a token
+  signed with the raw secret and a `sub` claim could be replayed as an API
+  access token against the passport JWT strategy.
+- **Verification**: constant-time signature compare (`timingSafeEqual`), then
+  expiry check. Returns `{ userId, notificationId }` or `null`.
+- **Replay**: not single-use. Marking a notification read is idempotent and
+  authorizes nothing else, so replay within the expiry window is harmless.
+  This avoids any Redis/DB state for token tracking.
+
+Implemented as `createActionToken` / `verifyActionToken` on
+`PushNotificationsService` (it already has `ConfigService`).
+
+### Backend endpoint
+
+New controller `PushActionsController` in the notifications module (avoids a
+circular import: NotificationsModule already imports PushNotificationsModule):
+
+- `POST /notifications/push/mark-read`, body `{ token: string }` (DTO with
+  `@IsString()` validation), **no JwtAuthGuard** — the token is the auth.
+- Invalid/expired token → 401. Valid token → existing
+  `NotificationsService.markAsRead(notificationId, userId)` (which also emits
+  the WS `notificationRead` event so open clients stay in sync). Deleted
+  notification → 404 (acceptable).
+- Response: `SuccessMessageDto`.
+
+`NotificationsService.sendPushNotification` adds
+`markReadToken: this.pushNotificationsService.createActionToken(...)` to
+`data`.
+
+### Service worker
+
+`frontend/src/sw-custom.ts`:
+
+- **push handler**: when `data.data.markReadToken` is present and the platform
+  supports notification actions (feature-detect via `'maxActions' in
+  Notification && Notification.maxActions > 0`), add
+  `actions: [{ action: 'mark-read', title: 'Mark as read' }]`. iOS Safari
+  lacks action support and degrades to a plain notification.
+- **notificationclick handler**: branch on `event.action`:
+  - `'mark-read'` → close the notification and `fetch('/api/notifications/push/mark-read')`
+    with the token, best-effort (errors swallowed). Do NOT open a window. Do
+    not clear the app badge (other unreads may exist; the app corrects the
+    badge next launch).
+  - default (body click) → existing open/focus behavior.
+- Pure decision logic is extracted to `frontend/src/utils/swPush.ts`
+  (`buildNotificationOptions`, `getNavigationHash`, action detection) so it is
+  unit-testable under Vitest; the SW file keeps only event wiring.
+
+### Testing
+
+- Backend: token round-trip / tamper / expiry / malformed cases on
+  `PushNotificationsService`; new `push-actions.controller.spec.ts` (valid →
+  markAsRead called, invalid → 401); `notifications.service.spec.ts` asserts
+  the payload carries `markReadToken`.
+- Frontend: Vitest unit tests for `swPush.ts` helpers.
+- `backend/openapi.json` regenerated (new endpoint).
+
+## Non-Goals
+
+- **Inline reply**: requires an unauthenticated token that authorizes sending
+  messages as the user — a materially riskier capability than idempotent
+  mark-read, and unsupported on iOS anyway. Deferred pending an explicit
+  security decision (tracked in #397).
+- Single-use token enforcement (see Replay above).

--- a/docs/superpowers/specs/2026-08-09-push-notification-actions-design.md
+++ b/docs/superpowers/specs/2026-08-09-push-notification-actions-design.md
@@ -22,7 +22,10 @@ The backend embeds a single-purpose signed token in each push payload
 - **Payload**: `{ u: userId, n: notificationId, exp: epochSeconds }` with a
   7-day expiry (push delivery TTL is 24h, but a displayed notification can be
   clicked days later).
-- **Format**: `base64url(JSON payload) + "." + base64url(HMAC-SHA256(payload))`.
+- **Format**: `payloadB64 + "." + base64url(HMAC-SHA256(key, payloadB64))`
+  where `payloadB64 = base64url(JSON.stringify(payload))` — the MAC is
+  computed over the base64url-encoded payload *string* (the first token
+  part verbatim), not the raw JSON bytes.
 - **Key**: derived from `JWT_SECRET` via `HMAC-SHA256(key=JWT_SECRET,
   msg="semaphore-push-action-v1")`. Never the raw `JWT_SECRET` — a token
   signed with the raw secret and a `sub` claim could be replayed as an API

--- a/frontend/src/__tests__/utils/swPush.test.ts
+++ b/frontend/src/__tests__/utils/swPush.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getNavigationHash,
+  supportsNotificationActions,
+  buildNotificationOptions,
+  getMarkReadRequest,
+} from '../../utils/swPush';
+
+describe('swPush', () => {
+  describe('getNavigationHash', () => {
+    it('builds a channel hash when community + channel ids are present', () => {
+      expect(
+        getNavigationHash({ communityId: 'c1', channelId: 'ch1' }),
+      ).toBe('#/community/c1/channel/ch1');
+    });
+
+    it('builds a DM hash when only a directMessageGroupId is present', () => {
+      expect(getNavigationHash({ directMessageGroupId: 'g1' })).toBe(
+        '#/direct-messages/g1',
+      );
+    });
+
+    it('falls back to the root hash when nothing matches', () => {
+      expect(getNavigationHash({})).toBe('#/');
+      expect(getNavigationHash({ type: 'other' })).toBe('#/');
+    });
+
+    it('falls back to the root hash when data is undefined', () => {
+      expect(getNavigationHash(undefined)).toBe('#/');
+    });
+  });
+
+  describe('supportsNotificationActions', () => {
+    it('returns true when maxActions is a positive number', () => {
+      expect(supportsNotificationActions({ maxActions: 2 })).toBe(true);
+    });
+
+    it('returns true for a constructor function with maxActions (the real Notification global)', () => {
+      class FakeNotification {
+        static maxActions = 2;
+      }
+      expect(supportsNotificationActions(FakeNotification)).toBe(true);
+    });
+
+    it('returns false when maxActions is 0', () => {
+      expect(supportsNotificationActions({ maxActions: 0 })).toBe(false);
+    });
+
+    it('returns false when maxActions is missing', () => {
+      expect(supportsNotificationActions({})).toBe(false);
+    });
+
+    it('returns false when passed undefined', () => {
+      expect(supportsNotificationActions(undefined)).toBe(false);
+    });
+  });
+
+  describe('buildNotificationOptions', () => {
+    const baseData = {
+      title: 'New message',
+      body: 'Hello there',
+    };
+
+    it('includes the mark-read action when actions are supported and a token is present', () => {
+      const options = buildNotificationOptions(
+        { ...baseData, data: { markReadToken: 'tok' } },
+        true,
+      );
+      expect(options.actions).toEqual([
+        { action: 'mark-read', title: 'Mark as read' },
+      ]);
+    });
+
+    it('omits actions when actions are supported but no token is present', () => {
+      const options = buildNotificationOptions(
+        { ...baseData, data: {} },
+        true,
+      );
+      expect(options.actions).toBeUndefined();
+    });
+
+    it('omits actions when a token is present but actions are unsupported', () => {
+      const options = buildNotificationOptions(
+        { ...baseData, data: { markReadToken: 'tok' } },
+        false,
+      );
+      expect(options.actions).toBeUndefined();
+    });
+
+    it('omits actions when neither supported nor a token is present', () => {
+      const options = buildNotificationOptions(
+        { ...baseData, data: {} },
+        false,
+      );
+      expect(options.actions).toBeUndefined();
+    });
+
+    it('falls back to /pwa-192x192.png for icon and badge when not provided', () => {
+      const options = buildNotificationOptions(baseData, false);
+      expect(options.icon).toBe('/pwa-192x192.png');
+      expect(options.badge).toBe('/pwa-192x192.png');
+    });
+
+    it('uses provided icon/badge when present', () => {
+      const options = buildNotificationOptions(
+        { ...baseData, icon: '/custom-icon.png', badge: '/custom-badge.png' },
+        false,
+      );
+      expect(options.icon).toBe('/custom-icon.png');
+      expect(options.badge).toBe('/custom-badge.png');
+    });
+
+    it('passes through tag and data, and sets vibrate/requireInteraction', () => {
+      const data = { notificationId: 'n1' };
+      const options = buildNotificationOptions(
+        { ...baseData, tag: 'msg-1', data },
+        false,
+      );
+      expect(options.body).toBe('Hello there');
+      expect(options.tag).toBe('msg-1');
+      expect(options.data).toBe(data);
+      expect(options.vibrate).toEqual([200, 100, 200]);
+      expect(options.requireInteraction).toBe(false);
+    });
+  });
+
+  describe('getMarkReadRequest', () => {
+    it('returns null when there is no markReadToken', () => {
+      expect(getMarkReadRequest(undefined)).toBeNull();
+      expect(getMarkReadRequest({})).toBeNull();
+    });
+
+    it('builds the mark-read request when a token is present', () => {
+      const request = getMarkReadRequest({ markReadToken: 'tok123' });
+      expect(request).toEqual({
+        url: '/api/notifications/push/mark-read',
+        init: {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token: 'tok123' }),
+        },
+      });
+    });
+  });
+});

--- a/frontend/src/sw-custom.ts
+++ b/frontend/src/sw-custom.ts
@@ -9,6 +9,13 @@ import { registerRoute, NavigationRoute } from 'workbox-routing';
 import { CacheFirst } from 'workbox-strategies';
 import { ExpirationPlugin } from 'workbox-expiration';
 import { swDbGet, swDbSet, SW_DB_KEYS } from './utils/swDb';
+import {
+  buildNotificationOptions,
+  getMarkReadRequest,
+  getNavigationHash,
+  supportsNotificationActions,
+  type PushNotificationData,
+} from './utils/swPush';
 
 declare let self: ServiceWorkerGlobalScope;
 
@@ -86,22 +93,6 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array {
   return outputArray;
 }
 
-// Push notification types
-interface PushNotificationData {
-  title: string;
-  body: string;
-  icon?: string;
-  badge?: string;
-  tag?: string;
-  data?: {
-    notificationId?: string;
-    channelId?: string | null;
-    communityId?: string | null;
-    directMessageGroupId?: string | null;
-    type?: string;
-  };
-}
-
 /**
  * Set or clear the app-icon badge flag (Badging API, Chromium-only).
  * Always resolves — feature-detected and error-swallowed so badge support
@@ -134,17 +125,12 @@ self.addEventListener('push', (event: PushEvent) => {
     return;
   }
 
-  // `vibrate` is a non-standard (but widely supported) notification option
-  // missing from the TS lib's NotificationOptions.
-  const options: NotificationOptions & { vibrate: number[] } = {
-    body: data.body,
-    icon: data.icon || '/pwa-192x192.png',
-    badge: data.badge || '/pwa-192x192.png',
-    tag: data.tag,
-    data: data.data,
-    vibrate: [200, 100, 200],
-    requireInteraction: false,
-  };
+  // In SW scope the global `Notification` constructor exists but isn't in
+  // the `webworker` lib types under that name in all contexts — cast as needed.
+  const options = buildNotificationOptions(
+    data,
+    supportsNotificationActions(Notification as unknown),
+  );
 
   event.waitUntil(
     Promise.all([
@@ -163,14 +149,20 @@ self.addEventListener('notificationclick', (event: NotificationEvent) => {
 
   const data = event.notification.data as PushNotificationData['data'];
 
-  // Determine the path to navigate to (app uses HashRouter, so paths must be under /#/)
-  let hash = '#/';
-  if (data?.communityId && data?.channelId) {
-    hash = `#/community/${data.communityId}/channel/${data.channelId}`;
-  } else if (data?.directMessageGroupId) {
-    hash = `#/direct-messages/${data.directMessageGroupId}`;
+  if (event.action === 'mark-read') {
+    // Best-effort: mark the notification read server-side without opening or
+    // focusing any window. Deliberately does NOT clear the SW-set badge flag
+    // — other unread notifications may still exist, and the app corrects the
+    // badge to the exact count on next launch (see useAppBadge).
+    const request = getMarkReadRequest(data);
+    if (request) {
+      event.waitUntil(fetch(request.url, request.init).catch(() => {}));
+    }
+    return;
   }
 
+  // Determine the path to navigate to (app uses HashRouter, so paths must be under /#/)
+  const hash = getNavigationHash(data);
   const targetUrl = new URL(`/${hash}`, self.location.origin).href;
 
   // Clear the SW-set badge flag, then focus an existing same-origin window

--- a/frontend/src/utils/swPush.ts
+++ b/frontend/src/utils/swPush.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure decision logic for the push notification / notificationclick handlers
+ * in `sw-custom.ts`. Extracted so it's unit-testable under Vitest — this
+ * module must stay import-safe from both the service worker (no DOM/window
+ * globals, no workbox imports) and a plain Node/jsdom test runner.
+ */
+
+// Push notification types
+export interface PushNotificationData {
+  title: string;
+  body: string;
+  icon?: string;
+  badge?: string;
+  tag?: string;
+  data?: {
+    notificationId?: string;
+    channelId?: string | null;
+    communityId?: string | null;
+    directMessageGroupId?: string | null;
+    type?: string;
+    markReadToken?: string;
+  };
+}
+
+/**
+ * Determine the in-app hash to navigate to when a notification body is
+ * clicked (app uses HashRouter, so paths must be under /#/).
+ */
+export function getNavigationHash(data: PushNotificationData['data']): string {
+  if (data?.communityId && data?.channelId) {
+    return `#/community/${data.communityId}/channel/${data.channelId}`;
+  } else if (data?.directMessageGroupId) {
+    return `#/direct-messages/${data.directMessageGroupId}`;
+  }
+  return '#/';
+}
+
+/**
+ * Feature-detect notification action button support (Chromium yes, iOS
+ * Safari no). Takes the `Notification` constructor as a parameter so it's
+ * testable without a DOM global — the SW passes the real global. Must not
+ * throw when passed `undefined` (e.g. an environment with no `Notification`).
+ */
+export function supportsNotificationActions(notificationCtor: unknown): boolean {
+  // The real `Notification` global is a constructor (typeof 'function');
+  // accept plain objects too for test doubles.
+  if (
+    !notificationCtor ||
+    (typeof notificationCtor !== 'function' &&
+      typeof notificationCtor !== 'object')
+  ) {
+    return false;
+  }
+  const maxActions = (notificationCtor as { maxActions?: unknown }).maxActions;
+  return typeof maxActions === 'number' && maxActions > 0;
+}
+
+/**
+ * Build the options object passed to `registration.showNotification`. Adds
+ * the "Mark as read" action only when the platform supports actions and the
+ * payload carries a `markReadToken` (i.e. the backend authorized the action).
+ */
+export function buildNotificationOptions(
+  data: PushNotificationData,
+  supportsActions: boolean,
+): NotificationOptions & {
+  vibrate: number[];
+  actions?: { action: string; title: string }[];
+} {
+  // `vibrate` and `actions` are non-standard (but widely supported)
+  // notification options missing from the TS lib's NotificationOptions.
+  const options: NotificationOptions & {
+    vibrate: number[];
+    actions?: { action: string; title: string }[];
+  } = {
+    body: data.body,
+    icon: data.icon || '/pwa-192x192.png',
+    badge: data.badge || '/pwa-192x192.png',
+    tag: data.tag,
+    data: data.data,
+    vibrate: [200, 100, 200],
+    requireInteraction: false,
+  };
+
+  if (supportsActions && data.data?.markReadToken) {
+    options.actions = [{ action: 'mark-read', title: 'Mark as read' }];
+  }
+
+  return options;
+}
+
+/**
+ * Build the fetch request for the "Mark as read" notification action.
+ * Returns `null` when the payload carries no `markReadToken` (nothing to
+ * authorize the call with). Same-origin relative URL — the SW only ever
+ * serves the web origin, where /api is proxied.
+ */
+export function getMarkReadRequest(
+  data: PushNotificationData['data'],
+): { url: string; init: RequestInit } | null {
+  const token = data?.markReadToken;
+  if (!token) {
+    return null;
+  }
+  return {
+    url: '/api/notifications/push/mark-read',
+    init: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    },
+  };
+}


### PR DESCRIPTION
Closes #397 (mark-read portion; inline reply deliberately deferred — see below).

## What

Push notifications now carry a **Mark as read** action button, so a mention can be dismissed from the notification itself without opening the app.

## How it works

The SW deliberately stores no JWT, so the backend embeds a scoped action token in each push payload (`data.markReadToken`):

- **Token**: `base64url(payload).base64url(HMAC-SHA256)` over `{u: userId, n: notificationId, exp}`, 7-day expiry (push TTL is 24h but a displayed notification can be clicked later).
- **Key derivation**: HMAC of `JWT_SECRET` with a domain-separation string — never the raw secret, so an action token can't be replayed against the passport JWT strategy.
- **Replay**: not single-use by design; marking read is idempotent and authorizes nothing else, avoiding Redis/DB token state.
- **Endpoint**: `POST /notifications/push/mark-read` (new `PushActionsController`, intentionally unauthenticated — the token is the auth). Reuses `NotificationsService.markAsRead`, so the existing WS `notificationRead` event keeps open clients in sync.

Service worker changes:

- Action button added only when the platform supports actions (`Notification.maxActions`, feature-detected — iOS Safari degrades to a plain notification) **and** the payload carries a token.
- `notificationclick` branches on `event.action`: mark-read closes the notification and fires a best-effort same-origin fetch without opening/focusing a window; body clicks keep the existing open/focus behavior.
- Pure decision logic extracted to `frontend/src/utils/swPush.ts` so it's unit-testable (the SW file keeps only event wiring).

Design doc: `docs/superpowers/specs/2026-08-09-push-notification-actions-design.md`

## Deliberately out of scope

**Inline reply**: requires an unauthenticated token that can *send messages* as the user — a materially riskier capability than idempotent mark-read (and unsupported on iOS anyway). Left open in #397 pending an explicit decision.

## Testing

- Backend: token round-trip/tamper/truncation/expiry/malformed cases; controller spec (valid → markAsRead, invalid → 401); payload includes/omits `markReadToken`. Full suite: **149 suites / 2543 tests passing**.
- Frontend: 18 unit tests for the `swPush` helpers. Full suite: **180 files / 1943 tests passing**. Lint, type-check, and the `vite-plugin-pwa` SW build all pass.
- Review caught (and fixed with a regression test): the feature detection initially rejected function-typed constructors — the real `Notification` global is a constructor, so the button would never have appeared in production.
- `backend/openapi.json` regenerated; verified the only operational change is the new `PushActionsController_markRead` (rest is key-order churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)