### PR TITLE
ci(electron): launch smoke test for packed apps

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -127,6 +127,29 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Launch the packed app and require the ELECTRON_SMOKE_OK readiness
+      # marker (printed by main.ts under ELECTRON_SMOKE=1). Liveness is NOT
+      # a valid check: a main-process startup crash leaves the process alive
+      # behind Electron's error dialog — exactly how the v0.4.0-v0.4.2
+      # Windows crash shipped with green CI.
+      - name: Smoke test packed app
+        working-directory: frontend
+        shell: pwsh
+        run: |
+          $env:ELECTRON_SMOKE = '1'
+          $p = Start-Process -FilePath "release\win-unpacked\Semaphore Chat.exe" `
+            -RedirectStandardOutput smoke-out.log -RedirectStandardError smoke-err.log -PassThru
+          if (-not $p.WaitForExit(60000)) {
+            Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
+          }
+          Get-Process -Name "Semaphore Chat" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+          $out = (Get-Content smoke-out.log -Raw -ErrorAction SilentlyContinue) + "`n" + (Get-Content smoke-err.log -Raw -ErrorAction SilentlyContinue)
+          Write-Host $out
+          if ($out -notmatch 'ELECTRON_SMOKE_OK') {
+            Write-Error "Electron smoke test FAILED: packed app never reached ready state (no ELECTRON_SMOKE_OK)"
+            exit 1
+          }
+
       - name: Upload Windows installer
         uses: actions/upload-artifact@v4
         with:
@@ -213,6 +236,17 @@ jobs:
         run: pnpm run build:all && pnpm run electron-builder:linux AppImage deb rpm --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Same readiness-marker smoke test as the Windows job (see comment
+      # there). xvfb provides a display; --no-sandbox because the unpacked
+      # chrome-sandbox helper isn't SUID on the runner.
+      - name: Smoke test packed app
+        working-directory: frontend
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq xvfb
+          ELECTRON_SMOKE=1 xvfb-run -a timeout 60 ./release/linux-unpacked/semaphore-chat --no-sandbox > smoke.log 2>&1 || true
+          cat smoke.log
+          grep -q ELECTRON_SMOKE_OK smoke.log || { echo "Electron smoke test FAILED: packed app never reached ready state (no ELECTRON_SMOKE_OK)"; exit 1; }
 
       - name: Upload Linux AppImage
         uses: actions/upload-artifact@v4

--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -1118,6 +1118,16 @@ app.whenReady().then(() => {
   // on the process that just launched (rather than a second-instance
   // relaunch). The renderer isn't ready yet, so this queues.
   extractDeepLinkUrls(process.argv).forEach(handleDeepLinkUrl);
+
+  // CI smoke test (electron-build.yml): print a readiness marker and exit.
+  // CI must assert this positive signal rather than process liveness — an
+  // uncaught main-process exception leaves the process alive behind
+  // Electron's error dialog (how the v0.4.0-v0.4.2 Windows startup crash
+  // shipped despite green builds).
+  if (process.env.ELECTRON_SMOKE === '1') {
+    console.log('ELECTRON_SMOKE_OK');
+    app.exit(0);
+  }
 });
 
 // Tray keeps the app alive — don't quit when windows are hidden


### PR DESCRIPTION
## Summary

Closes the last prevention gap from the v0.4.0–v0.4.2 Windows launch-crash incident: CI now launches the packed app on both the Windows and Linux build runners and fails the job unless the app prints an `ELECTRON_SMOKE_OK` readiness marker (emitted by `main.ts` at the end of `whenReady` when `ELECTRON_SMOKE=1`).

A liveness check would not have caught the incident — an uncaught main-process exception leaves the process alive behind Electron's error dialog — so the test asserts the positive readiness signal instead. The smoke steps run inside the build jobs, which `create-release` depends on, so a failing smoke blocks any release from publishing. The `main.ts` hook is env-gated and inert in normal use.

## Test plan

Validated on real runners before this PR via workflow_dispatch (run 32305318461, `create_release=false`): both the Windows and Linux smoke steps launched the packed app, captured `ELECTRON_SMOKE_OK`, and passed. `build-electron` type-check clean in Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CNX6zvyQtG3SwCWYNf8AN