### PR TITLE
fix(electron): Windows launch crash — shell-proof build scripts (v0.4.3 hotfix)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -44,6 +44,10 @@ CVE-2026-27904
 CVE-2026-4926
 # socket.io-parser
 CVE-2026-33151
+# extract-zip (dev/build-time only: @electron/get unpacks the Electron binary
+# at install; not shipped in app.asar or images. No fixed version upstream yet
+# — remove when one lands.) Added 2026-08-19 pre-v0.4.3 audit.
+CVE-2026-56876
 
 # --- frontend image: OS packages from the nginx/alpine base (bump base image) ---
 # libxml2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.3] - 2026-08-19
+
+### Fixed
+
+- **Windows Desktop App Crash on Launch** — Every Windows build of v0.4.0–v0.4.2 crashed at startup with `Invalid package config ...app.asar\electron\dist\package.json` (no window, orphaned background processes). The `build-electron` script wrote `electron/dist/package.json` with a shell `echo` under single quotes; on the Windows CI runner the script shell is cmd.exe, which treats single quotes as literal characters, so the shipped file was not valid JSON and Electron's module resolver threw before any app code ran. The file (and the `.cjs` renames) are now written by Node itself (`fs.writeFileSync`/`renameSync` + `JSON.stringify`), which is shell-independent, and `build:all` now fails the build if the emitted artifacts are missing or unparseable. **Note for Windows users on 0.4.0–0.4.2**: the app crashes before the auto-updater can run, so this one update must be installed manually — download and run the 0.4.3 installer (it closes the broken instances itself). Auto-update works again from then on. Windows users still on 0.3.x auto-update normally; Linux builds were never affected.
+
 ## [0.4.2] - 2026-08-18
 
 ### Changed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,9 +18,10 @@
   "scripts": {
     "clean": "rimraf dist electron/dist release",
     "build": "vite build",
-    "build-electron": "tsc --project electron/tsconfig.electron.json && mv electron/dist/main.js electron/dist/main.cjs && echo '{\"type\":\"commonjs\"}' > electron/dist/package.json",
-    "build-preload": "tsc electron/preload.ts --outDir electron/dist --module commonjs --target es2020 --esModuleInterop --skipLibCheck && mv electron/dist/preload.js electron/dist/preload.cjs",
-    "build:all": "pnpm run clean && pnpm run build && pnpm run build-electron && pnpm run build-preload",
+    "build-electron": "tsc --project electron/tsconfig.electron.json && node -e \"const fs=require('fs');fs.renameSync('electron/dist/main.js','electron/dist/main.cjs');fs.writeFileSync('electron/dist/package.json',JSON.stringify({type:'commonjs'}))\"",
+    "build-preload": "tsc electron/preload.ts --outDir electron/dist --module commonjs --target es2020 --esModuleInterop --skipLibCheck && node -e \"require('fs').renameSync('electron/dist/preload.js','electron/dist/preload.cjs')\"",
+    "build:all": "pnpm run clean && pnpm run build && pnpm run build-electron && pnpm run build-preload && pnpm run verify-electron-build",
+    "verify-electron-build": "node -e \"const fs=require('fs');JSON.parse(fs.readFileSync('electron/dist/package.json','utf8'));for(const f of ['main.cjs','preload.cjs','package.json'])if(!fs.existsSync('electron/dist/'+f))throw new Error('missing electron/dist/'+f);console.log('electron build artifacts OK')\"",
     "build:renderer": "vite build",
     "package": "pnpm run build:all && electron-builder --dir",
     "build:win": "pnpm run build:all && electron-builder --win",


### PR DESCRIPTION
## Summary

**Every Windows build of v0.4.0–v0.4.2 crashes on launch** with `Invalid package config ...app.asar\electron\dist\package.json` — no window, no tray, orphaned `Semaphore Chat.exe` processes.

Root cause (verified by extracting `app.asar` from the shipped `Semaphore-Chat-Setup-0.4.2.exe`): `build-electron` writes `electron/dist/package.json` with `echo '{"type":"commonjs"}' >`. pnpm's script shell on the Windows CI runner is cmd.exe, which treats single quotes as literal characters, so the shipped file is literally `'{"type":"commonjs"}' \r\n` — invalid JSON. Electron's `getNearestParentPackageJSON` throws during module resolution, before any app code (including electron-updater) runs. Introduced in d3d8a93 (#432); v0.3.0 predates the file and is unaffected. Linux builds survive only because that job's shell is bash. CI passed silently — the corruption only surfaces at runtime.

## Changes

- `build-electron` / `build-preload`: write `package.json` via `node -e` + `JSON.stringify` and do the `.cjs` renames via `fs.renameSync` — identical behavior under cmd.exe, PowerShell, and bash (the old `mv` only worked on Windows because Git Bash happened to be in PATH).
- New `verify-electron-build` step chained into `build:all`: fails any build (local or CI, every platform) where the emitted `package.json` doesn't parse or `main.cjs`/`preload.cjs` are missing — the guard that would have failed the v0.4.0 Windows build instead of shipping it.
- CHANGELOG entry for v0.4.3, including the manual-reinstall note for affected Windows users (the broken app can't run its updater).

## Test plan

- `build-electron` + `build-preload` + `verify-electron-build` run in Docker: emitted file is exactly `{"type":"commonjs"}` (JSON.parse-verified), `main.cjs`/`preload.cjs` present, output layout unchanged from the working Linux builds.
- The definitive platform test is the Windows CI job on the release tag: `verify-electron-build` now runs inside `build:all` on the same runner/shell that produced the bad artifact.

## Release notes for v0.4.3

Windows users on 0.4.0–0.4.2 must install this update manually (download the installer; it closes the broken instances). Auto-update resumes afterward. Windows 0.3.x users and Linux users update normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CNX6zvyQtG3SwCWYNf8AN